### PR TITLE
210 scripts to generate performance metrics

### DIFF
--- a/ChronoGrapher/GrapherRecordingService.h
+++ b/ChronoGrapher/GrapherRecordingService.h
@@ -32,11 +32,11 @@ public:
         get_engine().pop_finalize_callback(this);
     }
 
-    void record_story_chunk(tl::request const &request, uint64_t chunk_size, tl::bulk &b)
+    void record_story_chunk(tl::request const &request, tl::bulk &b)
     {
         try
         {
-            std::vector <char> mem_vec(chunk_size + 1);
+            std::vector <char> mem_vec(b.size());
             std::chrono::high_resolution_clock::time_point start, end;
             LOG_DEBUG("[GrapherRecordingService] StoryChunk recording RPC invoked, ThreadID={}", tl::thread::self_id());
             tl::endpoint ep = request.get_endpoint();
@@ -59,8 +59,8 @@ public:
 #ifndef NDEBUG
             start = std::chrono::high_resolution_clock::now();
 #endif
-            int ret = deserializedWithCereal(&mem_vec[0], b.size() - 1
-                                             , *story_chunk); // TODO: (Kun) the extra byte might not be necessary
+            int ret = deserializedWithCereal(&mem_vec[0], b.size()
+                                             , *story_chunk);
             if(ret != CL_SUCCESS)
             {
                 LOG_ERROR("[GrapherRecordingService] Failed to deserialize a story chunk, ThreadID={}"

--- a/ChronoGrapher/GrapherRecordingService.h
+++ b/ChronoGrapher/GrapherRecordingService.h
@@ -16,7 +16,6 @@ namespace tl = thallium;
 
 namespace chronolog
 {
-#define MAX_BULK_MEM_SIZE (4 * 1024 * 1024)
 class GrapherRecordingService: public tl::provider <GrapherRecordingService>
 {
 public:
@@ -33,66 +32,74 @@ public:
         get_engine().pop_finalize_callback(this);
     }
 
-    void record_story_chunk(tl::request const &request, tl::bulk &b)
+    void record_story_chunk(tl::request const &request, uint64_t chunk_size, tl::bulk &b)
     {
-        std::vector <char> mem_vec(MAX_BULK_MEM_SIZE);
-        std::chrono::high_resolution_clock::time_point start, end;
-        LOG_DEBUG("[GrapherRecordingService] StoryChunk recording RPC invoked, ThreadID={}", tl::thread::self_id());
-        tl::endpoint ep = request.get_endpoint();
-        LOG_DEBUG("[GrapherRecordingService] Endpoint obtained, ThreadID={}", tl::thread::self_id());
-        std::vector <std::pair <void*, std::size_t>> segments(1);
-        segments[0].first = (void*)(&mem_vec[0]);
-        segments[0].second = mem_vec.size();
-        LOG_DEBUG("[GrapherRecordingService] Bulk memory prepared, size: {}, ThreadID={}", mem_vec.size()
-                  , tl::thread::self_id());
-        tl::engine tl_engine = get_engine();
-        LOG_DEBUG("[GrapherRecordingService] Engine addr: {}, ThreadID={}", (void*)&tl_engine, tl::thread::self_id());
-        tl::bulk local = tl_engine.expose(segments, tl::bulk_mode::write_only);
-        LOG_DEBUG("[GrapherRecordingService] Bulk memory exposed, ThreadID={}", tl::thread::self_id());
-        b.on(ep) >> local;
-        LOG_DEBUG("[GrapherRecordingService] Received {} bytes of StoryChunk data, ThreadID={}", b.size()
-                  , tl::thread::self_id());
-//        for(auto i = 0; i < b.size() - 1; ++i)
-//        {
-//            std::cout << (char)*(char*)(&mem_vec[0]+i) << " ";
-//        }
-//        std::cout << std::endl;
-
-        StoryChunk * story_chunk= new StoryChunk();
-#ifndef NDEBUG
-        start = std::chrono::high_resolution_clock::now();
-#endif
-        int ret = deserializedWithCereal(&mem_vec[0], b.size() - 1, *story_chunk); // TODO: (Kun) the extra byte might not be necessary
-        if(ret != CL_SUCCESS)
+        try
         {
-            LOG_ERROR("[GrapherRecordingService] Failed to deserialize a story chunk, ThreadID={}", tl::thread::self_id());
-            delete story_chunk;
-            ret = 10000000 + tl::thread::self_id(); // arbitrary error code encoded with thread id
-            LOG_ERROR("[GrapherRecordingService] Discarding the story chunk, responding {} to Keeper", ret);
-            request.respond(ret);
+            std::vector <char> mem_vec(chunk_size + 1);
+            std::chrono::high_resolution_clock::time_point start, end;
+            LOG_DEBUG("[GrapherRecordingService] StoryChunk recording RPC invoked, ThreadID={}", tl::thread::self_id());
+            tl::endpoint ep = request.get_endpoint();
+            LOG_DEBUG("[GrapherRecordingService] Endpoint obtained, ThreadID={}", tl::thread::self_id());
+            std::vector <std::pair <void*, std::size_t>> segments(1);
+            segments[0].first = (void*)(&mem_vec[0]);
+            segments[0].second = mem_vec.size();
+            LOG_DEBUG("[GrapherRecordingService] Bulk memory prepared, size: {}, ThreadID={}", mem_vec.size()
+                      , tl::thread::self_id());
+            tl::engine tl_engine = get_engine();
+            LOG_DEBUG("[GrapherRecordingService] Engine addr: {}, ThreadID={}", (void*)&tl_engine
+                      , tl::thread::self_id());
+            tl::bulk local = tl_engine.expose(segments, tl::bulk_mode::write_only);
+            LOG_DEBUG("[GrapherRecordingService] Bulk memory exposed, ThreadID={}", tl::thread::self_id());
+            b.on(ep) >> local;
+            LOG_DEBUG("[GrapherRecordingService] Received {} bytes of StoryChunk data, ThreadID={}", b.size()
+                      , tl::thread::self_id());
+
+            StoryChunk*story_chunk = new StoryChunk();
+#ifndef NDEBUG
+            start = std::chrono::high_resolution_clock::now();
+#endif
+            int ret = deserializedWithCereal(&mem_vec[0], b.size() - 1
+                                             , *story_chunk); // TODO: (Kun) the extra byte might not be necessary
+            if(ret != CL_SUCCESS)
+            {
+                LOG_ERROR("[GrapherRecordingService] Failed to deserialize a story chunk, ThreadID={}"
+                          , tl::thread::self_id());
+                delete story_chunk;
+                ret = 10000000 + tl::thread::self_id(); // arbitrary error code encoded with thread id
+                LOG_ERROR("[GrapherRecordingService] Discarding the story chunk, responding {} to Keeper", ret);
+                request.respond(ret);
+                return;
+            }
+#ifndef NDEBUG
+            end = std::chrono::high_resolution_clock::now();
+            LOG_INFO("[GrapherRecordingService] Deserialization took {} us, ThreadID={}",
+                    std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0
+                     , tl::thread::self_id());
+#endif
+            LOG_DEBUG("[GrapherRecordingService] StoryChunk received: StoryId {} StartTime {} eventCount {} ThreadID={}"
+                      , story_chunk->getStoryId(), story_chunk->getStartTime(), story_chunk->getEventCount()
+                      , tl::thread::self_id());
+
+            request.respond(b.size());
+            LOG_DEBUG("[GrapherRecordingService] StoryChunk recording RPC responded {}, ThreadID={}", b.size()
+                      , tl::thread::self_id());
+
+            theIngestionQueue.ingestStoryChunk(story_chunk);
+        }
+        catch(std::bad_alloc const &ex)
+        {
+            LOG_ERROR("[GrapherRecordingService] Failed to allocate memory for StoryChunk data, ThreadID={}"
+                      , tl::thread::self_id());
+            request.respond(20000000 + tl::thread::self_id());
             return;
         }
-#ifndef NDEBUG
-        end = std::chrono::high_resolution_clock::now();
-        LOG_INFO("[GrapherRecordingService] Deserialization took {} us, ThreadID={}",
-                std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0
-                 , tl::thread::self_id());
-#endif
-        LOG_DEBUG("[GrapherRecordingService] StoryChunk received: StoryId {} StartTime {} eventCount {} ThreadID={}"
-                  , story_chunk->getStoryId(), story_chunk->getStartTime(), story_chunk->getEventCount(), tl::thread::self_id());
-
-        request.respond(b.size());
-        LOG_DEBUG("[GrapherRecordingService] StoryChunk recording RPC responded {}, ThreadID={}"
-                  , b.size(), tl::thread::self_id());
-
-        theIngestionQueue.ingestStoryChunk(story_chunk);
     }
 
 private:
     GrapherRecordingService(tl::engine &tl_engine, uint16_t service_provider_id, ChunkIngestionQueue &ingestion_queue)
             : tl::provider <GrapherRecordingService>(tl_engine, service_provider_id), theIngestionQueue(ingestion_queue)
     {
-//        mem_vec.resize(MAX_BULK_MEM_SIZE);
         define("record_story_chunk", &GrapherRecordingService::record_story_chunk, tl::ignore_return_value());
         //set up callback for the case when the engine is being finalized while this provider is still alive
         get_engine().push_finalize_callback(this, [p = this]()
@@ -136,8 +143,6 @@ private:
     GrapherRecordingService &operator=(GrapherRecordingService const &) = delete;
 
     ChunkIngestionQueue &theIngestionQueue;
-
-//    std::vector <char> mem_vec;
 };
 
 }// namespace chronolog

--- a/ChronoKeeper/StoryChunkExtractorRDMA.cpp
+++ b/ChronoKeeper/StoryChunkExtractorRDMA.cpp
@@ -44,13 +44,13 @@ int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk
 
         std::vector <std::pair <void*, std::size_t>> segments(1);
         segments[0].first = (void*)(serialized_story_chunk.data());
-        segments[0].second = serialized_story_chunk_size + 1; // TODO: (Kun) the extra byte might not be necessary
+        segments[0].second = serialized_story_chunk_size;
         tl::bulk tl_bulk = extraction_engine.expose(segments, tl::bulk_mode::read_only);
         LOG_DEBUG("[StoryChunkExtractorRDMA] Draining to Grapher with story chunk size: {} ...", tl_bulk.size());
 #ifndef NDEBUG
         start = std::chrono::high_resolution_clock::now();
 #endif
-        size_t result = drain_to_grapher.on(service_ph)(serialized_story_chunk_size, tl_bulk);
+        size_t result = drain_to_grapher.on(service_ph)(tl_bulk);
 #ifndef NDEBUG
         end = std::chrono::high_resolution_clock::now();
         LOG_INFO("[StoryChunkExtractorRDMA] Draining to Grapher took {} us",
@@ -58,7 +58,7 @@ int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk
 #endif
         LOG_DEBUG("[StoryChunkExtractorRDMA] Draining to Grapher returned with result: {}", result);
 
-        if(result == serialized_story_chunk_size + 1) // TODO: (Kun) the extra byte might not be necessary
+        if(result == serialized_story_chunk_size)
         {
             LOG_INFO("[StoryChunkExtractorRDMA] Successfully drained a story chunk to Grapher, StoryID: {}, "
                      "StartTime: {}", story_chunk->getStoryId(), story_chunk->getStartTime());

--- a/ChronoKeeper/StoryChunkExtractorRDMA.cpp
+++ b/ChronoKeeper/StoryChunkExtractorRDMA.cpp
@@ -29,14 +29,11 @@ int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk
         start = std::chrono::high_resolution_clock::now();
 #endif
         size_t serialized_story_chunk_size;
-        char *serialized_buf = new char[MAX_BULK_MEM_SIZE];
         std::ostringstream oss(std::ios::binary);
-        oss.rdbuf()->pubsetbuf(serialized_buf, MAX_BULK_MEM_SIZE);
         cereal::BinaryOutputArchive oarchive(oss);
         oarchive(*story_chunk);
-//        std::string serialized_story_chunk = oss.str();
-//        serialized_story_chunk_size = serialized_story_chunk.size();
-        serialized_story_chunk_size = oss.tellp();
+        std::string serialized_story_chunk = oss.str();
+        serialized_story_chunk_size = serialized_story_chunk.size();
 
 #ifndef NDEBUG
         end = std::chrono::high_resolution_clock::now();
@@ -46,22 +43,20 @@ int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk
         LOG_DEBUG("[StoryChunkExtractorRDMA] Serialized story chunk size: {}", serialized_story_chunk_size);
 
         std::vector <std::pair <void*, std::size_t>> segments(1);
-//        segments[0].first = (void*)(serialized_story_chunk.data());
-        segments[0].first = (void*)(serialized_buf);
+        segments[0].first = (void*)(serialized_story_chunk.data());
         segments[0].second = serialized_story_chunk_size + 1; // TODO: (Kun) the extra byte might not be necessary
         tl::bulk tl_bulk = extraction_engine.expose(segments, tl::bulk_mode::read_only);
         LOG_DEBUG("[StoryChunkExtractorRDMA] Draining to Grapher with story chunk size: {} ...", tl_bulk.size());
 #ifndef NDEBUG
         start = std::chrono::high_resolution_clock::now();
 #endif
-        size_t result = drain_to_grapher.on(service_ph)(tl_bulk);
+        size_t result = drain_to_grapher.on(service_ph)(serialized_story_chunk_size, tl_bulk);
 #ifndef NDEBUG
         end = std::chrono::high_resolution_clock::now();
         LOG_INFO("[StoryChunkExtractorRDMA] Draining to Grapher took {} us",
                 std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0);
 #endif
         LOG_DEBUG("[StoryChunkExtractorRDMA] Draining to Grapher returned with result: {}", result);
-        delete[] serialized_buf;
 
         if(result == serialized_story_chunk_size + 1) // TODO: (Kun) the extra byte might not be necessary
         {

--- a/ChronoKeeper/StoryChunkExtractorRDMA.h
+++ b/ChronoKeeper/StoryChunkExtractorRDMA.h
@@ -10,8 +10,6 @@ namespace tl = thallium;
 namespace chronolog
 {
 
-#define MAX_BULK_MEM_SIZE (4 * 1024 * 1024)
-
 class StoryChunkExtractorRDMA: public StoryChunkExtractorBase
 {
 public:

--- a/Client/ChronoAdmin/client_admin.cpp
+++ b/Client/ChronoAdmin/client_admin.cpp
@@ -9,7 +9,11 @@
 #include <chrono>
 #include <mpi.h>
 #include <chrono_monitor.h>
+#include <TimerWrapper.h>
 #include <cstring>
+#include <margo.h>
+
+#define MAX_EVENT_SIZE (32 * 1024 * 1024)
 
 typedef struct workload_conf_args_
 {
@@ -24,10 +28,13 @@ typedef struct workload_conf_args_
     std::string event_input_file;
     bool interactive = false;
     bool shared_story = false;
+    bool perf_test = false;
 } workload_conf_args;
 
 std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
 {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     int opt;
     char*config_file = nullptr;
     workload_conf_args workload_args;
@@ -45,11 +52,12 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
                                     , {"barrier"         , optional_argument, nullptr, 'r'}
                                     , {"event_input_file", optional_argument, nullptr, 'f'}
                                     , {"shared_story"    , optional_argument, nullptr, 'o'}
+                                    , {"perf"            , optional_argument, nullptr, 'p'}
                                     , {nullptr           , 0                , nullptr, 0} // Terminate the options array
     };
 
     // Parse the command-line options
-    while((opt = getopt_long(argc, argv, "c:ih:t:a:s:b:n:g:rf:o", long_options, nullptr)) != -1)
+    while((opt = getopt_long(argc, argv, "c:ih:t:a:s:b:n:g:rf:op", long_options, nullptr)) != -1)
     {
         switch(opt)
         {
@@ -81,13 +89,16 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
                 workload_args.event_interval = strtoll(optarg, nullptr, 10);
                 break;
             case 'r':
-                workload_args.barrier = false;
+                workload_args.barrier = true;
                 break;
             case 'f':
                 workload_args.event_input_file = optarg;
                 break;
             case 'o':
                 workload_args.shared_story = true;
+                break;
+            case 'p':
+                workload_args.perf_test = true;
                 break;
             case '?':
                 // Invalid option or missing argument
@@ -103,7 +114,8 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
                              "-g|--event_interval <event_interval>\n"
                              "-r|--barrier\n"
                              "-f|--input <event_input_file>\n"
-                             "-o|--shared_story\n" << argv[0] << std::endl;
+                             "-o|--shared_story\n"
+                             "-p|--perf\n" << argv[0] << std::endl;
                 exit(EXIT_FAILURE);
             default:
                 // Unknown option
@@ -115,49 +127,56 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
     // Check if the config file option is provided
     if(config_file)
     {
-        std::cout << "Config file specified: " << config_file << std::endl;
-        if(workload_args.interactive)
+        if(rank == 0)
         {
-            std::cout << "Interactive mode: on" << std::endl;
-        }
-        else
-        {
-            std::cout << "Interactive mode: off" << std::endl;
-            std::cout << "Chronicle count: " << workload_args.chronicle_count << std::endl;
-            std::cout << "Story count: " << workload_args.story_count << std::endl;
-            if(!workload_args.event_input_file.empty())
+            std::cout << "Config file specified: " << config_file << std::endl;
+            if(workload_args.interactive)
             {
-                std::cout << "Event input file specified: " << workload_args.event_input_file.c_str() << std::endl;
-                std::cout << "Barrier: " << (workload_args.barrier ? "true" : "false") << std::endl;
-                std::cout << "Shared story: " << (workload_args.shared_story ? "true" : "false") << std::endl;
+                std::cout << "Interactive mode: on" << std::endl;
             }
             else
             {
-                std::cout << "No event input file specified, use default/specified separate conf args ..." << std::endl;
-                std::cout << "Min event size: " << workload_args.min_event_size << std::endl;
-                std::cout << "Ave event size: " << workload_args.ave_event_size << std::endl;
-                std::cout << "Max event size: " << workload_args.max_event_size << std::endl;
-                std::cout << "Event count: " << workload_args.event_count << std::endl;
-                std::cout << "Event interval: " << workload_args.event_interval << std::endl;
-                std::cout << "Barrier: " << (workload_args.barrier ? "true" : "false") << std::endl;
-                std::cout << "Shared story: " << (workload_args.shared_story ? "true" : "false") << std::endl;
+                std::cout << "Interactive mode: off" << std::endl;
+                std::cout << "Chronicle count: " << workload_args.chronicle_count << std::endl;
+                std::cout << "Story count: " << workload_args.story_count << std::endl;
+                if(!workload_args.event_input_file.empty())
+                {
+                    std::cout << "Event input file specified: " << workload_args.event_input_file.c_str() << std::endl;
+                    std::cout << "Barrier: " << (workload_args.barrier ? "true" : "false") << std::endl;
+                    std::cout << "Shared story: " << (workload_args.shared_story ? "true" : "false") << std::endl;
+                }
+                else
+                {
+                    std::cout << "No event input file specified, use default/specified separate conf args ..."
+                              << std::endl;
+                    std::cout << "Min event size: " << workload_args.min_event_size << std::endl;
+                    std::cout << "Ave event size: " << workload_args.ave_event_size << std::endl;
+                    std::cout << "Max event size: " << workload_args.max_event_size << std::endl;
+                    std::cout << "Event count: " << workload_args.event_count << std::endl;
+                    std::cout << "Event interval: " << workload_args.event_interval << std::endl;
+                    std::cout << "Barrier: " << (workload_args.barrier ? "true" : "false") << std::endl;
+                    std::cout << "Shared story: " << (workload_args.shared_story ? "true" : "false") << std::endl;
+                }
             }
         }
         return {std::pair <std::string, workload_conf_args>((config_file), workload_args)};
     }
     else
     {
-        std::cout << "No config file specified, using default settings instead:" << std::endl;
-        std::cout << "Interactive mode: " << (workload_args.interactive ? "on" : "off") << std::endl;
-        std::cout << "Chronicle count: " << workload_args.chronicle_count << std::endl;
-        std::cout << "Story count: " << workload_args.story_count << std::endl;
-        std::cout << "Min event size: " << workload_args.min_event_size << std::endl;
-        std::cout << "Ave event size: " << workload_args.ave_event_size << std::endl;
-        std::cout << "Max event size: " << workload_args.max_event_size << std::endl;
-        std::cout << "Event count: " << workload_args.event_count << std::endl;
-        std::cout << "Event interval: " << workload_args.event_interval << std::endl;
-        std::cout << "Barrier: " << (workload_args.barrier ? "true" : "false") << std::endl;
-        std::cout << "Shared story: " << (workload_args.shared_story ? "true" : "false") << std::endl;
+        if(rank == 0)
+        {
+            std::cout << "No config file specified, using default settings instead:" << std::endl;
+            std::cout << "Interactive mode: " << (workload_args.interactive ? "on" : "off") << std::endl;
+            std::cout << "Chronicle count: " << workload_args.chronicle_count << std::endl;
+            std::cout << "Story count: " << workload_args.story_count << std::endl;
+            std::cout << "Min event size: " << workload_args.min_event_size << std::endl;
+            std::cout << "Ave event size: " << workload_args.ave_event_size << std::endl;
+            std::cout << "Max event size: " << workload_args.max_event_size << std::endl;
+            std::cout << "Event count: " << workload_args.event_count << std::endl;
+            std::cout << "Event interval: " << workload_args.event_interval << std::endl;
+            std::cout << "Barrier: " << (workload_args.barrier ? "true" : "false") << std::endl;
+            std::cout << "Shared story: " << (workload_args.shared_story ? "true" : "false") << std::endl;
+        }
         return {};
     }
 }
@@ -172,7 +191,7 @@ void random_sleep()
     usleep(usec * rank);
 }
 
-void test_create_chronicle(chronolog::Client &client, const std::string &chronicle_name)
+int test_create_chronicle(chronolog::Client &client, const std::string &chronicle_name)
 {
     int ret, flags = 0;
     std::map <std::string, std::string> chronicle_attrs;
@@ -181,6 +200,7 @@ void test_create_chronicle(chronolog::Client &client, const std::string &chronic
     chronicle_attrs.emplace("TieringPolicy", "Hot");
     ret = client.CreateChronicle(chronicle_name, chronicle_attrs, flags);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_CHRONICLE_EXISTS);
+    return ret;
 }
 
 chronolog::StoryHandle*
@@ -199,29 +219,33 @@ test_acquire_story(chronolog::Client &client, const std::string &chronicle_name,
     return acq_ret.second;
 }
 
-void test_write_event(chronolog::StoryHandle*story_handle, const std::string &event_payload)
+int test_write_event(chronolog::StoryHandle*story_handle, const std::string &event_payload)
 {
     int ret = story_handle->log_event(event_payload);
     assert(ret == 1);
+    return ret;
 }
 
-void test_release_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name)
+int test_release_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name)
 {
     random_sleep(); // TODO: (Kun) remove this when the hanging bug upon concurrent acquire is fixed
     int ret = client.ReleaseStory(chronicle_name, story_name);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST);
+    return ret;
 }
 
-void test_destroy_chronicle(chronolog::Client &client, const std::string &chronicle_name)
+int test_destroy_chronicle(chronolog::Client &client, const std::string &chronicle_name)
 {
     int ret = client.DestroyChronicle(chronicle_name);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED);
+    return ret;
 }
 
-void test_destroy_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name)
+int test_destroy_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name)
 {
     int ret = client.DestroyStory(chronicle_name, story_name);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED);
+    return ret;
 }
 
 // function to extract and execute commands from command line input
@@ -282,7 +306,14 @@ uint64_t get_bigbang_timestamp(std::ifstream &file)
 
 int main(int argc, char**argv)
 {
+    std::string argobots_conf_str = R"({"argobots" : {"abt_mem_max_num_stacks" : 8
+                                                    , "abt_thread_stacksize" : 2097152}})";
+    margo_set_environment(argobots_conf_str.c_str());
+
+    int rank, size;
     MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
 
     std::string default_conf_file_path = "./default_conf.json";
     std::pair <std::string, workload_conf_args> cmd_args = cmd_arg_parse(argc, argv);
@@ -308,31 +339,38 @@ int main(int argc, char**argv)
     chronolog::Client client(confManager);
     chronolog::StoryHandle*story_handle;
 
+    TimerWrapper connectTimer(workload_args.perf_test, "Connect");
+    TimerWrapper createChronicleTimer(workload_args.perf_test, "CreateChronicle");
+    TimerWrapper acquireStoryTimer(workload_args.perf_test, "AcquireStory");
+    TimerWrapper writeEventTimer(workload_args.perf_test, "WriteEvent");
+    TimerWrapper releaseStoryTimer(workload_args.perf_test, "ReleaseStory");
+    TimerWrapper destroyStoryTimer(workload_args.perf_test, "DestroyStory");
+    TimerWrapper destroyChronicleTimer(workload_args.perf_test, "DestroyChronicle");
+    TimerWrapper disconnectTimer(workload_args.perf_test, "Disconnect");
+
     int ret;
-    uint64_t total_event_payload_size = 0;
+    uint64_t event_payload_size_per_rank = 0;
 
     std::string client_id = gen_random(8);
-    std::cout << "Generated client id: " << client_id << std::endl;
+//    std::cout << "Generated client id: " << client_id << std::endl;
 
     std::string server_ip = confManager.CLIENT_CONF.VISOR_CLIENT_PORTAL_SERVICE_CONF.RPC_CONF.IP;
-    int base_port = confManager.CLIENT_CONF.VISOR_CLIENT_PORTAL_SERVICE_CONF.RPC_CONF.BASE_PORT;
     std::string server_uri = confManager.CLIENT_CONF.VISOR_CLIENT_PORTAL_SERVICE_CONF.RPC_CONF.PROTO_CONF;
-    server_uri += "://" + server_ip + ":" + std::to_string(base_port);
 
     std::string username = getpwuid(getuid())->pw_name;
-    ret = client.Connect();
+    ret = connectTimer.timeBlock(&chronolog::Client::Connect, client);
     assert(ret == chronolog::CL_SUCCESS);
 
-    std::cout << " connected to server address : " << server_uri << std::endl;
+//    std::cout << "Connected to server address: " << server_uri << std::endl;
+    std::string payload_str(MAX_EVENT_SIZE, 'a');
 
-    std::chrono::steady_clock::time_point t1, t2;
-    t1 = std::chrono::steady_clock::now();
+    double local_e2e_start = MPI_Wtime();
     if(workload_args.interactive)
     {
+        // Interactive mode, accept commands from stdin
         std::cout << "Metadata operations: \n" << "\t-c <chronicle_name> , create a Chronicle <chronicle_name>\n"
                   << "\t-a -s <chronicle_name> <story_name>, acquire Story <story_name> in Chronicle <chronicle_name>\n"
                   << "\t-w <event_string>, write Event with <event_string> as payload\n"
-                  //                  << "\t-r <event_id>, read Event <event_id>"
                   << "\t-q -s <chronicle_name> <story_name>, release Story <story_name> in Chronicle <chronicle_name>\n"
                   << "\t-d -s <chronicle_name> <story_name>, destroy Story <story_name> in Chronicle <chronicle_name>\n"
                   << "\t-d -c <chronicle_name>, destroy Chronicle <chronicle_name>\n" << "\t-disconnect\n" << std::endl;
@@ -402,14 +440,13 @@ std::vector <std::string> &command_subs)
     }
     else
     {
-        int rank;
-        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
+        // Non-interactive mode, execute workload via command line arguments
         std::random_device rand_device;
         std::mt19937 gen(rand_device());
         std::uniform_int_distribution char_dist(0, 255);
         double sigma = (double)(workload_args.max_event_size - workload_args.min_event_size) / 6;
         std::normal_distribution <double> size_dist((double)workload_args.ave_event_size, sigma);
+        MPI_Barrier(MPI_COMM_WORLD);
         for(uint64_t i = 0; i < workload_args.chronicle_count; i++)
         {
             // create chronicle test
@@ -418,7 +455,7 @@ std::vector <std::string> &command_subs)
                 chronicle_name = "chronicle_" + std::to_string(i);
             else
                 chronicle_name = "chronicle_" + std::to_string(rank) + "_" + std::to_string(i);
-            test_create_chronicle(client, chronicle_name);
+            ret = createChronicleTimer.timeBlock(test_create_chronicle, client, chronicle_name);
             if(workload_args.barrier)
                 MPI_Barrier(MPI_COMM_WORLD);
 
@@ -431,106 +468,194 @@ std::vector <std::string> &command_subs)
                     story_name = "story_" + std::to_string(j);
                 else
                     story_name = "story_" + std::to_string(rank) + "_" + std::to_string(j);
