### PR TITLE
285 create a separate client error codes header file

### DIFF
--- a/ChronoAPI/ChronoLog/include/chronolog_errcode.h
+++ b/ChronoAPI/ChronoLog/include/chronolog_errcode.h
@@ -1,37 +1,39 @@
-//
-// Created by kfeng on 12/19/22.
-//
-
 #ifndef CHRONOLOG_CHRONOLOG_ERRCODE_H
 #define CHRONOLOG_CHRONOLOG_ERRCODE_H
+
+//#include "Chronolog/Client/include/client_errorcodes.h"
+
 namespace chronolog
 {
 enum ErrorCode
 {
-    CL_SUCCESS = 0,                         // Success
-    CL_ERR_UNKNOWN = -1,                    // Error does not belong to any categories below
-    CL_ERR_INVALID_ARG = -2,                // Invalid arguments
-    CL_ERR_NOT_EXIST = -3,                  // Specified Chronicle or Story or property does not exist
-    CL_ERR_ACQUIRED = -4,                   // Specified Chronicle or Story is acquired, cannot be destroyed
-    CL_ERR_NOT_ACQUIRED = -5,               // Specified Chronicle or Story is not acquired, cannot be released
-    CL_ERR_CHRONICLE_EXISTS = -6,           // Specified Chronicle exists, cannot be created/renamed to
-    CL_ERR_STORY_EXISTS = -7,               // Specified Story exists, cannot be created/renamed to
-    CL_ERR_Archive_EXISTS = -8,             // Specified Archive exists, cannot be created/renamed to
-    CL_ERR_CHRONICLE_PROPERTY_FULL = -9,    // Property list of Chronicle is full, cannot add new property
-    CL_ERR_STORY_PROPERTY_FULL = -10,       // Property list of Story is full, cannot add new property
-    CL_ERR_CHRONICLE_METADATA_FULL = -11,   // Metadata list of Chronicle is full, cannot add new property
-    CL_ERR_STORY_METADATA_FULL = -12,       // Metadata list of Story is full, cannot add new property
-    CL_ERR_INVALID_CONF = -13,              // Content of configuration file is invalid
-    CL_ERR_NO_KEEPERS = -14,                // No ChronoKeepers are available
-    CL_ERR_NO_CONNECTION = -15,             // No valid connection to ChronoVisor
-    CL_ERR_NOT_AUTHORIZED = -16,            // Client is not authorized for operation
-    CL_ERR_STORY_CHUNK_EXISTS = -17,        // Specified Story chunk exists, cannot be created
-    CL_ERR_CHRONICLE_DIR_NOT_EXIST = -18,   // Chronicle directory does not exist
-    CL_ERR_STORY_FILE_NOT_EXIST = -19,      // Story file does not exist
-    CL_ERR_STORY_CHUNK_DSET_NOT_EXIST = -20,// Story chunk dataset does not exist
-    CL_ERR_STORY_CHUNK_EXTRACTION = -21,    // Error in extracting Story chunk in ChronoKeeper
-    CL_ERR_NO_PLAYERS = -22,                // No ChronoPlayers are available for story playback
-};
-}
+    // ---------- Client error codes ----------
+    CL_SUCCESS = 0,                             // Success
+    CL_ERR_UNKNOWN = -1,                        // Generic error
+    CL_ERR_INVALID_ARG = -2,                    // Invalid input
+    CL_ERR_NOT_EXIST = -3,                      // Missing Chronicle, Story, or property
+    CL_ERR_ACQUIRED = -4,                       // Already acquired, cannot destroy
+    CL_ERR_NOT_ACQUIRED = -5,                   // Not acquired, cannot release
+    CL_ERR_CHRONICLE_EXISTS = -6,               // Chronicle already exists
+    CL_ERR_NO_KEEPERS = -7,                     // No ChronoKeepers available
+    CL_ERR_NO_CONNECTION = -8,                  // No connection to ChronoVisor
+    CL_ERR_NOT_AUTHORIZED = -9,                 // Unauthorized operation
+    CL_ERR_NO_PLAYERS = -10,                     // No ChronoPlayers available
 
