### PR TITLE
Add SWMR access flag while openning HDF5 archive files

### DIFF
--- a/ChronoPlayer/HDF5ArchiveReadingAgent.cpp
+++ b/ChronoPlayer/HDF5ArchiveReadingAgent.cpp
@@ -36,7 +36,7 @@ int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName &c
         try
         {
             LOG_DEBUG("[HDF5ArchiveReadingAgent] Opening file: {}", file_name);
-            file = std::make_unique <H5::H5File>(file_name, H5F_ACC_RDONLY);
+            file = std::make_unique <H5::H5File>(file_name, H5F_ACC_SWMR_READ);
 
             LOG_DEBUG("[HDF5ArchiveReadingAgent] Opening dataset: data");
             H5::DataSet dataset = file->openDataSet("/story_chunks/data.vlen_bytes");

--- a/chrono_common/StoryChunkWriter.cpp
+++ b/chrono_common/StoryChunkWriter.cpp
@@ -17,7 +17,7 @@ hsize_t StoryChunkWriter::writeStoryChunk(StoryChunkHVL &story_chunk)
     try
     {
         LOG_DEBUG("[StoryChunkWriter] Creating StoryChunk file: {}", file_name);
-        file = std::make_unique<H5::H5File>(file_name, H5F_ACC_TRUNC);
+        file = std::make_unique<H5::H5File>(file_name, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE);
 
         LOG_DEBUG("[StoryChunkWriter] Writing StoryChunk to file...");
         ret = writeEvents(file, data);
@@ -61,7 +61,7 @@ hsize_t StoryChunkWriter::writeStoryChunk(StoryChunk &story_chunk)
     try
     {
         LOG_DEBUG("[StoryChunkWriter] Creating StoryChunk file: {}", file_name);
-        file = std::make_unique<H5::H5File>(file_name, H5F_ACC_TRUNC);
+        file = std::make_unique<H5::H5File>(file_name, H5F_ACC_TRUNC | H5F_ACC_SWMR_WRITE);
 
         LOG_DEBUG("[StoryChunkWriter] Writing StoryChunk to file...");
         ret = writeEvents(file, data);


### PR DESCRIPTION
Changes in this PR:

- Add SWMR access flag to support opening a HDF5 file for read and write in different threads