-                story_handle = test_acquire_story(client, chronicle_name, story_name);
+                story_handle = acquireStoryTimer.timeBlock(test_acquire_story, client, chronicle_name, story_name);
                 if(workload_args.barrier)
                     MPI_Barrier(MPI_COMM_WORLD);
 
                 // write event test
-                uint64_t event_count_per_story = workload_args.event_count / workload_args.story_count;
-                for(uint64_t k = 0; k < event_count_per_story; k++)
-                {
-                    if(workload_args.event_input_file.empty())
-                    {
-                        // randomly generate events with size in specified range
-                        uint64_t event_size = (unsigned long)std::min(
-                                std::max(size_dist(gen), (double)workload_args.min_event_size * 1.0),
-                                (double)workload_args.max_event_size * 1.0);
-                        total_event_payload_size += event_size;
-                        std::string event_payload;
-                        event_payload.resize(event_size);
-                        for(uint64_t l = 0; l < event_size; l++)
-                            event_payload += std::to_string('a' + std::abs(char_dist(gen)) + 1);
-                        test_write_event(story_handle, event_payload);
-                        if(workload_args.barrier)
-                            MPI_Barrier(MPI_COMM_WORLD);
-
-                        if(workload_args.event_interval > 0)
-                            usleep(workload_args.event_interval);
-                    }
-                    else
-                    {
-                        // read event payload from input file line by line
-                        std::ifstream input_file(workload_args.event_input_file);
-
-                        // check if the file opened successfully
-                        if(input_file.is_open())
-                        {
-                            uint64_t bigbang_timestamp = get_bigbang_timestamp(input_file);
-                            uint64_t last_event_timestamp = bigbang_timestamp;
-                            uint64_t event_timestamp;
-                            std::string event_payload;
-                            struct timespec sleep_ts{};
-                            while(std::getline(input_file, event_payload))
-                            {
-                                event_timestamp = get_event_timestamp(event_payload);
-                                if(event_timestamp < last_event_timestamp)
+                std::string event_payload;
+                writeEventTimer.timeBlock([&]()
                                 {
-                                    LOG_INFO("An Out-of-Order event is found, sleeping for 1 second ...");
-                                    sleep_ts.tv_sec = 1;
-                                    sleep_ts.tv_nsec = 0;
-                                }
-                                else
-                                {
-                                    sleep_ts.tv_sec = (long)(event_timestamp - last_event_timestamp) / 1000000000;
-                                    sleep_ts.tv_nsec = (long)(event_timestamp - last_event_timestamp) % 1000000000;
-                                }
-                                // TODO: (Kun) work around on failure when daytime changes
-                                if(sleep_ts.tv_sec > 3600) sleep_ts.tv_sec = 0;
-                                LOG_DEBUG("Sleeping for {}.{} seconds to emulate interval between events ..."
-                                          , sleep_ts.tv_sec, sleep_ts.tv_nsec);
-                                nanosleep(&sleep_ts, nullptr);
-                                last_event_timestamp = event_timestamp;
-                                total_event_payload_size += event_payload.size();
-                                test_write_event(story_handle, event_payload);
-                                if(workload_args.barrier)
-                                    MPI_Barrier(MPI_COMM_WORLD);
-                            }
+                                    uint64_t event_count_per_story =
+                                            workload_args.event_count / workload_args.story_count;
+                                    for(uint64_t k = 0; k < event_count_per_story; k++)
+                                    {
+                                        if(workload_args.event_input_file.empty())
+                                        {
+                                            // randomly generate events size if range is specified
+                                            writeEventTimer.pauseTimer();
 
-                            input_file.close();
-                        }
-                        else
-                        {
-                            std::cout << "Unable to open the file";
-                        }
-                    }
-                }
+                                            uint64_t event_size;
+                                            if(workload_args.ave_event_size == workload_args.min_event_size &&
+                                               workload_args.ave_event_size == workload_args.max_event_size)
+                                            {
+                                                event_size = workload_args.ave_event_size;
+                                            }
+                                            else
+                                            {
+                                                event_size = (unsigned long)std::min(std::max(size_dist(gen),
+                                                                                             (double)workload_args.min_event_size * 1.0),
+                                                        (double)workload_args.max_event_size * 1.0);
+                                            }
+                                            event_payload = payload_str.substr(0, event_size);
+                                            event_payload_size_per_rank += event_size;
+                                            writeEventTimer.resumeTimer();
+                                            ret = test_write_event(story_handle, event_payload);
+                                            if(workload_args.barrier)
+                                                MPI_Barrier(MPI_COMM_WORLD);
+
+                                            if(workload_args.event_interval > 0)
+                                                usleep(workload_args.event_interval);
+                                        }
+                                        else
+                                        {
+                                            // read event payload from input file line by line
+                                            std::ifstream input_file(workload_args.event_input_file);
+
+                                            // check if the file opened successfully
+                                            if(input_file.is_open())
+                                            {
+                                                writeEventTimer.pauseTimer();
+                                                uint64_t bigbang_timestamp = get_bigbang_timestamp(input_file);
+                                                uint64_t last_event_timestamp = bigbang_timestamp;
+                                                uint64_t event_timestamp;
+                                                struct timespec sleep_ts{};
+                                                while(std::getline(input_file, event_payload))
+                                                {
+                                                    event_timestamp = get_event_timestamp(event_payload);
+                                                    if(event_timestamp < last_event_timestamp)
+                                                    {
+                                                        LOG_INFO(
+                                                                "An Out-of-Order event is found, sleeping for 1 second ...");
+                                                        sleep_ts.tv_sec = 1;
+                                                        sleep_ts.tv_nsec = 0;
+                                                    }
+                                                    else
+                                                    {
+                                                        sleep_ts.tv_sec =
+                                                                (long)(event_timestamp - last_event_timestamp) /
+                                                                1000000000;
+                                                        sleep_ts.tv_nsec =
+                                                                (long)(event_timestamp - last_event_timestamp) %
+                                                                1000000000;
+                                                    }
+                                                    // TODO: (Kun) work around on failure when daytime changes
+                                                    if(sleep_ts.tv_sec > 3600) sleep_ts.tv_sec = 0;
+                                                    LOG_DEBUG(
+                                                            "Sleeping for {}.{} seconds to emulate interval between events ..."
+                                                            , sleep_ts.tv_sec, sleep_ts.tv_nsec);
+                                                    nanosleep(&sleep_ts, nullptr);
+                                                    last_event_timestamp = event_timestamp;
+                                                    event_payload_size_per_rank += event_payload.size();
+                                                    writeEventTimer.resumeTimer();
+                                                    ret = test_write_event(story_handle, event_payload);
+                                                    if(workload_args.barrier)
+                                                        MPI_Barrier(MPI_COMM_WORLD);
+                                                }
+
+                                                input_file.close();
+                                            }
+                                            else
+                                            {
+                                                std::cout << "Unable to open the file";
+                                            }
+                                        }
+                                    }
+                                });
 
                 // release story test