-#endif //CHRONOLOG_CHRONOLOG_ERRCODE_H
+    // ---------- Server-only error codes (must be <-100) ----------
+    CL_ERR_STORY_EXISTS = -101,                 // Specified Story exists, cannot be created/renamed to
+    CL_ERR_Archive_EXISTS = -102,               // Specified Archive exists, cannot be created/renamed to
+    CL_ERR_CHRONICLE_PROPERTY_FULL = -103,      // Property list of Chronicle is full, cannot add new property
+    CL_ERR_STORY_PROPERTY_FULL = -104,          // Property list of Story is full, cannot add new property
+    CL_ERR_CHRONICLE_METADATA_FULL = -105,      // Metadata list of Chronicle is full, cannot add new property
+    CL_ERR_STORY_METADATA_FULL = -106,          // Metadata list of Story is full, cannot add new property
+    CL_ERR_INVALID_CONF = -107,                 // Invalid configuration, cannot be created
+    CL_ERR_STORY_CHUNK_EXISTS = -108,           // Specified Story chunk exists, cannot be created
+    CL_ERR_CHRONICLE_DIR_NOT_EXIST = -109,      // Chronicle directory does not exist
+    CL_ERR_STORY_FILE_NOT_EXIST = -110,         // Story file does not exist
+    CL_ERR_STORY_CHUNK_DSET_NOT_EXIST = -111,   // Story chunk dataset does not exist
+    CL_ERR_STORY_CHUNK_EXTRACTION = -112        // Error in extracting Story chunk in ChronoKeeper
+};
+} 
+
+#endif // CHRONOLOG_CHRONOLOG_ERRCODE_H

--- a/ChronoAPI/ChronoLog/include/chronolog_errcode.h
+++ b/ChronoAPI/ChronoLog/include/chronolog_errcode.h
@@ -1,25 +1,12 @@
 #ifndef CHRONOLOG_CHRONOLOG_ERRCODE_H
 #define CHRONOLOG_CHRONOLOG_ERRCODE_H
 
