### PR TITLE
Integrate HDF5 archiver to extract StoryChunks

### DIFF
--- a/ChronoGrapher/CMakeLists.txt
+++ b/ChronoGrapher/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 find_package(Thallium REQUIRED)
 find_package(spdlog REQUIRED)
+find_package(HDF5 REQUIRED COMPONENTS C CXX)
 
 #message("Chronographer CMakeLists - CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
 #message("Chronographer CMakeLists - CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
@@ -20,10 +21,13 @@ target_sources(chrono_grapher PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/GrapherDataStore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/StoryChunkExtractor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CSVFileChunkExtractor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/HDF5FileChunkExtractor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/StoryChunkWriter.cpp
     ${CMAKE_SOURCE_DIR}/chrono_common/StoryChunk.cpp
     ${CMAKE_SOURCE_DIR}/ChronoAPI/ChronoLog/src/chrono_monitor.cpp)
 
 target_link_libraries(chrono_grapher chronolog_client thallium)
+target_link_libraries(chrono_grapher ${HDF5_LIBRARIES})
 
 set_target_properties(chrono_grapher PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 

--- a/ChronoGrapher/ChronoGrapher.cpp
+++ b/ChronoGrapher/ChronoGrapher.cpp
@@ -14,6 +14,7 @@
 #include "DataStoreAdminService.h"
 #include "ConfigurationManager.h"
 #include "CSVFileChunkExtractor.h"
+#include "HDF5FileChunkExtractor.h"
 #include "cmd_arg_parse.h"
 
 // we will be using a combination of the uint32_t representation of the service IP address
@@ -136,7 +137,8 @@ int main(int argc, char**argv)
     chronolog::ChunkIngestionQueue ingestionQueue;
     std::string csv_files_directory = confManager.GRAPHER_CONF.EXTRACTOR_CONF.story_files_dir;
 
-    chronolog::CSVFileStoryChunkExtractor storyExtractor(process_id_string.str(), csv_files_directory);
+//    chronolog::CSVFileStoryChunkExtractor storyExtractor(process_id_string.str(), csv_files_directory);
+    chronolog::HDF5FileChunkExtractor storyExtractor(process_id_string.str(), csv_files_directory);
     chronolog::GrapherDataStore theDataStore(ingestionQueue, storyExtractor.getExtractionQueue());
 
     chronolog::ServiceId collectionServiceId(datastore_endpoint.first, datastore_endpoint.second

--- a/ChronoGrapher/HDF5FileChunkExtractor.cpp
+++ b/ChronoGrapher/HDF5FileChunkExtractor.cpp
@@ -1,4 +1,5 @@
 #include "HDF5FileChunkExtractor.h"
+#include "StoryChunkWriter.h"
 
 namespace tl = thallium;
 

--- a/ChronoGrapher/HDF5FileChunkExtractor.cpp
+++ b/ChronoGrapher/HDF5FileChunkExtractor.cpp
@@ -1,0 +1,35 @@
+#include "HDF5FileChunkExtractor.h"
+
+namespace tl = thallium;
+
+namespace chronolog
+{
+HDF5FileChunkExtractor::HDF5FileChunkExtractor(const std::string &chrono_process_id_card
+                                               , const std::string &hdf5_files_root_dir)
+                                               : chrono_process_id(chrono_process_id_card)
+                                               , rootDirectory(hdf5_files_root_dir)
+{}
+
+HDF5FileChunkExtractor::~HDF5FileChunkExtractor()
+{
+    LOG_INFO("[HDF5FileChunkExtractor] Destructor called. Cleaning up...");
+}
+
+int HDF5FileChunkExtractor::processStoryChunk(StoryChunk *story_chunk)
+{
+    LOG_INFO("[HDF5FileChunkExtractor] Writing StoryChunk...");
+    StoryChunkWriter chunkWriter(rootDirectory, "story_chunks", "data");
+    hsize_t size = chunkWriter.writeStoryChunk(*story_chunk);
+    int ret = (size == 0) ? CL_ERR_UNKNOWN : CL_SUCCESS;
+    if(size == 0)
+    {
+        LOG_ERROR("[HDF5FileChunkExtractor] Error writing StoryChunk to file.");
+    }
+    else
+    {
+        LOG_INFO("[HDF5FileChunkExtractor] StoryChunk written to file.");
+    }
+    LOG_DEBUG("[HDF5FileChunkExtractor] Finished processing StoryChunk.");
+    return ret;
+}
+} // chronolog

--- a/ChronoGrapher/HDF5FileChunkExtractor.h
+++ b/ChronoGrapher/HDF5FileChunkExtractor.h
@@ -1,9 +1,7 @@
 #ifndef CHRONOLOG_HDF5_FILE_CHUNK_EXTRACTOR_H
 #define CHRONOLOG_HDF5_FILE_CHUNK_EXTRACTOR_H
 
-#include "chronolog_types.h"
 #include "StoryChunkExtractor.h"
-#include "StoryChunkWriter.h"
 
 namespace chronolog
 {

--- a/ChronoGrapher/HDF5FileChunkExtractor.h
+++ b/ChronoGrapher/HDF5FileChunkExtractor.h
@@ -1,0 +1,27 @@
+#ifndef CHRONOLOG_HDF5_FILE_CHUNK_EXTRACTOR_H
+#define CHRONOLOG_HDF5_FILE_CHUNK_EXTRACTOR_H
+
+#include "chronolog_types.h"
+#include "StoryChunkExtractor.h"
+#include "StoryChunkWriter.h"
+
+namespace chronolog
+{
+
+class HDF5FileChunkExtractor: public StoryChunkExtractorBase
+{
+public:
+    HDF5FileChunkExtractor(std::string const &chrono_process_id_card, std::string const &hdf5_files_root_dir);
+
+    ~HDF5FileChunkExtractor();
+
+    virtual int processStoryChunk(StoryChunk *);
+
+private:
+    std::string chrono_process_id;
+    std::string rootDirectory;
+};
+
+} // chronolog
+
+#endif //CHRONOLOG_HDF5_FILE_CHUNK_EXTRACTOR_H

--- a/ChronoGrapher/StoryChunkWriter.cpp
+++ b/ChronoGrapher/StoryChunkWriter.cpp
@@ -1,0 +1,163 @@
+#include "StoryChunkWriter.h"
+
+namespace chronolog
+{
+hsize_t StoryChunkWriter::writeStoryChunk(StoryChunkHVL &story_chunk)
+{
+    std::vector <LogEventHVL> data;
+    data.reserve(story_chunk.getEventCount());
+    for(const auto &start: story_chunk)
+    {
+        data.push_back(start.second);
+    }
+    std::string file_name = rootDirectory + story_chunk.getChronicleName() + "." + story_chunk.getStoryName() + "." +
+                            std::to_string(story_chunk.getStartTime() / 1000000000) + ".vlen.h5";
+    hsize_t ret = 0;
+    try
+    {
+        LOG_DEBUG("[StoryChunkWriter] Creating StoryChunk file: {}", file_name);
+        auto *file = new H5::H5File(file_name, H5F_ACC_TRUNC);
+        sleep(1);
+        LOG_DEBUG("[StoryChunkWriter] Writing StoryChunk to file...");
+        ret = writeEvents(file, data);
+        if(ret == 0)
+        {
+            LOG_ERROR("[StoryChunkWriter] Error writing StoryChunk to file.");
+            return ret;
+        }
+        file->flush(H5F_SCOPE_GLOBAL);
+        hsize_t file_size = file->getFileSize();
+        LOG_DEBUG("[StoryChunkWriter] Closing StoryChunk file, size: {}", file_size);
+        delete file;
+        LOG_DEBUG("[StoryChunkWriter] Finished writing StoryChunk to file.");
+        return file_size;
+    }
+    catch(H5::FileIException &error)
+    {
+        LOG_ERROR("[StoryChunkWriter] FileIException: {}", error.getCDetailMsg());
+        H5::FileIException::printErrorStack();
+    }
+    return ret;
+}
+
+hsize_t StoryChunkWriter::writeStoryChunk(StoryChunk &story_chunk)
+{
+    std::vector <LogEventHVL> data;
+    data.reserve(story_chunk.getEventCount());
+    for(const auto &event: story_chunk)
+    {
+        LogEventHVL event_hvl;
+        event_hvl.storyId = event.second.getStoryId();
+        event_hvl.eventTime = event.second.time();
+        event_hvl.clientId = event.second.getClientId();
+        event_hvl.eventIndex = event.second.index();
+        event_hvl.logRecord.len = event.second.logRecord.size();
+        event_hvl.logRecord.p = new uint8_t[event_hvl.logRecord.len];
+        std::memcpy(event_hvl.logRecord.p, event.second.logRecord.data(), event_hvl.logRecord.len);
+        data.push_back(event_hvl);
+    }
+    std::string file_name = rootDirectory + "/" + story_chunk.getChronicleName() + "." + story_chunk.getStoryName() + "." +
+                            std::to_string(story_chunk.getStartTime() / 1000000000) + ".vlen.h5";
+    hsize_t ret = 0;
+    try
+    {
+        LOG_DEBUG("[StoryChunkWriter] Creating StoryChunk file: {}", file_name);
+        auto *file = new H5::H5File(file_name, H5F_ACC_TRUNC);
+
+        LOG_DEBUG("[StoryChunkWriter] Writing StoryChunk to file...");
+        ret = writeEvents(file, data);
+        if(ret == 0)
+        {
+            LOG_ERROR("[StoryChunkWriter] Error writing StoryChunk to file.");
+            return ret;
+        }
+
+        file->flush(H5F_SCOPE_GLOBAL);
+        hsize_t file_size = file->getFileSize();
+
+        LOG_DEBUG("[StoryChunkWriter] Closing StoryChunk file, size: {}", file_size);
+        delete file;
+
+        LOG_DEBUG("[StoryChunkWriter] Finished writing StoryChunk to file.");
+        ret = file_size;
+    }
+    catch(H5::FileIException &error)
+    {
+        LOG_ERROR("[StoryChunkWriter] FileIException: {}", error.getCDetailMsg());
+        H5::FileIException::printErrorStack();
+    }
+    for(auto &event: data)
+    {
+        delete[] static_cast<uint8_t *>(event.logRecord.p);
+        event.logRecord.p = nullptr;
+    }
+    return ret;
+}
+
+hsize_t StoryChunkWriter::writeEvents(H5::H5File *file, std::vector <LogEventHVL> &data)
+{
+    int ret = 0;
+    try
+    {
+        /*
+         * Create a group in the file
+        */
+        LOG_DEBUG("[StoryChunkWriter] Creating group: {}", groupName);
+        auto *group = new H5::Group(file->createGroup(groupName));
+
+        hsize_t dim_size = data.size();
+        LOG_DEBUG("[StoryChunkWriter] Creating dataspace with size: {}", dim_size);
+        auto *dataspace = new H5::DataSpace(numDims, &dim_size);
+
+        // target dtype for the file
+        LOG_DEBUG("[StoryChunkWriter] Creating data type for events...");
+        H5::CompType data_type = createEventCompoundType();
+
+        LOG_DEBUG("[StoryChunkWriter] Creating dataset: {}", dsetName);
+        auto *dataset = new H5::DataSet(
+                file->createDataSet("/" + groupName + "/" + dsetName + ".vlen_bytes", data_type, *dataspace));
+
+        LOG_DEBUG("[StoryChunkWriter] Writing data to dataset...");
+        dataset->write(&data.front(), data_type);
+
+        delete dataset;
+        delete dataspace;
+        delete group;
+
+        return data.size();
+    }
+    catch(H5::FileIException &error)
+    {
+        LOG_ERROR("[StoryChunkWriter] FileIException: {}", error.getCDetailMsg());
+        H5::FileIException::printErrorStack();
+    }
+    catch(H5::DataSetIException &error)
+    {
+        LOG_ERROR("[StoryChunkWriter] DataSetIException: {}", error.getCDetailMsg());
+        H5::DataSetIException::printErrorStack();
+    }
+    catch(H5::DataSpaceIException &error)
+    {
+        LOG_ERROR("[StoryChunkWriter] DataSpaceIException: {}", error.getCDetailMsg());
+        H5::DataSpaceIException::printErrorStack();
+    }
+    catch(H5::DataTypeIException &error)
+    {
+        LOG_ERROR("[StoryChunkWriter] DataTypeIException: {}", error.getCDetailMsg());
+        H5::DataTypeIException::printErrorStack();
+    }
+    return ret;
+}
+
+H5::CompType StoryChunkWriter::createEventCompoundType()
+{
+    H5::CompType data_type(sizeof(LogEventHVL));
+    data_type.insertMember("storyId", HOFFSET(LogEventHVL, storyId), H5::PredType::NATIVE_UINT64);
+    data_type.insertMember("eventTime", HOFFSET(LogEventHVL, eventTime), H5::PredType::NATIVE_UINT64);
+    data_type.insertMember("clientId", HOFFSET(LogEventHVL, clientId), H5::PredType::NATIVE_UINT32);
+    data_type.insertMember("eventIndex", HOFFSET(LogEventHVL, eventIndex), H5::PredType::NATIVE_UINT32);
+    data_type.insertMember("logRecord", HOFFSET(LogEventHVL, logRecord), H5::VarLenType(H5::PredType::NATIVE_UINT8));
+    return data_type;
+}
+
+}

--- a/ChronoGrapher/StoryChunkWriter.h
+++ b/ChronoGrapher/StoryChunkWriter.h
@@ -2,6 +2,7 @@
 #define CHRONOLOG_STORY_CHUNK_WRITER_H
 
 #include <string>
+#include <memory>
 #include <H5Cpp.h>
 #include "chrono_monitor.h"
 #include "StoryChunk.h"
@@ -24,7 +25,7 @@ public:
 
     hsize_t writeStoryChunk(StoryChunk &story_chunk);
 
-    hsize_t writeEvents(H5::H5File *file, std::vector <LogEventHVL> &data);
+    hsize_t writeEvents(std::unique_ptr<H5::H5File> &file, std::vector <LogEventHVL> &data);
 
     H5::CompType createEventCompoundType();
 

--- a/ChronoGrapher/StoryChunkWriter.h
+++ b/ChronoGrapher/StoryChunkWriter.h
@@ -1,0 +1,39 @@
+#ifndef CHRONOLOG_STORY_CHUNK_WRITER_H
+#define CHRONOLOG_STORY_CHUNK_WRITER_H
+
+#include <string>
+#include <H5Cpp.h>
+#include "chrono_monitor.h"
+#include "StoryChunk.h"
+
+namespace chronolog
+{
+class StoryChunkWriter
+{
+public:
+    StoryChunkWriter(std::string const &root_dir, std::string const &group_name, std::string const &dset_name)
+            : rootDirectory(root_dir), groupName(group_name), dsetName(dset_name), numDims(1)
+    {};
+
+    ~StoryChunkWriter()
+    {
+        LOG_INFO("[StoryChunkWriter] Destructor called. Cleaning up...");
+    }
+
+    hsize_t writeStoryChunk(StoryChunkHVL &story_chunk);
+
+    hsize_t writeStoryChunk(StoryChunk &story_chunk);
+
+    hsize_t writeEvents(H5::H5File *file, std::vector <LogEventHVL> &data);
+
+    H5::CompType createEventCompoundType();
+
+private:
+    std::string rootDirectory;
+    std::string groupName;
+    std::string dsetName;
+    int numDims;
+};
+} // chronolog
+
+#endif //CHRONOLOG_STORY_CHUNK_WRITER_H

--- a/chrono_common/StoryChunk.h
+++ b/chrono_common/StoryChunk.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <iostream>
+#include <sstream>
 #include <thallium/serialization/stl/string.hpp>
 #include <thallium/serialization/stl/map.hpp>
 #include <thallium/serialization/stl/tuple.hpp>
@@ -23,6 +24,8 @@ typedef uint32_t chrono_index;
 typedef std::tuple <chrono_time, chrono_index> ArrivalSequence;
 
 typedef std::tuple <chrono_time, ClientId, chrono_index> EventSequence;
+
+typedef std::tuple <uint64_t, uint64_t> EventOffsetSize;
 
 class StoryChunk
 {
@@ -113,5 +116,124 @@ private:
     uint64_t revisionTime;
     std::map <EventSequence, LogEvent> logEvents;
 };
+
+class StoryChunkHVL
+{
+public:
+    explicit StoryChunkHVL(ChronicleName const &chronicle_name = "", StoryName const &story_name = ""
+                           , StoryId const &story_id = 0, uint64_t start_time = 0
+                           , uint64_t end_time = 0, uint32_t chunk_size = 0)
+            : chronicleName(chronicle_name), storyName(story_name)
+              , storyId(story_id)
+              , startTime(start_time), endTime(end_time), revisionTime(end_time)
+    {}
+
+    ~StoryChunkHVL() = default;
+
+    ChronicleName const &getChronicleName() const
+    { return chronicleName; }
+
+    StoryName const &getStoryName() const
+    { return storyName; }
+
+    [[nodiscard]] StoryId const &getStoryId() const
+    { return storyId; }
+
+    [[nodiscard]] uint64_t getStartTime() const
+    { return startTime; }
+
+    [[nodiscard]] uint64_t getEndTime() const
+    { return endTime; }
+
+    [[nodiscard]] bool empty() const
+    { return logEvents.empty(); }
+
+    [[nodiscard]] size_t getEventCount() const
+    { return logEvents.size(); }
+
+    [[nodiscard]] size_t getTotalPayloadSize() const
+    {
+        size_t total_size = 0;
+        for(auto const &event: logEvents)
+        { total_size += event.second.logRecord.len; }
+        return total_size;
+    }
+
+    [[nodiscard]] std::map <EventSequence, LogEventHVL>::const_iterator begin() const
+    { return logEvents.begin(); }
+
+    [[nodiscard]] std::map <EventSequence, LogEventHVL>::const_iterator end() const
+    { return logEvents.end(); }
+
+    [[nodiscard]] std::map <EventSequence, LogEventHVL>::const_iterator lower_bound(uint64_t chrono_time) const
+    { return logEvents.lower_bound(EventSequence{chrono_time, 0, 0}); }
+
+    [[nodiscard]] uint64_t firstEventTime() const
+    { return (*logEvents.begin()).second.time(); }
+
+    int insertEvent(LogEventHVL const &event)
+    {
+        if((event.time() >= startTime) && (event.time() < endTime))
+        {
+            logEvents.insert(std::pair <EventSequence, LogEventHVL>({event.time(), event.clientId, event.index()},
+                                                                  event));
+            return 1;
+        }
+        else
+        { return 0; }
+    }
+
+    bool operator==(const StoryChunkHVL &other) const
+    {
+        return ((storyId == other.storyId) && (startTime == other.startTime) && (endTime == other.endTime) &&
+                (revisionTime == other.revisionTime) && (logEvents == other.logEvents));
+    }
+
+    bool operator!=(const StoryChunkHVL &other) const
+    {
+        return !(*this == other);
+    }
+
+    [[nodiscard]] std::string toString() const
+    {
+        std::stringstream ss;
+        ss << "StoryChunk:{" << storyId << ":" << startTime << ":" << endTime << "} has " << logEvents.size()
+           << " events: ";
+        for(auto const &event: logEvents)
+        {
+            ss << "<" << std::get <0>(event.first) << ", " << std::get <1>(event.first) << ", "
+               << std::get <2>(event.first) << ">: " << event.second.toString();
+        }
+//        LOG_DEBUG("string size in StoryChunk::toString(): {}", ss.str().size());
+        return ss.str();
+    }
+
+    std::string chronicleName;
+    StoryName storyName;
+    StoryId storyId;
+    uint64_t startTime;
+    uint64_t endTime;
+    uint64_t revisionTime;
+
+    std::map <EventSequence, LogEventHVL> logEvents;
+
+};
+
+struct OffsetMapEntry
+{
+    EventSequence eventId;
+    EventOffsetSize offsetSize;
+
+    OffsetMapEntry()
+    {
+        eventId = EventSequence(0, 0, 0);
+        offsetSize = EventOffsetSize(0, 0);
+    }
+
+    OffsetMapEntry(EventSequence eventId, EventOffsetSize offsetSize): eventId(
+            std::move(eventId)), offsetSize(std::move(offsetSize))
+    {}
+};
+
 }
 #endif

--- a/chrono_common/chronolog_types.h
+++ b/chrono_common/chronolog_types.h
@@ -4,6 +4,8 @@
 
 #include <string>
 #include <ostream>
+#include <cstring>
+#include "H5Cpp.h"
 
 namespace chronolog
 {
@@ -68,6 +70,123 @@ public:
                           " ClientId: " + std::to_string(clientId) + " EventIndex: " + std::to_string(eventIndex) +
                           " LogRecord: " + logRecord;
         return str;
+    }
+};
+
+class LogEventHVL
+{
+public:
+    uint64_t storyId;
+    uint64_t eventTime{};
+    uint32_t clientId{};
+    uint32_t eventIndex{};
+    hvl_t logRecord{};
+
+    LogEventHVL(): storyId(0), eventTime(0), clientId(0), eventIndex(0)
+    {
+        logRecord.len = 0;
+        logRecord.p = nullptr;
+    };
+
+    LogEventHVL(uint64_t story_id, uint64_t event_time, uint32_t client_id, uint32_t event_index, hvl_t log_record)
+            : storyId(story_id), eventTime(event_time), clientId(client_id), eventIndex(event_index)
+    {
+        logRecord.len = log_record.len;
+        logRecord.p = new uint8_t[log_record.len];
+        std::memcpy(logRecord.p, log_record.p, log_record.len);
+    };
+
+    ~LogEventHVL() {
+        if (logRecord.p) {
+            delete[] static_cast<uint8_t*>(logRecord.p);
+            logRecord.p = nullptr;
+        }
+    }
+
+    LogEventHVL(const LogEventHVL& other)
+            : storyId(other.storyId), eventTime(other.eventTime), clientId(other.clientId), eventIndex(other.eventIndex) {
+        logRecord.len = other.logRecord.len;
+        logRecord.p = new uint8_t[logRecord.len];
+        std::memcpy(logRecord.p, other.logRecord.p, logRecord.len);
+    }
+
+    [[nodiscard]] uint64_t const &time() const
+    { return eventTime; }
+
+    [[nodiscard]] uint32_t const &index() const
+    { return eventIndex; }
+
+    [[nodiscard]] std::string toString() const
+    {
+        std::string str =
+                "storyId: " + std::to_string(storyId) + "\n" + "eventTime: " + std::to_string(eventTime) + "\n" +
+                "clientId: " + std::to_string(clientId) + "\n" + "eventIndex: " + std::to_string(eventIndex) + "\n";
+        str += "logRecord: ";
+        char*ptr = static_cast<char*>(logRecord.p);
+        for(hsize_t i = 0; i < logRecord.len; i++)
+        {
+            str += *(ptr + i);
+            str += " ";
+        }
+        str += "\n";
+//        LOG_DEBUG("logRecord len: {}", logRecord.len);
+        return str;
+    }
+
+    bool operator==(const LogEventHVL &other) const
+    {
+        if(storyId != other.storyId)
+        {
+            return false;
+        }
+        if(eventTime != other.eventTime)
+        {
+            return false;
+        }
+        if(clientId != other.clientId)
+        {
+            return false;
+        }
+        if(eventIndex != other.eventIndex)
+        {
+            return false;
+        }
+        for(hsize_t i = 0; i < logRecord.len; i++)
+        {
+            if(((uint8_t*)logRecord.p)[i] != ((uint8_t*)other.logRecord.p)[i])
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool operator!=(const LogEventHVL &other) const
+    {
+        return !(*this == other);
+    }
+
+    bool operator<(const LogEventHVL &other) const
+    {
+        return eventTime < other.eventTime;
+    }
+
+    LogEventHVL& operator=(const LogEventHVL& other) {
+        if (this != &other) {
+            storyId = other.storyId;
+            eventTime = other.eventTime;
+            clientId = other.clientId;
+            eventIndex = other.eventIndex;
+
+            if (logRecord.p) {
+                delete[] static_cast<uint8_t*>(logRecord.p);
+            }
+
+            logRecord.len = other.logRecord.len;
+            logRecord.p = new uint8_t[logRecord.len];
+            std::memcpy(logRecord.p, other.logRecord.p, logRecord.len);
+        }
+        return *this;
     }
 };
 

--- a/chrono_common/chronolog_types.h
+++ b/chrono_common/chronolog_types.h
@@ -147,8 +147,16 @@ public:
 
     bool operator<(const LogEventHVL &other) const
     {
-        return std::make_tuple(eventTime, clientId, eventIndex) <
-               std::make_tuple(other.eventTime, other.clientId, other.eventIndex);
+        if (eventTime < other.eventTime) {
+            return true;
+        } else if (eventTime == other.eventTime) {
+            if (clientId < other.clientId) {
+                return true;
+            } else if (clientId == other.clientId) {
+                return eventIndex < other.eventIndex;
+            }
+        }
+        return false;
     }
 
     LogEventHVL& operator=(const LogEventHVL& other) {

--- a/chrono_common/chronolog_types.h
+++ b/chrono_common/chronolog_types.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <ostream>
 #include <cstring>
+#include <tuple>
 #include "H5Cpp.h"
 
 namespace chronolog
@@ -135,30 +136,8 @@ public:
 
     bool operator==(const LogEventHVL &other) const
     {
-        if(storyId != other.storyId)
-        {
-            return false;
-        }
-        if(eventTime != other.eventTime)
-        {
-            return false;
-        }
-        if(clientId != other.clientId)
-        {
-            return false;
-        }
-        if(eventIndex != other.eventIndex)
-        {
-            return false;
-        }
-        for(hsize_t i = 0; i < logRecord.len; i++)
-        {
-            if(((uint8_t*)logRecord.p)[i] != ((uint8_t*)other.logRecord.p)[i])
-            {
-                return false;
-            }
-        }
-        return true;
+        return storyId == other.storyId && eventTime == other.eventTime && clientId == other.clientId &&
+               eventIndex == other.eventIndex;
     }
 
     bool operator!=(const LogEventHVL &other) const
@@ -168,7 +147,8 @@ public:
 
     bool operator<(const LogEventHVL &other) const
     {
-        return eventTime < other.eventTime;
+        return std::make_tuple(eventTime, clientId, eventIndex) <
+               std::make_tuple(other.eventTime, other.clientId, other.eventIndex);
     }
 
     LogEventHVL& operator=(const LogEventHVL& other) {

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,6 @@ spack:
     - mochi-thallium@0.10.1 ^libfabric@1.16.1 fabrics=mlx,rxd,rxm,shm,sockets,tcp,udp,verbs
     - mochi-margo@0.13 ^libfabric@1.16.1 fabrics=mlx,rxd,rxm,shm,sockets,tcp,udp,verbs
     - mercury@2.2.0~boostsys ^libfabric@1.16.1 fabrics=mlx,rxd,rxm,shm,sockets,tcp,udp,verbs
-    - hdf5@1.14.1-2 +cxx
+    - hdf5@1.14.1-2 +cxx +threadsafe
     - py-pybind11@2.11.1
   view: true


### PR DESCRIPTION
**Summary:**
Integrate HDF5 archiver to the existing data pipeline in Grapher following most of the design in https://docs.google.com/drawings/d/1N2x9mtqL9y2m-ns5EH3mH4boPEaHiz-GzaV7nPRV2hQ/edit. Please notice the highlighted new StoryChunk and LogEvent definitions.

**Changes:**
- Archive StoryChunks in HDF5 files using HDF5 vlen data type. In order to do this, two new versions of StoryChunk and LogEvent are added on the side of the existing two
- Add Thread-safe support to HDF5 dependency as a requirement to write multiple HDF5 files in multiple threads

**Notes:**
Each file only has one dataset for one StoryChunk in this version. Thus, each Story is spread into across multiple files instead of being stored in a single file.