-                test_release_story(client, chronicle_name, story_name);
+                ret = releaseStoryTimer.timeBlock(test_release_story, client, chronicle_name, story_name);
                 if(workload_args.barrier)
                     MPI_Barrier(MPI_COMM_WORLD);
 
                 // destroy story test
-                test_destroy_story(client, chronicle_name, story_name);
+                ret = destroyStoryTimer.timeBlock(test_destroy_story, client, chronicle_name, story_name);
                 if(workload_args.barrier)
                     MPI_Barrier(MPI_COMM_WORLD);
             }
 
             // destroy chronicle test
-            test_destroy_chronicle(client, chronicle_name);
+            ret = destroyChronicleTimer.timeBlock(test_destroy_chronicle, client, chronicle_name);
             if(workload_args.barrier)
                 MPI_Barrier(MPI_COMM_WORLD);
         }
     }
-    t2 = std::chrono::steady_clock::now();
+    double local_e2e_end = MPI_Wtime();
 
-    ret = client.Disconnect();
+    ret = disconnectTimer.timeBlock(&chronolog::Client::Disconnect, client);
     assert(ret == chronolog::CL_SUCCESS);
+    if(workload_args.barrier)
+        MPI_Barrier(MPI_COMM_WORLD);
 
-    std::cout << "Total payload written: " << total_event_payload_size << std::endl;
-    double duration = (double)(t2 - t1).count() / 1.0e9;
-    std::cout << "Time used: " << duration << " seconds" << std::endl;
-    std::cout << "Bandwidth: " << (double)total_event_payload_size / duration / 1e6 << " MB/s" << std::endl;
+    double local_e2e_duration = local_e2e_end - local_e2e_start;
+    double global_e2e_start, global_e2e_end, global_e2e_duration_ave, global_e2e_duration;
+    MPI_Reduce(&local_e2e_start, &global_e2e_start, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&local_e2e_end, &global_e2e_end, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    global_e2e_duration = global_e2e_end - global_e2e_start;
+    MPI_Reduce(&local_e2e_duration, &global_e2e_duration_ave, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+
+    uint64_t total_event_payload_size = 0;
+    MPI_Reduce(&event_payload_size_per_rank, &total_event_payload_size, 1, MPI_UINT64_T, MPI_SUM, 0, MPI_COMM_WORLD);
+    if(rank == 0)
+    {
+        std::cout << "======================================" << std::endl;
+        std::cout << "======== Performance results: ========" << std::endl;
+        std::cout << "======================================" << std::endl;
+        global_e2e_duration_ave /= size;
+        std::cout << "Total payload written: " << total_event_payload_size << std::endl;
+        if(workload_args.barrier)
+        {
+            std::cout << "Connect throughput: " << (double)size / connectTimer.getDuration() << " op/s" << std::endl;
+            std::cout << "CreateChronicle throughput: "
+                      << (double)workload_args.chronicle_count * size / createChronicleTimer.getDuration() << " op/s"
+                      << std::endl;
+            std::cout << "AcquireStory throughput: "
+                      << (double)workload_args.story_count * size / acquireStoryTimer.getDuration() << " op/s"
+                      << std::endl;
+            std::cout << "ReleaseStory throughput: "
+                      << (double)workload_args.story_count * size / releaseStoryTimer.getDuration() << " op/s"
+                      << std::endl;
+            std::cout << "DestroyStory throughput: "
+                      << (double)workload_args.story_count * size / destroyStoryTimer.getDuration() << " op/s"
+                      << std::endl;
+            std::cout << "DestroyChronicle throughput: "
+                      << (double)workload_args.chronicle_count * size / destroyChronicleTimer.getDuration() << " op/s"
+                      << std::endl;
+            std::cout << "Disconnect throughput: " << (double)size / disconnectTimer.getDuration() << " op/s"
+                      << std::endl;
+            std::cout << "End-to-end bandwidth: " << (double)total_event_payload_size / global_e2e_duration / 1e6
+                      << " MB/s" << std::endl;
+            std::cout << "Data access bandwidth: "
+                      << (double)total_event_payload_size / writeEventTimer.getDuration() / 1e6 << " "
+                                                                                                   "MB/s" << std::endl;
+        }
+        else
+        {
+            std::cout << "Connect throughput: " << (double)size / connectTimer.getDurationAve() << " op/s" << std::endl;
+            std::cout << "CreateChronicle throughput: "
+                      << (double)workload_args.chronicle_count * size / createChronicleTimer.getDurationAve() << " op/s"
+                      << std::endl;
+            std::cout << "AcquireStory throughput: "
+                      << (double)workload_args.story_count * size / acquireStoryTimer.getDurationAve() << " op/s"
+                      << std::endl;
+            std::cout << "ReleaseStory throughput: "
+                      << (double)workload_args.story_count * size / releaseStoryTimer.getDurationAve() << " op/s"
+                      << std::endl;
+            std::cout << "DestroyStory throughput: "
+                      << (double)workload_args.story_count * size / destroyStoryTimer.getDurationAve() << " op/s"
+                      << std::endl;
+            std::cout << "DestroyChronicle throughput: "
+                      << (double)workload_args.chronicle_count / destroyChronicleTimer.getDurationAve() << " op/s"
+                      << std::endl;
+            std::cout << "Disconnect throughput: " << (double)size / disconnectTimer.getDurationAve() << " op/s"
+                      << std::endl;
+            std::cout << "End-to-end bandwidth: " << (double)total_event_payload_size / global_e2e_duration_ave / 1e6
+                      << " MB/s" << std::endl;
+            std::cout << "Data access bandwidth: "
+                      << (double)total_event_payload_size / writeEventTimer.getDurationAve() / 1e6 << " MB/s"
+                      << std::endl;
+        }
+    }
 
     MPI_Finalize();
 

--- a/Client/ChronoAdmin/client_admin.cpp
+++ b/Client/ChronoAdmin/client_admin.cpp
@@ -625,7 +625,7 @@ std::vector <std::string> &command_subs)
                       << std::endl;
             std::cout << "End-to-end bandwidth: " << (double)total_event_payload_size / global_e2e_duration / 1e6
                       << " MB/s" << std::endl;
-            std::cout << "Data access bandwidth: "
+            std::cout << "Data-access bandwidth: "
                       << (double)total_event_payload_size / writeEventTimer.getDuration() / 1e6 << " "
                                                                                                    "MB/s" << std::endl;
         }