-//#include "Chronolog/Client/include/client_errorcodes.h"
+#include "../../../Client/include/client_errcode.h"
 
 namespace chronolog
 {
 enum ErrorCode
 {
-    // ---------- Client error codes ----------
-    CL_SUCCESS = 0,                             // Success
-    CL_ERR_UNKNOWN = -1,                        // Generic error
-    CL_ERR_INVALID_ARG = -2,                    // Invalid input
-    CL_ERR_NOT_EXIST = -3,                      // Missing Chronicle, Story, or property
-    CL_ERR_ACQUIRED = -4,                       // Already acquired, cannot destroy
-    CL_ERR_NOT_ACQUIRED = -5,                   // Not acquired, cannot release
-    CL_ERR_CHRONICLE_EXISTS = -6,               // Chronicle already exists
-    CL_ERR_NO_KEEPERS = -7,                     // No ChronoKeepers available
-    CL_ERR_NO_CONNECTION = -8,                  // No connection to ChronoVisor
-    CL_ERR_NOT_AUTHORIZED = -9,                 // Unauthorized operation
-    CL_ERR_NO_PLAYERS = -10,                     // No ChronoPlayers available
-
     // ---------- Server-only error codes (must be <-100) ----------
     CL_ERR_STORY_EXISTS = -101,                 // Specified Story exists, cannot be created/renamed to
     CL_ERR_Archive_EXISTS = -102,               // Specified Archive exists, cannot be created/renamed to

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(chronolog_client thallium)
 set(PUBLIC_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/include/chronolog_client.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/ClientConfiguration.h
-    ${CMAKE_SOURCE_DIR}/ChronoAPI/ChronoLog/include/chronolog_errcode.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/client_errcode.h
 )
 
 # install library

--- a/Client/include/chronolog_client.h
+++ b/Client/include/chronolog_client.h
@@ -8,8 +8,7 @@
 #include <fstream>
 
 #include "ClientConfiguration.h"
-#include "chronolog_errcode.h"
-
+#include "client_errcode.h"
 
 namespace chronolog
 {

--- a/Client/include/client_errcode.h
+++ b/Client/include/client_errcode.h
@@ -5,17 +5,17 @@ namespace chronolog
 {
     enum ClientErrorCode
     {
-        CL_SUCCESS = 0,                 // Success
-        CL_ERR_UNKNOWN = -1,            // Generic error
-        CL_ERR_INVALID_ARG = -2,        // Invalid input
-        CL_ERR_NOT_EXIST = -3,          // Missing Chronicle, Story, or property
-        CL_ERR_ACQUIRED = -4,           // Already acquired, cannot destroy
-        CL_ERR_NOT_ACQUIRED = -5,       // Not acquired, cannot release
-        CL_ERR_CHRONICLE_EXISTS = -6,   // Chronicle already exists
-        CL_ERR_NO_KEEPERS = -14,        // No ChronoKeepers available
-        CL_ERR_NO_CONNECTION = -15,     // No connection to ChronoVisor
-        CL_ERR_NOT_AUTHORIZED = -16,    // Unauthorized operation
-        CL_ERR_NO_PLAYERS = -22         // No ChronoPlayers available
+        CL_SUCCESS = 0,                    // Success
+        CL_ERR_UNKNOWN = -1,               // Generic error
+        CL_ERR_INVALID_ARG = -2,           // Invalid input
+        CL_ERR_NOT_EXIST = -3,             // Missing Chronicle, Story, or property
+        CL_ERR_ACQUIRED = -4,              // Already acquired, cannot destroy
+        CL_ERR_NOT_ACQUIRED = -5,          // Not acquired, cannot release
+        CL_ERR_CHRONICLE_EXISTS = -6,      // Chronicle already exists
+        CL_ERR_NO_KEEPERS = -7,            // No ChronoKeepers available
+        CL_ERR_NO_CONNECTION = -8,         // No connection to ChronoVisor
+        CL_ERR_NOT_AUTHORIZED = -9,        // Unauthorized operation
+        CL_ERR_NO_PLAYERS = -10,           // No ChronoPlayers available
     };
 }
 

--- a/Client/include/client_errcode.h
+++ b/Client/include/client_errcode.h
@@ -1,0 +1,22 @@
+#ifndef CHRONOLOG_CLIENT_ERRORCODE_H
+#define CHRONOLOG_CLIENT_ERRORCODE_H
+
+namespace chronolog
+{
+    enum ClientErrorCode
+    {
+        CL_SUCCESS = 0,                 // Success
+        CL_ERR_UNKNOWN = -1,            // Generic error
+        CL_ERR_INVALID_ARG = -2,        // Invalid input
+        CL_ERR_NOT_EXIST = -3,          // Missing Chronicle, Story, or property
+        CL_ERR_ACQUIRED = -4,           // Already acquired, cannot destroy
+        CL_ERR_NOT_ACQUIRED = -5,       // Not acquired, cannot release
+        CL_ERR_CHRONICLE_EXISTS = -6,   // Chronicle already exists
+        CL_ERR_NO_KEEPERS = -14,        // No ChronoKeepers available
+        CL_ERR_NO_CONNECTION = -15,     // No connection to ChronoVisor
+        CL_ERR_NOT_AUTHORIZED = -16,    // Unauthorized operation
+        CL_ERR_NO_PLAYERS = -22         // No ChronoPlayers available
+    };
+}
+
+#endif // CHRONOLOG_CLIENT_ERRORCODE_H

--- a/Client/src/ChronologClientImpl.h
+++ b/Client/src/ChronologClientImpl.h
@@ -1,7 +1,7 @@
 #ifndef CHRONOLOG_CLIENT_IMPL_H
 #define CHRONOLOG_CLIENT_IMPL_H
 
-#include "chronolog_errcode.h"
+#include "client_errcode.h"
 #include "ClientConfiguration.h"
 
 #include "chronolog_types.h"

--- a/Client/src/ClientQueryService.cpp
+++ b/Client/src/ClientQueryService.cpp
@@ -1,10 +1,8 @@
-
-
 #include <thallium.hpp>
 #include <thallium/serialization/stl/vector.hpp>
 #include <cereal/archives/binary.hpp>
 
-#include "chronolog_errcode.h"
+#include "client_errcode.h"
 #include "chrono_monitor.h"
 #include "StoryChunk.h"
 #include "ClientQueryService.h"

--- a/Client/src/KeeperRecordingClient.h
+++ b/Client/src/KeeperRecordingClient.h
@@ -7,7 +7,7 @@
 
 #include "chronolog_types.h"
 #include "KeeperIdCard.h"
-#include "chronolog_errcode.h"
+#include "client_errcode.h"
 
 namespace tl = thallium;
 

--- a/Client/src/PlaybackQueryRpcClient.cpp
+++ b/Client/src/PlaybackQueryRpcClient.cpp
@@ -5,7 +5,7 @@
 #include <thallium/serialization/stl/map.hpp>
 
 #include "chrono_monitor.h"
-#include "chronolog_errcode.h"
+#include "client_errcode.h"
 #include "ServiceId.h"
 #include "PlaybackQueryRpcClient.h"
 #include "ClientQueryService.h"


### PR DESCRIPTION
Pull Request for issue #285 includes: 
1. Creation of a new client_errcode.h file that collects all the error codes used by the client. 
2. Update all the files in the Client/ folder to use the new client_errcode.h
3. Modify the original chronolog_errcode.h to include the client codes but to have the additional server codes starting from -100.

Note: Some error codes are not directly used in the client because they are not checked at any point, but the server returns them. 