### PR TITLE
Create repository-traffic.yml

### DIFF
--- a/.github/workflows/repository-traffic.yml
+++ b/.github/workflows/repository-traffic.yml
@@ -1,0 +1,30 @@
+name: Repository Traffic
+
+on:
+  schedule:
+    # Runs every Sunday at 11:55 PM UTC
+    - cron: "55 23 * * 0"
+  workflow_dispatch:
+
+jobs:
+  traffic:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - uses: actions/checkout@v2
+
+      # Calculate traffic and clones and store in CSV file
+      - name: Repository Traffic
+        uses: sangonzal/repository-traffic-action@v0.1.6
+        env:
+          TRAFFIC_ACTION_TOKEN: ${{ secrets.TRAFFIC_ACTION_TOKEN }}
+
+      # Commit changes to the repository
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v4
+        with:
+          author_name: EnekoGonzalez
+          message: "Update GitHub traffic data"
+          add: "./repo-traffic-data/*"
+          ref: "repo-traffic-data"  # commits to branch "traffic"


### PR DESCRIPTION
### Description:
This PR adds a GitHub Action that pulls repository traffic and clones data from the GitHub API v3 and stores it in a CSV file, which is committed to the repository.

### Key Features:

1. Collects traffic and clones data beyond GitHub's 2-week limit.
2. Commits the data in CSV format directly to the repository.

### Why This Change:
Enables long-term tracking of repository traffic and clones data within the repo.