@@ -651,7 +651,7 @@ std::vector <std::string> &command_subs)
                       << std::endl;
             std::cout << "End-to-end bandwidth: " << (double)total_event_payload_size / global_e2e_duration_ave / 1e6
                       << " MB/s" << std::endl;
-            std::cout << "Data access bandwidth: "
+            std::cout << "Data-access bandwidth: "
                       << (double)total_event_payload_size / writeEventTimer.getDurationAve() / 1e6 << " MB/s"
                       << std::endl;
         }

--- a/Client/synthetic_workload/perf_test.sh
+++ b/Client/synthetic_workload/perf_test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+REP=3
+EVENT_SIZE_MIN=16
+EVENT_SIZE_MAX=1024
+EVENT_SIZE_AVE=512
+EVENT_COUNT=100
+STORY_COUNT=1
+CHRONICLE_COUNT=1
+SHARED_STORY=false
+BARRIER=true
+
+NUM_NODES=1
+NUM_PROCS=2
+BUILD_TYPE=Debug
+CHRONOLOG_INSTALL_DIR=/home/${USER}/chronolog/${BUILD_TYPE}
+CHRONOLOG_BIN_DIR=${CHRONOLOG_INSTALL_DIR}/bin
+CHRONOLOG_LIB_DIR=${CHRONOLOG_INSTALL_DIR}/lib
+HOST_FILE=${CHRONOLOG_INSTALL_DIR}/conf/hosts_client
+CLIENT_ADMIN_BIN=${CHRONOLOG_BIN_DIR}/client_admin
+MPIEXEC_BIN=/home/${USER}/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-11.4.0/mpich-4.0.2-nb7jqr5onqb7g7ynodbtsnqrax5sofyo/bin/mpiexec
+CONF_FILE=/home/${USER}/chronolog/${BUILD_TYPE}/conf/default_conf.json
+OUTPUT_LOG_FILE=./perf_test.log
+
+rm -f ${OUTPUT_LOG_FILE}
+head -${NUM_NODES} ${HOST_FILE} > "${HOST_FILE}.${NUM_NODES}"
+cli_args_args="-a ${EVENT_SIZE_MIN} -b ${EVENT_SIZE_MAX} -s ${EVENT_SIZE_AVE} -n ${EVENT_COUNT} -t ${STORY_COUNT} -h ${CHRONICLE_COUNT} -p"
+[[ "S{SHARED_STORY}" == "true" ]] && cli_args_args+=" -o"
+[[ "${BARRIER}" == "true" ]] && cli_args_args+=" -r"
+for i in $(seq 1 ${REP}); do
+    echo "======================================================================================" >> ${OUTPUT_LOG_FILE}
+    echo "Iteration ${i}" >> ${OUTPUT_LOG_FILE}
+    echo LD_LIBRARY_PATH=${CHRONOLOG_LIB_DIR} ${MPIEXEC_BIN} -n ${NUM_PROCS} -f "${HOST_FILE}.${NUM_NODES}" \
+             "${CLIENT_ADMIN_BIN}" -c "${CONF_FILE}" "${cli_args_args}"
+    LD_LIBRARY_PATH=${CHRONOLOG_LIB_DIR} ${MPIEXEC_BIN} -n ${NUM_PROCS} -f "${HOST_FILE}.${NUM_NODES}" \
+    "${CLIENT_ADMIN_BIN}" -c "${CONF_FILE}" "${cli_args_args}" >> ${OUTPUT_LOG_FILE} 2>&1
+done

