### PR TITLE
177 enhance logger implementation with namespace and improved error handling

### DIFF
--- a/ChronoAPI/ChronoLog/include/chrono_monitor.h
+++ b/ChronoAPI/ChronoLog/include/chrono_monitor.h
@@ -1,5 +1,5 @@
-#ifndef CHRONOLOG_LOG_H
-#define CHRONOLOG_LOG_H
+#ifndef CHRONOLOG_CHRONO_MONITOR_H
+#define CHRONOLOG_CHRONO_MONITOR_H
 
 #include <spdlog/spdlog.h>
 #include <mutex>
@@ -48,13 +48,13 @@ namespace chronolog
 #define LOG_TRACE(...)
 #define LOG_DEBUG(...)
 #else
-#define LOG_TRACE(...) chronolog::Logger::getInstance().trace(__VA_ARGS__)
-#define LOG_DEBUG(...) chronolog::Logger::getInstance().debug(__VA_ARGS__)
+#define LOG_TRACE(...) chronolog::chrono_monitor::getInstance().trace(__VA_ARGS__)
+#define LOG_DEBUG(...) chronolog::chrono_monitor::getInstance().debug(__VA_ARGS__)
 #endif
-#define LOG_INFO(...) chronolog::Logger::getInstance().info(__VA_ARGS__)
-#define LOG_WARNING(...) chronolog::Logger::getInstance().warn(__VA_ARGS__)
-#define LOG_ERROR(...) chronolog::Logger::getInstance().error(__VA_ARGS__)
-#define LOG_CRITICAL(...) chronolog::Logger::getInstance().critical(__VA_ARGS__)
+#define LOG_INFO(...) chronolog::chrono_monitor::getInstance().info(__VA_ARGS__)
+#define LOG_WARNING(...) chronolog::chrono_monitor::getInstance().warn(__VA_ARGS__)
+#define LOG_ERROR(...) chronolog::chrono_monitor::getInstance().error(__VA_ARGS__)
+#define LOG_CRITICAL(...) chronolog::chrono_monitor::getInstance().critical(__VA_ARGS__)
 
 /**
  * @class Logger
@@ -64,7 +64,7 @@ namespace chronolog
  * throughout the application. It allows configuration of log type, location, level,
  * and name. It is designed to work with the spdlog library.
  */
-class Logger
+class chrono_monitor
 {
 public:
 
@@ -103,15 +103,15 @@ public:
     static spdlog::logger &getInstance();
 
     // Delete copy constructor and assignment operator
-    Logger(const Logger &) = delete;
+    chrono_monitor(const chrono_monitor &) = delete;
 
-    Logger &operator=(const Logger &) = delete;
+    chrono_monitor &operator=(const chrono_monitor &) = delete;
 
-    ~Logger() = default;
+    ~chrono_monitor() = default;
 
 private:
     //Private Constructor
-    Logger() = default;
+    chrono_monitor() = default;
 
     /**
      * @brief The shared pointer to the spdlog logger instance.
@@ -130,4 +130,4 @@ private:
 
 } // namespace chronolog
 
-#endif //CHRONOLOG_LOG_H
+#endif //CHRONOLOG_CHRONO_MONITOR_H

--- a/ChronoAPI/ChronoLog/include/log.h
+++ b/ChronoAPI/ChronoLog/include/log.h
@@ -4,6 +4,8 @@
 #include <spdlog/spdlog.h>
 #include <mutex>
 
+namespace chronolog
+{
 
 /**
  * @def LOG_TRACE(...)
@@ -46,13 +48,13 @@
 #define LOG_TRACE(...)
 #define LOG_DEBUG(...)
 #else
-#define LOG_TRACE(...) Logger::getInstance().trace(__VA_ARGS__)
-#define LOG_DEBUG(...) Logger::getInstance().debug(__VA_ARGS__)
+#define LOG_TRACE(...) chronolog::Logger::getInstance().trace(__VA_ARGS__)
+#define LOG_DEBUG(...) chronolog::Logger::getInstance().debug(__VA_ARGS__)
 #endif
-#define LOG_INFO(...) Logger::getInstance().info(__VA_ARGS__)
-#define LOG_WARNING(...) Logger::getInstance().warn(__VA_ARGS__)
-#define LOG_ERROR(...) Logger::getInstance().error(__VA_ARGS__)
-#define LOG_CRITICAL(...) Logger::getInstance().critical(__VA_ARGS__)
+#define LOG_INFO(...) chronolog::Logger::getInstance().info(__VA_ARGS__)
+#define LOG_WARNING(...) chronolog::Logger::getInstance().warn(__VA_ARGS__)
+#define LOG_ERROR(...) chronolog::Logger::getInstance().error(__VA_ARGS__)
+#define LOG_CRITICAL(...) chronolog::Logger::getInstance().critical(__VA_ARGS__)
 
 /**
  * @class Logger
@@ -85,10 +87,9 @@ public:
      *                     and returns 1 if there was an error during initialization.
      */
     static int initialize(const std::string &logType, const std::string &location, spdlog::level::level_enum logLevel
-                          , const std::string &loggerName
-                , const std::size_t &logFileSize = 104857600
-                , const std::size_t &logFileNum = 3
-                , spdlog::level::level_enum flushLevel = spdlog::level::warn);
+                          , const std::string &loggerName, const std::size_t &logFileSize = 104857600
+                          , const std::size_t &logFileNum = 3
+                          , spdlog::level::level_enum flushLevel = spdlog::level::warn);
 
 
     /**
@@ -103,7 +104,9 @@ public:
 
     // Delete copy constructor and assignment operator
     Logger(const Logger &) = delete;
+
     Logger &operator=(const Logger &) = delete;
+
     ~Logger() = default;
 
 private:
@@ -124,5 +127,7 @@ private:
      */
     static std::mutex mutex;
 };
+
+} // namespace chronolog
 
 #endif //CHRONOLOG_LOG_H

