### PR TITLE
199 full support of configurable communication protocol

### DIFF
--- a/ChronoGrapher/ChronoGrapher.cpp
+++ b/ChronoGrapher/ChronoGrapher.cpp
@@ -184,7 +184,7 @@ int main(int argc, char**argv)
         std::stringstream s1;
         s1 << recordingEngine->self();
         LOG_INFO("[ChronoGrapher] starting RecordingService at {} with provider_id {}", s1.str()
-                 , datastore_service_provider_id);
+                 , recording_service_provider_id);
         grapherRecordingService = chronolog::GrapherRecordingService::CreateRecordingService(*recordingEngine
                                                                                              , recording_service_provider_id
                                                                                              , ingestionQueue);

--- a/ChronoKeeper/ChronoKeeperInstance.cpp
+++ b/ChronoKeeper/ChronoKeeperInstance.cpp
@@ -224,7 +224,7 @@ int main(int argc, char**argv)
         std::stringstream s1;
         s1 << recordingEngine->self();
         LOG_INFO("[ChronoKeeperInstance] GroupID={} starting KeeperRecordingService at {} with provider_id {}"
-                 , keeper_group_id, s1.str(), datastore_service_provider_id);
+                 , keeper_group_id, s1.str(), recording_service_provider_id);
         keeperRecordingService = chronolog::KeeperRecordingService::CreateKeeperRecordingService(*recordingEngine
                                                                                                  , recording_service_provider_id
                                                                                                  , ingestionQueue);

--- a/ChronoVisor/include/KeeperRegistry.h
+++ b/ChronoVisor/include/KeeperRegistry.h
@@ -167,6 +167,7 @@ public:
         std::mutex registryLock;
         thallium::engine* registryEngine;
         KeeperRegistryService* keeperRegistryService;
+        std::string dataStoreAdminServiceProtocol;
         size_t delayedDataAdminExitSeconds;
 
         std::map<RecordingGroupId, RecordingGroup> recordingGroups;

--- a/Client/src/ChronologClientImpl.cpp
+++ b/Client/src/ChronologClientImpl.cpp
@@ -58,6 +58,7 @@ chronolog::ChronologClientImpl::ChronologClientImpl(const ChronoLog::Configurati
             std::to_string(confManager.CLIENT_CONF.VISOR_CLIENT_PORTAL_SERVICE_CONF.RPC_CONF.BASE_PORT);
     rpcVisorClient = chl::RpcVisorClient::CreateRpcVisorClient(*tlEngine, CLIENT_VISOR_NA_STRING
                                                                , confManager.CLIENT_CONF.VISOR_CLIENT_PORTAL_SERVICE_CONF.RPC_CONF.SERVICE_PROVIDER_ID);
+    storytellerRpcProtocol = confManager.KEEPER_CONF.KEEPER_RECORDING_SERVICE_CONF.RPC_CONF.PROTO_CONF;
 }
 ///////////////
 
@@ -157,7 +158,7 @@ int chronolog::ChronologClientImpl::Connect()
         clientId = connectResponseMsg.getClientId();
         if(storyteller == nullptr)
         {
-            storyteller = new StorytellerClient(clockProxy, *tlEngine, clientId);
+            storyteller = new StorytellerClient(clockProxy, *tlEngine, clientId, storytellerRpcProtocol);
         }
         //TODO: if we ever change the connection hashing algorithm we'd need to handle reconnection case with the new client_id 
     }

--- a/Client/src/ChronologClientImpl.h
+++ b/Client/src/ChronologClientImpl.h
@@ -74,6 +74,7 @@ private:
     uint32_t hostId;
     uint32_t pid;
     ClientId clientId;
+    std::string storytellerRpcProtocol;
     ChronologTimer clockProxy;
     thallium::engine*tlEngine;
     RpcVisorClient*rpcVisorClient;

--- a/deploy/single_user_deploy.sh
+++ b/deploy/single_user_deploy.sh
@@ -117,6 +117,13 @@ check_rpc_comm_conf() {
     keeper_grapher_drain_rpc_in_grapher=$(jq '.chrono_grapher.KeeperGrapherDrainService.rpc' "${CONF_FILE}")
     [[ "${keeper_grapher_drain_rpc_in_keeper}" != "${keeper_grapher_drain_rpc_in_grapher}" ]] && echo -e "${ERR}mismatched KeeperGrapherDrainService conf in ${CONF_FILE}, exiting ...${NC}" >&2 && exit 1
 
+    # to assume Keeper and Grapher use the same protocol for dataStoreAdminService
+    keeper_data_store_admin_protocol=$(jq '.chrono_keeper.KeeperDataStoreAdminService.rpc.protocol_conf' "${CONF_FILE}")
+    grapher_data_store_admin_protocol=$(jq '.chrono_grapher.DataStoreAdminService.rpc.protocol_conf' "${CONF_FILE}")
+    [[ "${keeper_data_store_admin_protocol}" != "${grapher_data_store_admin_protocol}" ]] && echo -e "${ERR}mismatched protocol for DataStoreAdminService in Keeper and Grapher conf in ${CONF_FILE}, exiting ...${NC}" >&2 && exit 1
+
+    [[ "${verbose}" == "true" ]] && echo -e "${DEBUG}Check rpc conf done${NC}"
+
     [[ "${verbose}" == "true" ]] && echo -e "${DEBUG}Check base conf file done${NC}"
 }
 


### PR DESCRIPTION
Changes:

- Use protocol of Keeper's RecordingService configuration in the conf file to create StorytellerClient in Client.
- Use protocol of Keeper's DataStoreAdminService configuration in the conf file to create DataStoreAdminClient in Visor. This assumes that Keeper and Grapher uses the same protocol for their DataStoreAdminService. This is assured by the deployment script.

Notes:

- Since testing this PR involves different communication protocols like`ofi+verbs`, it has to be tested on supporting platform like Ares.