--- a/Client/synthetic_workload/perf_test.sh
+++ b/Client/synthetic_workload/perf_test.sh
@@ -1,37 +1,39 @@
 #!/bin/bash
 
 REP=3
-EVENT_SIZE_MIN=16
-EVENT_SIZE_MAX=1024
-EVENT_SIZE_AVE=512
-EVENT_COUNT=100
+EVENT_SIZE_MIN=4096
+EVENT_SIZE_MAX=4096
+EVENT_SIZE_AVE=4096
+EVENT_COUNT=1000
 STORY_COUNT=1
 CHRONICLE_COUNT=1
 SHARED_STORY=false
 BARRIER=true
 
-NUM_NODES=1
-NUM_PROCS=2
-BUILD_TYPE=Debug
+NUM_NODES=4
+NUM_PROCS=4
+BUILD_TYPE=Release
 CHRONOLOG_INSTALL_DIR=/home/${USER}/chronolog/${BUILD_TYPE}
 CHRONOLOG_BIN_DIR=${CHRONOLOG_INSTALL_DIR}/bin
 CHRONOLOG_LIB_DIR=${CHRONOLOG_INSTALL_DIR}/lib
 HOST_FILE=${CHRONOLOG_INSTALL_DIR}/conf/hosts_client
 CLIENT_ADMIN_BIN=${CHRONOLOG_BIN_DIR}/client_admin