--- a/ChronoAPI/ChronoLog/src/chrono_monitor.cpp
+++ b/ChronoAPI/ChronoLog/src/chrono_monitor.cpp
@@ -59,7 +59,6 @@ int chrono_monitor::initialize(const std::string &logType, const std::string &lo
 
 spdlog::logger &chrono_monitor::getInstance()
 {
-    //std::lock_guard <std::mutex> lock(mutex);
     if(logger)
     {
         return *logger;

--- a/ChronoAPI/ChronoLog/src/chrono_monitor.cpp
+++ b/ChronoAPI/ChronoLog/src/chrono_monitor.cpp
@@ -2,7 +2,7 @@
 // Created by eneko on 12/1/23.
 //
 
-#include "log.h"
+#include "chrono_monitor.h"
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <iostream>
@@ -11,12 +11,12 @@
 namespace chronolog
 {
 
-std::shared_ptr <spdlog::logger> Logger::logger = nullptr;
-std::mutex Logger::mutex;
+std::shared_ptr <spdlog::logger> chrono_monitor::logger = nullptr;
+std::mutex chrono_monitor::mutex;
 
-int Logger::initialize(const std::string &logType, const std::string &location, spdlog::level::level_enum logLevel
-                       , const std::string &loggerName, const std::size_t &logFileSize, const std::size_t &logFileNum
-                       , spdlog::level::level_enum flushLevel)
+int chrono_monitor::initialize(const std::string &logType, const std::string &location, spdlog::level::level_enum logLevel
+                               , const std::string &loggerName, const std::size_t &logFileSize, const std::size_t &logFileNum
+                               , spdlog::level::level_enum flushLevel)
 {
     std::lock_guard <std::mutex> lock(mutex);
     if(logger)
@@ -57,7 +57,7 @@ int Logger::initialize(const std::string &logType, const std::string &location, 
     return 0; // already initialized
 }
 
-spdlog::logger &Logger::getInstance()
+spdlog::logger &chrono_monitor::getInstance()
 {
     //std::lock_guard <std::mutex> lock(mutex);
     if(logger)

--- a/ChronoAPI/ChronoLog/src/log.cpp
+++ b/ChronoAPI/ChronoLog/src/log.cpp
@@ -59,7 +59,7 @@ int Logger::initialize(const std::string &logType, const std::string &location, 
 
 spdlog::logger &Logger::getInstance()
 {
-    std::lock_guard <std::mutex> lock(mutex);
+    //std::lock_guard <std::mutex> lock(mutex);
     if(logger)
     {
         return *logger;

--- a/ChronoAPI/ChronoLog/src/log.cpp
+++ b/ChronoAPI/ChronoLog/src/log.cpp
@@ -8,6 +8,9 @@
 #include <iostream>
 #include <filesystem>
 
+namespace chronolog
+{
+
 std::shared_ptr <spdlog::logger> Logger::logger = nullptr;
 std::mutex Logger::mutex;
 
@@ -67,3 +70,5 @@ spdlog::logger &Logger::getInstance()
         std::exit(EXIT_FAILURE);
     }
 }
+
+} // namespace chronolog

--- a/ChronoGrapher/CMakeLists.txt
+++ b/ChronoGrapher/CMakeLists.txt
@@ -18,7 +18,7 @@ target_sources(chrono_grapher PRIVATE
     ../chrono_common/StoryChunk.cpp
     StoryChunkExtractor.cpp
     CSVFileChunkExtractor.cpp
-    ../ChronoAPI/ChronoLog/src/log.cpp)
+    ../ChronoAPI/ChronoLog/src/chrono_monitor.cpp)
 target_link_libraries(chrono_grapher chronolog_client thallium)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../default_conf.json.in

--- a/ChronoGrapher/ChronoGrapher.cpp
+++ b/ChronoGrapher/ChronoGrapher.cpp
@@ -68,13 +68,13 @@ int main(int argc, char**argv)
         std::exit(EXIT_FAILURE);
     }
     ChronoLog::ConfigurationManager confManager(conf_file_path);
-    int result = Logger::initialize(confManager.GRAPHER_CONF.LOG_CONF.LOGTYPE
-                                    , confManager.GRAPHER_CONF.LOG_CONF.LOGFILE
-                                    , confManager.GRAPHER_CONF.LOG_CONF.LOGLEVEL
-                                    , confManager.GRAPHER_CONF.LOG_CONF.LOGNAME
-                                    , confManager.GRAPHER_CONF.LOG_CONF.LOGFILESIZE
-                                    , confManager.GRAPHER_CONF.LOG_CONF.LOGFILENUM
-                                    , confManager.GRAPHER_CONF.LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::Logger::initialize(confManager.GRAPHER_CONF.LOG_CONF.LOGTYPE
+                                               , confManager.GRAPHER_CONF.LOG_CONF.LOGFILE
+                                               , confManager.GRAPHER_CONF.LOG_CONF.LOGLEVEL
+                                               , confManager.GRAPHER_CONF.LOG_CONF.LOGNAME
+                                               , confManager.GRAPHER_CONF.LOG_CONF.LOGFILESIZE
+                                               , confManager.GRAPHER_CONF.LOG_CONF.LOGFILENUM
+                                               , confManager.GRAPHER_CONF.LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
@@ -88,8 +88,8 @@ int main(int argc, char**argv)
     std::string datastore_service_ip = confManager.GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.IP;
     int datastore_service_port = confManager.GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.BASE_PORT;
     std::string DATASTORE_SERVICE_NA_STRING =
-            confManager.GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF + "://" +
-            datastore_service_ip + ":" + std::to_string(datastore_service_port);
+            confManager.GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF + "://" + datastore_service_ip + ":" +
+            std::to_string(datastore_service_port);
 
     uint16_t datastore_service_provider_id = confManager.GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.SERVICE_PROVIDER_ID;
 
@@ -117,8 +117,7 @@ int main(int argc, char**argv)
     // validate ip address, instantiate Recording Service and create IdCard
 
     chronolog::service_endpoint recording_endpoint;
-    if(-1 == service_endpoint_from_dotted_string(RECORDING_SERVICE_IP, RECORDING_SERVICE_PORT
-                                                 , recording_endpoint))
+    if(-1 == service_endpoint_from_dotted_string(RECORDING_SERVICE_IP, RECORDING_SERVICE_PORT, recording_endpoint))
     {
         LOG_CRITICAL("[ChronoGrapher] Failed to start RecordingService. Invalid endpoint provided.");
         return (-1);
@@ -126,8 +125,8 @@ int main(int argc, char**argv)
     LOG_INFO("[ChronoGrapher] RecordingService started successfully.");
 
     // create GrapherIdCard to identify this Grapher process in ChronoVisor's Registry
-    chronolog::GrapherIdCard processIdCard(recording_group_id, recording_endpoint.first, recording_endpoint.second,
-                                           recording_service_provider_id);
+    chronolog::GrapherIdCard processIdCard(recording_group_id, recording_endpoint.first, recording_endpoint.second
+                                           , recording_service_provider_id);
 
     std::stringstream process_id_string;
     process_id_string << processIdCard;
@@ -148,15 +147,15 @@ int main(int argc, char**argv)
 
     try
     {
-        margo_instance_id collection_margo_id = margo_init(DATASTORE_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE
-                                                           , 1, 1);
+        margo_instance_id collection_margo_id = margo_init(DATASTORE_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1
+                                                           , 1);
 
         dataAdminEngine = new tl::engine(collection_margo_id);
 
         std::stringstream s3;
         s3 << dataAdminEngine->self();
-        LOG_DEBUG("[ChronoGrapher] starting DataStoreAdminService at address {} with ProviderID={}"
-             , s3.str(), datastore_service_provider_id);
+        LOG_DEBUG("[ChronoGrapher] starting DataStoreAdminService at address {} with ProviderID={}", s3.str()
+                  , datastore_service_provider_id);
         keeperDataAdminService = chronolog::DataStoreAdminService::CreateDataStoreAdminService(*dataAdminEngine
                                                                                                , datastore_service_provider_id
                                                                                                , theDataStore);
@@ -175,7 +174,7 @@ int main(int argc, char**argv)
 
     // Instantiate RecordingService
     tl::engine*recordingEngine = nullptr;
-    chronolog::GrapherRecordingService* grapherRecordingService = nullptr;
+    chronolog::GrapherRecordingService*grapherRecordingService = nullptr;
 
     try
     {
@@ -184,11 +183,11 @@ int main(int argc, char**argv)
 
         std::stringstream s1;
         s1 << recordingEngine->self();
-        LOG_INFO("[ChronoGrapher] starting RecordingService at {} with provider_id {}"
-             , s1.str(), datastore_service_provider_id);
+        LOG_INFO("[ChronoGrapher] starting RecordingService at {} with provider_id {}", s1.str()
+                 , datastore_service_provider_id);
         grapherRecordingService = chronolog::GrapherRecordingService::CreateRecordingService(*recordingEngine
-                                                                                                 , recording_service_provider_id
-                                                                                                 , ingestionQueue);
+                                                                                             , recording_service_provider_id
+                                                                                             , ingestionQueue);
     }
     catch(tl::exception const &)
     {
@@ -205,14 +204,14 @@ int main(int argc, char**argv)
 
     /// RegistryClient SetUp _____________________________________________________________________________________
     // create RegistryClient and register the new Recording service with the Registry
-    std::string REGISTRY_SERVICE_NA_STRING =
-            confManager.GRAPHER_CONF.VISOR_REGISTRY_SERVICE_CONF.PROTO_CONF + "://" +
-            confManager.GRAPHER_CONF.VISOR_REGISTRY_SERVICE_CONF.IP + ":" +
-            std::to_string(confManager.GRAPHER_CONF.VISOR_REGISTRY_SERVICE_CONF.BASE_PORT);
+    std::string REGISTRY_SERVICE_NA_STRING = confManager.GRAPHER_CONF.VISOR_REGISTRY_SERVICE_CONF.PROTO_CONF + "://" +
+                                             confManager.GRAPHER_CONF.VISOR_REGISTRY_SERVICE_CONF.IP + ":" +
+                                             std::to_string(
+                                                     confManager.GRAPHER_CONF.VISOR_REGISTRY_SERVICE_CONF.BASE_PORT);
 
     uint16_t REGISTRY_SERVICE_PROVIDER_ID = confManager.GRAPHER_CONF.VISOR_REGISTRY_SERVICE_CONF.SERVICE_PROVIDER_ID;
 
-    chronolog::GrapherRegistryClient* grapherRegistryClient = chronolog::GrapherRegistryClient::CreateRegistryClient(
+    chronolog::GrapherRegistryClient*grapherRegistryClient = chronolog::GrapherRegistryClient::CreateRegistryClient(
             *dataAdminEngine, REGISTRY_SERVICE_NA_STRING, REGISTRY_SERVICE_PROVIDER_ID);
 
     if(nullptr == grapherRegistryClient)
@@ -226,7 +225,7 @@ int main(int argc, char**argv)
     /// Registration with ChronoVisor __________________________________________________________________________________
     // try to register with chronoVisor a few times than log ERROR and exit...
     int registration_status = grapherRegistryClient->send_register_msg(
-                chronolog::GrapherRegistrationMsg(processIdCard, collectionServiceId));
+            chronolog::GrapherRegistrationMsg(processIdCard, collectionServiceId));
     //if the first attemp failes retry 
     int retries = 5;
     while((chronolog::CL_SUCCESS != registration_status) && (retries > 0))
@@ -263,7 +262,7 @@ int main(int argc, char**argv)
     //chronolog::StatsMsg keeperStatsMsg(grapherIdCard);
     while(keep_running)
     {
-       // grapherRegistryClient->send_stats_msg(keeperStatsMsg);
+        // grapherRegistryClient->send_stats_msg(keeperStatsMsg);
         sleep(30);
     }
 

--- a/ChronoGrapher/ChronoGrapher.cpp
+++ b/ChronoGrapher/ChronoGrapher.cpp
@@ -68,13 +68,13 @@ int main(int argc, char**argv)
         std::exit(EXIT_FAILURE);
     }
     ChronoLog::ConfigurationManager confManager(conf_file_path);
-    int result = chronolog::Logger::initialize(confManager.GRAPHER_CONF.LOG_CONF.LOGTYPE
-                                               , confManager.GRAPHER_CONF.LOG_CONF.LOGFILE
-                                               , confManager.GRAPHER_CONF.LOG_CONF.LOGLEVEL
-                                               , confManager.GRAPHER_CONF.LOG_CONF.LOGNAME
-                                               , confManager.GRAPHER_CONF.LOG_CONF.LOGFILESIZE
-                                               , confManager.GRAPHER_CONF.LOG_CONF.LOGFILENUM
-                                               , confManager.GRAPHER_CONF.LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize(confManager.GRAPHER_CONF.LOG_CONF.LOGTYPE
+                                                       , confManager.GRAPHER_CONF.LOG_CONF.LOGFILE
+                                                       , confManager.GRAPHER_CONF.LOG_CONF.LOGLEVEL
+                                                       , confManager.GRAPHER_CONF.LOG_CONF.LOGNAME
+                                                       , confManager.GRAPHER_CONF.LOG_CONF.LOGFILESIZE
+                                                       , confManager.GRAPHER_CONF.LOG_CONF.LOGFILENUM
+                                                       , confManager.GRAPHER_CONF.LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/ChronoGrapher/ChunkIngestionQueue.h
+++ b/ChronoGrapher/ChunkIngestionQueue.h
@@ -6,7 +6,7 @@
 #include <deque>
 #include <unordered_map>
 #include <mutex>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #include "chronolog_types.h"
 #include "StoryChunk.h"

--- a/ChronoGrapher/KeeperDataStore.cpp
+++ b/ChronoGrapher/KeeperDataStore.cpp
@@ -8,7 +8,7 @@
 
 #include "chronolog_errcode.h"
 #include "KeeperDataStore.h"
-#include "log.h"
+#include "chrono_monitor.h"
 
 namespace chl = chronolog;
 namespace tl = thallium;

--- a/ChronoGrapher/StoryChunkExtractionQueue.h
+++ b/ChronoGrapher/StoryChunkExtractionQueue.h
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <deque>
 #include <mutex>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #include "chronolog_types.h"
 #include "StoryChunk.h"

--- a/ChronoGrapher/StoryChunkExtractor.h
+++ b/ChronoGrapher/StoryChunkExtractor.h
@@ -11,7 +11,7 @@
 #include "chronolog_types.h"
 #include "StoryChunkExtractionQueue.h"
 #include "chronolog_errcode.h"
-#include "log.h"
+#include "chrono_monitor.h"
 
 
 namespace tl = thallium;

--- a/ChronoGrapher/StoryPipeline.cpp
+++ b/ChronoGrapher/StoryPipeline.cpp
@@ -7,7 +7,7 @@
 #include "StoryPipeline.h"
 #include "StoryChunkIngestionHandle.h"
 #include "StoryChunkExtractionQueue.h"
-#include "log.h"
+#include "chrono_monitor.h"
 
 //#define TRACE_CHUNKING
 #define TRACE_CHUNK_EXTRACTION

--- a/ChronoKeeper/CMakeLists.txt
+++ b/ChronoKeeper/CMakeLists.txt
@@ -20,7 +20,7 @@ target_sources(chrono_keeper PRIVATE
     StoryChunkExtractor.cpp
     CSVFileChunkExtractor.cpp
     StoryChunkExtractorRDMA.cpp
-    ../ChronoAPI/ChronoLog/src/log.cpp)
+    ../ChronoAPI/ChronoLog/src/chrono_monitor.cpp)
 
 target_link_libraries(chrono_keeper chronolog_client thallium)
 

--- a/ChronoKeeper/ChronoKeeperInstance.cpp
+++ b/ChronoKeeper/ChronoKeeperInstance.cpp
@@ -71,13 +71,13 @@ int main(int argc, char**argv)
         std::exit(EXIT_FAILURE);
     }
     ChronoLog::ConfigurationManager confManager(conf_file_path);
-    int result = chronolog::Logger::initialize(confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGTYPE
-                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILE
-                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGLEVEL
-                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGNAME
-                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILESIZE
-                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILENUM
-                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize(confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGTYPE
+                                                       , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILE
+                                                       , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGLEVEL
+                                                       , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGNAME
+                                                       , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILESIZE
+                                                       , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILENUM
+                                                       , confManager.KEEPER_CONF.KEEPER_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/ChronoKeeper/ChronoKeeperInstance.cpp
+++ b/ChronoKeeper/ChronoKeeperInstance.cpp
@@ -71,13 +71,13 @@ int main(int argc, char**argv)
         std::exit(EXIT_FAILURE);
     }
     ChronoLog::ConfigurationManager confManager(conf_file_path);
-    int result = Logger::initialize(confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGTYPE
-                                    , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILE
-                                    , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGLEVEL
-                                    , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGNAME
-                                    , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILESIZE
-                                    , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILENUM
-                                    , confManager.KEEPER_CONF.KEEPER_LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::Logger::initialize(confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGTYPE
+                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILE
+                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGLEVEL
+                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGNAME
+                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILESIZE
+                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILENUM
+                                               , confManager.KEEPER_CONF.KEEPER_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
@@ -161,8 +161,7 @@ int main(int argc, char**argv)
         std::string extraction_rpc_name = "record_story_chunk";
         drain_to_grapher = extractionEngine->define(extraction_rpc_name);
         LOG_DEBUG("[ChronoKeeperInstance] Looking up {} at: {} ...", extraction_rpc_name, KEEPER_GRAPHER_NA_STRING);
-        service_ph = tl::provider_handle(extractionEngine->lookup(KEEPER_GRAPHER_NA_STRING),
-                                                             extraction_provider_id);
+        service_ph = tl::provider_handle(extractionEngine->lookup(KEEPER_GRAPHER_NA_STRING), extraction_provider_id);
         if(service_ph.is_null())
         {
             LOG_ERROR("[ChronoKeeperInstance] Failed to lookup Grapher service provider handle");

--- a/ChronoKeeper/IngestionQueue.h
+++ b/ChronoKeeper/IngestionQueue.h
@@ -6,7 +6,7 @@
 #include <deque>
 #include <unordered_map>
 #include <mutex>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #include "chronolog_types.h"
 #include "StoryIngestionHandle.h"

--- a/ChronoKeeper/KeeperDataStore.cpp
+++ b/ChronoKeeper/KeeperDataStore.cpp
@@ -8,7 +8,7 @@
 
 #include "chronolog_errcode.h"
 #include "KeeperDataStore.h"
-#include "log.h"
+#include "chrono_monitor.h"
 
 namespace chl = chronolog;
 namespace tl = thallium;

--- a/ChronoKeeper/StoryChunkExtractionQueue.h
+++ b/ChronoKeeper/StoryChunkExtractionQueue.h
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <deque>
 #include <mutex>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #include "chronolog_types.h"
 #include "StoryChunk.h"

--- a/ChronoKeeper/StoryChunkExtractor.h
+++ b/ChronoKeeper/StoryChunkExtractor.h
@@ -10,7 +10,7 @@
 
 #include "chronolog_types.h"
 #include "StoryChunkExtractionQueue.h"
-#include "log.h"
+#include "chrono_monitor.h"
 
 
 namespace tl = thallium;

--- a/ChronoKeeper/StoryPipeline.cpp
+++ b/ChronoKeeper/StoryPipeline.cpp
@@ -7,7 +7,7 @@
 #include "StoryPipeline.h"
 #include "StoryIngestionHandle.h"
 #include "StoryChunkExtractionQueue.h"
-#include "log.h"
+#include "chrono_monitor.h"
 
 //#define TRACE_CHUNKING
 #define TRACE_CHUNK_EXTRACTION

--- a/ChronoStore/include/StoryReader.h
+++ b/ChronoStore/include/StoryReader.h
@@ -8,7 +8,7 @@
 #include <event.h>
 #include <datasetreader.h>
 #include <datasetminmax.h>
-#include <log.h>
+#include <chrono_monitor.h>
 
 class StoryReader
 {

--- a/ChronoStore/src/StoryReader.cpp
+++ b/ChronoStore/src/StoryReader.cpp
@@ -12,7 +12,7 @@
 #include <chunkattr.h>
 #include <datasetreader.h>
 #include <datasetminmax.h>
-#include <log.h>
+#include <chrono_monitor.h>
 #include <chronolog_errcode.h>
 
 #define DEBUG 0 // Set to 1 ito print H5 error messages to console

--- a/ChronoStore/src/StoryWriter.cpp
+++ b/ChronoStore/src/StoryWriter.cpp
@@ -15,7 +15,7 @@
 #include <event.h>
 #include <chunkattr.h>
 #include <StoryWriter.h>
-#include <log.h>
+#include <chrono_monitor.h>
 #include <chronolog_errcode.h>
 
 #define DATASET_RANK 1 // Dataset dimension

--- a/ChronoStore/test/CMakeLists.txt
+++ b/ChronoStore/test/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(hdf5_archiver_test
     ../include/StoryReader.h
     ../src/StoryReader.cpp
     story_chunk_test_utils.h
-    ../../ChronoAPI/ChronoLog/src/log.cpp
+    ../../ChronoAPI/ChronoLog/src/chrono_monitor.cpp
     ../../chrono_common/StoryChunk.cpp)
 
 target_include_directories(hdf5_archiver_test PRIVATE ../../ChronoKeeper
@@ -44,6 +44,6 @@ add_test(NAME hdf5_archiver_test COMMAND hdf5_archiver_test)
 
 # compound-vlen-bytes-based vs blob+map archiver implementation comparison
 add_executable(cmp_vlen_bytes_vs_blob_map cmp_vlen_bytes_vs_blob_map.cpp
-    ../../ChronoAPI/ChronoLog/src/log.cpp)
+    ../../ChronoAPI/ChronoLog/src/chrono_monitor.cpp)
 target_link_libraries(cmp_vlen_bytes_vs_blob_map ${HDF5_LIBRARIES} thallium)
 add_test(NAME cmp_vlen_bytes_vs_blob_map COMMAND cmp_vlen_bytes_vs_blob_map)

--- a/ChronoStore/test/cmp_vlen_bytes_dtype_test.cpp
+++ b/ChronoStore/test/cmp_vlen_bytes_dtype_test.cpp
@@ -12,7 +12,7 @@
 #include <unistd.h>
 #include <cassert>
 #include <hdf5.h>
-#include <log.h>
+#include <chrono_monitor.h>
 #include <chronolog_errcode.h>
 //#include <story_chunk_test_utils.h>
 

--- a/ChronoStore/test/cmp_vlen_bytes_vs_blob_map.cpp
+++ b/ChronoStore/test/cmp_vlen_bytes_vs_blob_map.cpp
@@ -5,7 +5,7 @@
 #include <utility>
 #include <vector>
 #include <random>
-#include <log.h>
+#include <chrono_monitor.h>
 #include <chronolog_errcode.h>
 #include <algorithm>
 #include <fstream>

--- a/ChronoStore/test/cmp_vlen_str_dtype_test.cpp
+++ b/ChronoStore/test/cmp_vlen_str_dtype_test.cpp
@@ -13,7 +13,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <hdf5.h>
-#include <log.h>
+#include <chrono_monitor.h>
 #include <chronolog_errcode.h>
 //#include <story_chunk_test_utils.h>
 

--- a/ChronoStore/test/hdf5_archiver_test.cpp
+++ b/ChronoStore/test/hdf5_archiver_test.cpp
@@ -8,7 +8,7 @@
 #include <hdf5.h>
 #include <StoryWriter.h>
 #include <StoryReader.h>
-#include <log.h>
+#include <chrono_monitor.h>
 #include <story_chunk_test_utils.h>
 #include "chronolog_types.h"
 

--- a/ChronoVisor/CMakeLists.txt
+++ b/ChronoVisor/CMakeLists.txt
@@ -17,7 +17,7 @@ target_sources(chronovisor_server PRIVATE
     ./src/KeeperRegistry.cpp
     ../chrono_common/ConfigurationManager.cpp
     ../ChronoAPI/ChronoLog/src/city.cpp
-    ../ChronoAPI/ChronoLog/src/log.cpp)
+    ../ChronoAPI/ChronoLog/src/chrono_monitor.cpp)
 
 target_include_directories(chronovisor_server PRIVATE
     ../ChronoAPI/ChronoLog/include

--- a/ChronoVisor/include/Chronicle.h
+++ b/ChronoVisor/include/Chronicle.h
@@ -11,7 +11,7 @@
 #include <Story.h>
 #include <Archive.h>
 #include "city.h"
-#include <log.h>
+#include <chrono_monitor.h>
 #include <chronolog_errcode.h>
 #include <mutex>
 

--- a/ChronoVisor/include/DataStoreAdminClient.h
+++ b/ChronoVisor/include/DataStoreAdminClient.h
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>
-#include "log.h"
+#include "chrono_monitor.h"
 #include "chronolog_types.h"
 
 namespace tl = thallium;

--- a/ChronoVisor/include/KeeperRegistryService.h
+++ b/ChronoVisor/include/KeeperRegistryService.h
@@ -10,7 +10,7 @@
 #include "KeeperStatsMsg.h"
 #include "GrapherIdCard.h"
 #include "GrapherRegistrationMsg.h"
-#include "log.h"
+#include "chrono_monitor.h"
 #include "KeeperRegistry.h"
 
 namespace tl = thallium;

--- a/ChronoVisor/include/Story.h
+++ b/ChronoVisor/include/Story.h
@@ -12,7 +12,7 @@
 #include <city.h>
 #include <mutex>
 #include <chronolog_errcode.h>
-#include <log.h>
+#include <chrono_monitor.h>
 
 #include "chronolog_types.h"
 

--- a/ChronoVisor/src/ClientRegistryManager.cpp
+++ b/ChronoVisor/src/ClientRegistryManager.cpp
@@ -6,7 +6,7 @@
 #include <mutex>
 #include "ClientRegistryManager.h"
 #include "chronolog_errcode.h"
-#include "log.h"
+#include "chrono_monitor.h"
 #include <ChronicleMetaDirectory.h>
 
 namespace chl = chronolog;

--- a/ChronoVisor/src/KeeperRegistry.cpp
+++ b/ChronoVisor/src/KeeperRegistry.cpp
@@ -5,7 +5,7 @@
 #include "KeeperRegistry.h"
 #include "KeeperRegistryService.h"
 #include "DataStoreAdminClient.h"
-#include "log.h"
+#include "chrono_monitor.h"
 #include "ConfigurationManager.h"
 /////////////////////////
 

--- a/ChronoVisor/src/chronovisor_instance.cpp
+++ b/ChronoVisor/src/chronovisor_instance.cpp
@@ -40,13 +40,13 @@ int main(int argc, char**argv)
         std::exit(EXIT_FAILURE);
     }
     ChronoLog::ConfigurationManager confManager(conf_file_path);
-    int result = Logger::initialize(confManager.VISOR_CONF.VISOR_LOG_CONF.LOGTYPE
-                                    , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILE
-                                    , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGLEVEL
-                                    , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGNAME
-                                    , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILESIZE
-                                    , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILENUM
-                                    , confManager.VISOR_CONF.VISOR_LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::Logger::initialize(confManager.VISOR_CONF.VISOR_LOG_CONF.LOGTYPE
+                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILE
+                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGLEVEL
+                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGNAME
+                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILESIZE
+                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILENUM
+                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/ChronoVisor/src/chronovisor_instance.cpp
+++ b/ChronoVisor/src/chronovisor_instance.cpp
@@ -4,7 +4,7 @@
 
 #include "cmd_arg_parse.h"
 #include "KeeperRegistry.h"
-#include "log.h"
+#include "chrono_monitor.h"
 #include "VisorClientPortal.h"
 
 volatile sig_atomic_t keep_running = true;
@@ -40,13 +40,13 @@ int main(int argc, char**argv)
         std::exit(EXIT_FAILURE);
     }
     ChronoLog::ConfigurationManager confManager(conf_file_path);
-    int result = chronolog::Logger::initialize(confManager.VISOR_CONF.VISOR_LOG_CONF.LOGTYPE
-                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILE
-                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGLEVEL
-                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGNAME
-                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILESIZE
-                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILENUM
-                                               , confManager.VISOR_CONF.VISOR_LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize(confManager.VISOR_CONF.VISOR_LOG_CONF.LOGTYPE
+                                                       , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILE
+                                                       , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGLEVEL
+                                                       , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGNAME
+                                                       , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILESIZE
+                                                       , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILENUM
+                                                       , confManager.VISOR_CONF.VISOR_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(chronolog_client
     src/StorytellerClient.cpp
     src/ChronologClient.cpp
     src/ChronologClientImpl.cpp
-    ../ChronoAPI/ChronoLog/src/log.cpp
+    ../ChronoAPI/ChronoLog/src/chrono_monitor.cpp
     ../chrono_common/ConfigurationManager.cpp
 )
 

--- a/Client/ChronoAdmin/client_admin.cpp
+++ b/Client/ChronoAdmin/client_admin.cpp
@@ -8,7 +8,7 @@
 #include <functional>
 #include <chrono>
 #include <mpi.h>
-#include <log.h>
+#include <chrono_monitor.h>
 #include <cstring>
 
 typedef struct workload_conf_args_

--- a/Client/src/ChronologClientImpl.cpp
+++ b/Client/src/ChronologClientImpl.cpp
@@ -26,7 +26,7 @@ chronolog::ChronologClientImpl::GetClientImplInstance(ChronoLog::ConfigurationMa
 chronolog::ChronologClientImpl*
 chronolog::ChronologClientImpl::GetClientImplInstance(chronolog::ClientPortalServiceConf const & visorClientPortalServiceConf)
 {
-    Logger::initialize("file", "/tmp/chrono_client.log", spdlog::level::info, "chrono_client", 1024000,3, spdlog::level::warn);
+    chrono_monitor::initialize("file", "/tmp/chrono_client.log", spdlog::level::info, "chrono_client", 1024000,3, spdlog::level::warn);
 
     std::lock_guard <std::mutex> lock_client(chronologClientMutex);
 

--- a/Client/src/StorytellerClient.h
+++ b/Client/src/StorytellerClient.h
@@ -6,7 +6,7 @@
 #include <map>
 
 #include <thallium.hpp>
-#include "log.h"
+#include "chrono_monitor.h"
 #include "KeeperIdCard.h"
 #include "chronolog_types.h"
 #include "chronolog_client.h"

--- a/Client/src/rpcVisorClient.h
+++ b/Client/src/rpcVisorClient.h
@@ -14,7 +14,7 @@
 #include <thallium/serialization/stl/vector.hpp>
 #include <thallium/serialization/stl/map.hpp>
 
-#include "log.h"
+#include "chrono_monitor.h"
 #include "chronolog_types.h"
 #include "ConnectResponseMsg.h"
 #include "AcquireStoryResponseMsg.h"

--- a/Client/storyteller_test/storyteller_test.cpp
+++ b/Client/storyteller_test/storyteller_test.cpp
@@ -2,7 +2,7 @@
 #include <ctime>
 #include <chrono>
 #include <unistd.h>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #include <thallium/serialization/stl/string.hpp>
 #include <thallium.hpp>

--- a/chrono_common/ConfigurationManager.cpp
+++ b/chrono_common/ConfigurationManager.cpp
@@ -65,13 +65,13 @@ void ChronoLog::ConfigurationManager::parseGrapherConf(json_object*json_conf)
                 }
             }
         }
-        else if(strcmp(key, "Logging") == 0)
+        else if(strcmp(key, "Monitoring") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object*chrono_logging = json_object_object_get(json_conf, "Logging");
+            json_object*chrono_logging = json_object_object_get(json_conf, "Monitoring");
             json_object_object_foreach(chrono_logging, key, val)
             {
-                if(strcmp(key, "log") == 0)
+                if(strcmp(key, "monitor") == 0)
                 {
                     parseLogConf(val, GRAPHER_CONF.LOG_CONF);
                 }

--- a/chrono_common/ConfigurationManager.h
+++ b/chrono_common/ConfigurationManager.h
@@ -773,13 +773,13 @@ private:
                     }
                 }
             }
-            else if(strcmp(key, "Logging") == 0)
+            else if(strcmp(key, "Monitoring") == 0)
             {
                 assert(json_object_is_type(val, json_type_object));
-                json_object*chronovisor_log = json_object_object_get(json_conf, "Logging");
+                json_object*chronovisor_log = json_object_object_get(json_conf, "Monitoring");
                 json_object_object_foreach(chronovisor_log, key, val)
                 {
-                    if(strcmp(key, "log") == 0)
+                    if(strcmp(key, "monitor") == 0)
                     {
                         parseLogConf(val, VISOR_CONF.VISOR_LOG_CONF);
                     }
@@ -884,13 +884,13 @@ private:
                     }
                 }
             }
-            else if(strcmp(key, "Logging") == 0)
+            else if(strcmp(key, "Monitoring") == 0)
             {
                 assert(json_object_is_type(val, json_type_object));
-                json_object*chronokeeper_log = json_object_object_get(json_conf, "Logging");
+                json_object*chronokeeper_log = json_object_object_get(json_conf, "Monitoring");
                 json_object_object_foreach(chronokeeper_log, key, val)
                 {
-                    if(strcmp(key, "log") == 0)
+                    if(strcmp(key, "monitor") == 0)
                     {
                         parseLogConf(val, KEEPER_CONF.KEEPER_LOG_CONF);
                     }
@@ -936,13 +936,13 @@ private:
                     }
                 }
             }
-            else if(strcmp(key, "Logging") == 0)
+            else if(strcmp(key, "Monitoring") == 0)
             {
                 assert(json_object_is_type(val, json_type_object));
-                json_object*chronoclient_log = json_object_object_get(json_conf, "Logging");
+                json_object*chronoclient_log = json_object_object_get(json_conf, "Monitoring");
                 json_object_object_foreach(chronoclient_log, key, val)
                 {
-                    if(strcmp(key, "log") == 0)
+                    if(strcmp(key, "monitor") == 0)
                     {
                         parseLogConf(val, CLIENT_CONF.CLIENT_LOG_CONF);
                     }

--- a/chrono_common/StoryChunk.h
+++ b/chrono_common/StoryChunk.h
@@ -7,7 +7,7 @@
 #include <thallium/serialization/stl/map.hpp>
 #include <thallium/serialization/stl/tuple.hpp>
 #include "chronolog_types.h"
-#include "log.h"
+#include "chrono_monitor.h"
 
 namespace chronolog
 {

--- a/default_conf.json.in
+++ b/default_conf.json.in
@@ -27,8 +27,8 @@
         "service_provider_id": 88
       }
     },
-    "Logging": {
-      "log": {
+    "Monitoring": {
+      "monitor": {
         "type": "file",
         "file": "chrono_visor.log",
         "level": "debug",
@@ -78,8 +78,8 @@
         "service_provider_id": 33
       }
     },
-    "Logging": {
-      "log": {
+    "Monitoring": {
+      "monitor": {
         "type": "file",
         "file": "chrono_keeper.log",
         "level": "debug",
@@ -120,8 +120,8 @@
         "service_provider_id": 88
       }
     },
-    "Logging": {
-      "log": {
+    "Monitoring": {
+      "monitor": {
         "type": "file",
         "file": "chrono_grapher.log",
         "level": "debug",
@@ -148,8 +148,8 @@
         "service_provider_id": 55
       }
     },
-    "Logging": {
-      "log": {
+    "Monitoring": {
+      "monitor": {
         "type": "file",
         "file": "chrono_client.log",
         "level": "debug",

--- a/test/communication/CMakeLists.txt
+++ b/test/communication/CMakeLists.txt
@@ -14,7 +14,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 add_executable(thallium_server thallium_server.cpp
-    ../../ChronoAPI/ChronoLog/src/log.cpp)
+    ../../ChronoAPI/ChronoLog/src/chrono_monitor.cpp)
 target_include_directories(thallium_server PRIVATE
     ../../ChronoAPI/ChronoLog/include)
 target_link_libraries(thallium_server PRIVATE thallium)
@@ -22,7 +22,7 @@ target_link_libraries(thallium_server PUBLIC "-pthread")
 add_test(NAME CommThalliumServer COMMAND thallium_server)
 
 add_executable(thallium_client thallium_client.cpp
-    ../../ChronoAPI/ChronoLog/src/log.cpp)
+    ../../ChronoAPI/ChronoLog/src/chrono_monitor.cpp)
 target_include_directories(thallium_client PRIVATE
     ../../ChronoAPI/ChronoLog/include)
 target_include_directories(thallium_client PRIVATE)
@@ -30,7 +30,7 @@ target_link_libraries(thallium_client thallium)
 add_test(NAME CommThalliumClient COMMAND thallium_client)
 
 add_executable(thallium_client_mpi thallium_client_mpi.cpp
-    ../../ChronoAPI/ChronoLog/src/log.cpp)
+    ../../ChronoAPI/ChronoLog/src/chrono_monitor.cpp)
 include_directories(SYSTEM ${MPI_INCLUDE_PATH})
 target_include_directories(thallium_client_mpi PRIVATE
     ../../ChronoAPI/ChronoLog/include)

--- a/test/communication/thallium_client.cpp
+++ b/test/communication/thallium_client.cpp
@@ -10,7 +10,7 @@
 #include <thallium/serialization/stl/vector.hpp>
 #include <thallium/serialization/stl/string.hpp>
 #include <thallium/serialization/stl/array.hpp>
-#include "log.h"
+#include "chrono_monitor.h"
 
 namespace tl = thallium;
 using namespace std::chrono;

--- a/test/communication/thallium_client_mpi.cpp
+++ b/test/communication/thallium_client_mpi.cpp
@@ -9,7 +9,7 @@
 #include <thallium/serialization/stl/vector.hpp>
 #include "../../ChronoAPI/ChronoLog/include/common.h"
 #include <mpi.h>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #define WARM_UP_REPS 3
 #define MSG_SIZE (1 * 1024 * 1024)

--- a/test/communication/thallium_server.cpp
+++ b/test/communication/thallium_server.cpp
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <unistd.h>
 #include <margo.h>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #define MAX_BULK_MEM_SIZE (1 * 1024 * 1024)
 

--- a/test/integration/Client/client_lib_connect_rpc_test.cpp
+++ b/test/integration/Client/client_lib_connect_rpc_test.cpp
@@ -10,7 +10,7 @@
 #include "common.h"
 #include <cassert>
 #include <cmd_arg_parse.h>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #define NUM_CONNECTION (1)
 

--- a/test/integration/Client/client_lib_hybrid_argobots_test.cpp
+++ b/test/integration/Client/client_lib_hybrid_argobots_test.cpp
@@ -6,7 +6,7 @@
 #include <abt.h>
 #include <mpi.h>
 #include <cmd_arg_parse.h>
-#include "log.h"
+#include "chrono_monitor.h"
 
 chronolog::Client*client;
 

--- a/test/integration/Client/client_lib_metadata_rpc_test.cpp
+++ b/test/integration/Client/client_lib_metadata_rpc_test.cpp
@@ -7,7 +7,7 @@
 #include "common.h"
 #include <cassert>
 #include <cmd_arg_parse.h>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #define NUM_CHRONICLE (10)
 #define NUM_STORY (10)

--- a/test/integration/Client/client_lib_multi_argobots_test.cpp
+++ b/test/integration/Client/client_lib_multi_argobots_test.cpp
@@ -7,7 +7,7 @@
 #include <abt.h>
 #include <atomic>
 #include <cmd_arg_parse.h>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #define CHRONICLE_NAME_LEN 32
 #define STORY_NAME_LEN 32

--- a/test/integration/Client/client_lib_multi_openmp_test.cpp
+++ b/test/integration/Client/client_lib_multi_openmp_test.cpp
@@ -4,7 +4,7 @@
 #include <thread>
 #include <omp.h>
 #include <cmd_arg_parse.h>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #define STORY_NAME_LEN 32
 

--- a/test/integration/Client/client_lib_multi_pthread_test.cpp
+++ b/test/integration/Client/client_lib_multi_pthread_test.cpp
@@ -3,7 +3,7 @@
 #include <common.h>
 #include <thread>
 #include <cmd_arg_parse.h>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #define STORY_NAME_LEN 32
 

--- a/test/integration/Client/client_lib_multi_storytellers.cpp
+++ b/test/integration/Client/client_lib_multi_storytellers.cpp
@@ -37,8 +37,8 @@ void thread_body(struct thread_arg*t)
 
     // Create the chronicle
     ret = client->CreateChronicle(chronicle_name, chronicle_attrs, flags);
-    LOG_DEBUG("[ClientLibMultiStorytellers] Chronicle created: tid={}, ChronicleName={}, Flags: {}", t->tid, chronicle_name
-         , flags);
+    LOG_DEBUG("[ClientLibMultiStorytellers] Chronicle created: tid={}, ChronicleName={}, Flags: {}", t->tid
+              , chronicle_name, flags);
 
     // Create attributes for the story
     std::string story_name = gen_random(STORY_NAME_LEN);
@@ -48,7 +48,7 @@ void thread_body(struct thread_arg*t)
     // Acquire the story
     auto acquire_ret = client->AcquireStory(chronicle_name, story_name, story_attrs, flags);
     LOG_DEBUG("[ClientLibMultiStorytellers] Story acquired: tid={}, ChronicleName={}, StoryName={}, Ret: {}", t->tid
-         , chronicle_name, story_name, acquire_ret.first);
+              , chronicle_name, story_name, acquire_ret.first);
 
     // Assertion for successful story acquisition or expected errors
     assert(acquire_ret.first == chronolog::CL_SUCCESS || acquire_ret.first == chronolog::CL_ERR_NOT_EXIST ||
@@ -68,7 +68,7 @@ void thread_body(struct thread_arg*t)
         // Release the story
         ret = client->ReleaseStory(chronicle_name, story_name);
         LOG_DEBUG("[ClientLibMultiStorytellers] Story released: tid={}, ChronicleName={}, StoryName={}, Ret: {}", t->tid
-             , chronicle_name, story_name, ret);
+                  , chronicle_name, story_name, ret);
 
         // Assertion for successful story release or expected errors
         assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NO_CONNECTION);
@@ -77,7 +77,7 @@ void thread_body(struct thread_arg*t)
     // Destroy the story
     ret = client->DestroyStory(chronicle_name, story_name);
     LOG_DEBUG("[ClientLibMultiStorytellers] Story destroyed: tid={}, ChronicleName={}, StoryName={}, Ret: {}", t->tid
-         , chronicle_name, story_name, ret);
+              , chronicle_name, story_name, ret);
 
     // Assertion for successful story destruction or expected errors
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED ||
@@ -112,13 +112,13 @@ int main(int argc, char**argv)
 
     ChronoLogRPCImplementation protocol = CHRONOLOG_THALLIUM_SOCKETS;
     ChronoLog::ConfigurationManager confManager(conf_file_path);
-    int result = Logger::initialize(confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGTYPE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::Logger::initialize(confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGTYPE
+                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILE
+                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
+                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
+                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
+                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/test/integration/Client/client_lib_multi_storytellers.cpp
+++ b/test/integration/Client/client_lib_multi_storytellers.cpp
@@ -4,7 +4,7 @@
 #include <thread>
 #include <chrono>
 #include <cmd_arg_parse.h>
-#include "log.h"
+#include "chrono_monitor.h"
 
 #define STORY_NAME_LEN 5
 
@@ -112,13 +112,13 @@ int main(int argc, char**argv)
 
     ChronoLogRPCImplementation protocol = CHRONOLOG_THALLIUM_SOCKETS;
     ChronoLog::ConfigurationManager confManager(conf_file_path);
-    int result = chronolog::Logger::initialize(confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGTYPE
-                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILE
-                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
-                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
-                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
-                                               , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize(confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGTYPE
+                                                       , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILE
+                                                       , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
+                                                       , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
+                                                       , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
+                                                       , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+                                                       , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/test/integration/Keeper-Grapher/CMakeLists.txt
+++ b/test/integration/Keeper-Grapher/CMakeLists.txt
@@ -12,7 +12,7 @@ target_sources(extract_test PRIVATE
     ../../../chrono_common/chronolog_types.h
     ../../../chrono_common/StoryChunk.cpp
     ../../../chrono_common/ConfigurationManager.cpp
-    ../../../ChronoAPI/ChronoLog/src/log.cpp)
+    ../../../ChronoAPI/ChronoLog/src/chrono_monitor.cpp)
 target_include_directories(extract_test PRIVATE include
     ../../../chrono_common
     ../../../ChronoAPI/ChronoLog/include)
@@ -25,7 +25,7 @@ target_sources(ingest_test PRIVATE
     ../../../chrono_common/chronolog_types.h
     ../../../chrono_common/StoryChunk.cpp
     ../../../chrono_common/ConfigurationManager.cpp
-    ../../../ChronoAPI/ChronoLog/src/log.cpp)
+    ../../../ChronoAPI/ChronoLog/src/chrono_monitor.cpp)
 target_include_directories(ingest_test PRIVATE include
     ../../../chrono_common
     ../../../ChronoAPI/ChronoLog/include)

--- a/test/overhead/clock/common.h
+++ b/test/overhead/clock/common.h
@@ -9,7 +9,7 @@
 #include <fstream>
 #include <numeric>
 #include <complex>
-#include "log.h"
+#include "chrono_monitor.h"
 
 //#define NO_LFENCE
 //#define NO_MFENCE

--- a/test/overhead/clock/timestamp_collision_detection.cpp
+++ b/test/overhead/clock/timestamp_collision_detection.cpp
@@ -8,7 +8,7 @@
 #include <unordered_map>
 #include <regex>
 #include <filesystem>
-#include "log.h"
+#include "chrono_monitor.h"
 
 int main(int argc, char*argv[])
 {


### PR DESCRIPTION
### Changes Made:
**- Namespace Addition:** Moved the Logger under the chronolog namespace.
**- File Renaming:** Renamed log.h and log.cpp to chrono_monitor.h and chrono_monitor.cpp.
**- Class Renaming:** Updated the Logger class name to match the files: chrono_monitor.
**- Mutex Optimization:** Removed unnecessary mutexes, retaining only the initialization mutex.

### Additional Analysis and Conclusions:
#### Compile-Time Error Handling:

**- Problem:** The issue of incorrect arguments resulting in runtime errors instead of compile-time errors.
**- Investigation:** This behavior is not due to the use of macros. It persists even when using the spdlog library directly.
**- Root Cause:** spdlog relies on the fmt library (formerly cppstring) for string formatting, which performs format string checks at runtime instead of compile-time.
**- Conclusion:** To achieve compile-time error checks, we would need to either switch to a different library or create a custom wrapper around spdlog.