-MPIEXEC_BIN=/home/${USER}/spack/opt/spack/linux-ubuntu22.04-zen3/gcc-11.4.0/mpich-4.0.2-nb7jqr5onqb7g7ynodbtsnqrax5sofyo/bin/mpiexec
+MPIEXEC_BIN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../.spack-env/view/bin/mpiexec"
 CONF_FILE=/home/${USER}/chronolog/${BUILD_TYPE}/conf/default_conf.json
 OUTPUT_LOG_FILE=./perf_test.log
 
 rm -f ${OUTPUT_LOG_FILE}
 head -${NUM_NODES} ${HOST_FILE} > "${HOST_FILE}.${NUM_NODES}"
-cli_args_args="-a ${EVENT_SIZE_MIN} -b ${EVENT_SIZE_MAX} -s ${EVENT_SIZE_AVE} -n ${EVENT_COUNT} -t ${STORY_COUNT} -h ${CHRONICLE_COUNT} -p"
-[[ "S{SHARED_STORY}" == "true" ]] && cli_args_args+=" -o"
-[[ "${BARRIER}" == "true" ]] && cli_args_args+=" -r"
-for i in $(seq 1 ${REP}); do
+cli_args="-a ${EVENT_SIZE_MIN} -b ${EVENT_SIZE_MAX} -s ${EVENT_SIZE_AVE} -n ${EVENT_COUNT} -t ${STORY_COUNT} -h ${CHRONICLE_COUNT} -p"
+[[ "S{SHARED_STORY}" == "true" ]] && cli_args+=" -o"
+[[ "${BARRIER}" == "true" ]] && cli_args+=" -r"
+for i in $(seq 1 ${REP})
+do
     echo "======================================================================================" >> ${OUTPUT_LOG_FILE}
     echo "Iteration ${i}" >> ${OUTPUT_LOG_FILE}
     echo LD_LIBRARY_PATH=${CHRONOLOG_LIB_DIR} ${MPIEXEC_BIN} -n ${NUM_PROCS} -f "${HOST_FILE}.${NUM_NODES}" \
-             "${CLIENT_ADMIN_BIN}" -c "${CONF_FILE}" "${cli_args_args}"
+        "${CLIENT_ADMIN_BIN}" -c "${CONF_FILE}" ${cli_args}
     LD_LIBRARY_PATH=${CHRONOLOG_LIB_DIR} ${MPIEXEC_BIN} -n ${NUM_PROCS} -f "${HOST_FILE}.${NUM_NODES}" \
-    "${CLIENT_ADMIN_BIN}" -c "${CONF_FILE}" "${cli_args_args}" >> ${OUTPUT_LOG_FILE} 2>&1
+        "${CLIENT_ADMIN_BIN}" -c "${CONF_FILE}" ${cli_args} >>${OUTPUT_LOG_FILE} 2>&1
 done
+

--- a/chrono_common/TimerWrapper.h
+++ b/chrono_common/TimerWrapper.h
@@ -1,0 +1,188 @@
+//
+// Created by kfeng on 10/7/24.
+//
+
+#ifndef CHRONOLOG_TIMERWRAPPER_H
+#define CHRONOLOG_TIMERWRAPPER_H
+
+#include <iostream>
+#include <chrono>
+#include <functional>
+#include <mpi.h>
+
+class TimerWrapper
+{
+public:
+    TimerWrapper(bool enable_timing, const std::string &name): name(name), enabled(enable_timing)
+    {
+        int rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        if(rank == 0)
+        {
+//            std::cout << "Resolution of timer " << name << ": " << MPI_Wtick() << " second.\n";
+            int global_time_flag;
+            int flag;
+            MPI_Attr_get(MPI_COMM_SELF, MPI_WTIME_IS_GLOBAL, &global_time_flag, &flag);
+            if(flag)
+            {
+                // If the attribute exists, print its value
+                if(!global_time_flag)
+                {
+                    std::cerr << "MPI_Wtime clocks are NOT synchronized across all processes for timer " << name <<
+                    std::endl;
+                }
+            }
+            else
+            {
+                std::cerr << "MPI_WTIME_IS_GLOBAL is not available in this MPI implementation for timer " << name <<
+                std::endl;
+            }
+        }
+    }
+
+    // Timing wrapper for functions that return non-void
+    template <typename Func, typename... Args, typename RetType = decltype(std::invoke(std::declval <Func>()
+                                                                                       , std::declval <Args>()...)), typename std::enable_if <!std::is_void <RetType>::value, int>::type = 0>
+    auto timeBlock(Func &&func, Args &&... args) -> RetType
+    {
+        if(enabled)
+        {
+            int rank, size;
+            MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+            MPI_Comm_size(MPI_COMM_WORLD, &size);
+            double local_start_time = MPI_Wtime();
+            auto result = std::invoke(std::forward <Func>(func), std::forward <Args>(
+                    args)...);  // Call function or block
+            double local_end_time = MPI_Wtime();
+            double local_elapsed = local_end_time - local_start_time;
+            double global_start_time, global_end_time;
+            MPI_Reduce(&local_start_time, &global_start_time, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+            MPI_Reduce(&local_end_time, &global_end_time, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+            double elapsed_max, elapsed_min, elapsed_ave;
+            MPI_Reduce(&local_elapsed, &elapsed_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+            MPI_Reduce(&local_elapsed, &elapsed_min, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+            MPI_Reduce(&local_elapsed, &elapsed_ave, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+            double global_elapsed = global_end_time - global_start_time;
+            if(rank == 0)
+            {
+                e2e_duration += global_elapsed;
+                duration_min += elapsed_min;
+                duration_ave += elapsed_ave;
+                duration_max += elapsed_max;
+            }
+            return result;  // Return the result of the function or block
+        }
+        else
+        {
+            return std::invoke(std::forward <Func>(func), std::forward <Args>(args)...);  // Call without timing
+        }
+    }
+
+    // Timing wrapper for functions that return void
+    template <typename Func, typename... Args, typename RetType = decltype(std::invoke(std::declval <Func>()
+                                                                                       , std::declval <Args>()...)), typename std::enable_if <std::is_void <RetType>::value, int>::type = 0>
+    void timeBlock(Func &&func, Args &&... args)
+    {
+        if(enabled)
+        {
+            int rank, size;
+            MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+            MPI_Comm_size(MPI_COMM_WORLD, &size);
+            double local_start_time = MPI_Wtime();
+            std::invoke(std::forward <Func>(func), std::forward <Args>(args)...);  // Call function or block
+            double local_end_time = MPI_Wtime();
+            double local_elapsed = local_end_time - local_start_time;
+            double global_start_time, global_end_time;
+            MPI_Reduce(&local_start_time, &global_start_time, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+            MPI_Reduce(&local_end_time, &global_end_time, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+            double elapsed_max, elapsed_min, elapsed_ave;
+            MPI_Reduce(&local_elapsed, &elapsed_max, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+            MPI_Reduce(&local_elapsed, &elapsed_min, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+            MPI_Reduce(&local_elapsed, &elapsed_ave, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+            double global_elapsed = global_end_time - global_start_time;
+            if(rank == 0)
+            {
+                e2e_duration += global_elapsed;
+                duration_max += elapsed_max;
+                duration_min += elapsed_min;
+                duration_ave += elapsed_ave;
+            }
+        }
+        else
+        {
+            std::invoke(std::forward <Func>(func), std::forward <Args>(args)...);  // Call without timing
+        }
+    }
+
+    // Pause timer
+    void pauseTimer()
+    {
+        pause_time = MPI_Wtime();
+    }
+
+    // Resume timer
+    void resumeTimer()
+    {
+        double pause_end_time = MPI_Wtime();
+        double pause_duration = pause_end_time - pause_time;
+        e2e_duration -= pause_duration;
+    }
+
+    // Reset timer
+    void resetTimer()
+    {
+        e2e_duration = 0;
+        duration_max = 0;
+        duration_min = 0;
+        duration_ave = 0;
+    }
+
+    // End timer
+    void report()
+    {
+        int rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        if(rank == 0)
+        {
+            std::cout << "Wall time in " << name << ": " << e2e_duration << " s.\n";
+            std::cout << "Min of local time in " << name << ": " << duration_min << " s.\n";
+            std::cout << "Ave of local time in " << name << ": " << duration_ave << " s.\n";
+            std::cout << "Max of local time in " << name << ": " << duration_max << " s.\n";
+        }
+    }
+
+    // Get end-to-end duration of last call
+    [[nodiscard]] double getDuration() const
+    {
+        return e2e_duration;
+    }
+
+    // Get max duration of last call
+    [[nodiscard]] double getDurationMax() const
+    {
+        return duration_max;
+    }
+
+    // Get min duration of last call
+    [[nodiscard]] double getDurationMin() const
+    {
+        return duration_min;
+    }
+
+    // Get ave duration of last call
+    [[nodiscard]] double getDurationAve() const
+    {
+        return duration_ave;
+    }
+
+private:
+    std::string name;  // Name of the timer
+    bool enabled;  // Flag to enable or disable timing
+    double e2e_duration;  // End-to-end duration of last call
+    double duration_min;  // Min duration of last call
+    double duration_ave;  // Ave duration of last call
+    double duration_max;  // Max duration of last call
+    double pause_time;  // Time of pause
+};
+
+#endif //CHRONOLOG_TIMERWRAPPER_H


### PR DESCRIPTION
Changes:

- Update Keeper-Grapher extraction to pass serialized StoryChunk size to get rid of fixed size limit
- Update `client_admin` to support performance test argument option `-p`
- Add MPI-based `TimerWrapper` to enable easy time measurement
- Add `perf_test.sh` to generate performance metrics