### PR TITLE
Addition of the basic writer example to run the client

### DIFF
--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -53,3 +53,4 @@ install(
 )
 
 add_subdirectory(ChronoAdmin)
+add_subdirectory(examples)

--- a/Client/examples/CMakeLists.txt
+++ b/Client/examples/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Client/examples/CMakeLists.txt
+cmake_minimum_required(VERSION 3.25)
+
+message("Building Client/examples")
+
+add_executable(client_lib_writer_example client_lib_writer_example.cpp)
+
+target_include_directories(client_lib_writer_example PRIVATE ${CMAKE_BINARY_DIR}/Client/include)
+
+target_link_libraries(client_lib_writer_example chronolog_client -lpthread -lrt)
+
+# Optionally: install the example binary
+install(TARGETS client_lib_writer_example DESTINATION bin)

--- a/Client/examples/client_lib_writer_example.cpp
+++ b/Client/examples/client_lib_writer_example.cpp
@@ -31,8 +31,6 @@ int main() {
     story_handle->log_event("Event 2");
     story_handle->log_event("Event 3");
 
-    // TODO: Replay the story to read logged events
-
     // Release the story
     ret = client.ReleaseStory(chronicle_name, story_name);
     assert(ret != chronolog::CL_SUCCESS);

--- a/test/integration/Client/CMakeLists.txt
+++ b/test/integration/Client/CMakeLists.txt
@@ -9,7 +9,6 @@ message("Building CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
 message("Build target: ClientExamples")
 
 set(client_examples 
-    client_lib_basic_example 
     client_lib_connect_rpc_test client_lib_metadata_rpc_test 
     client_lib_multi_argobots_test client_lib_multi_pthread_test  
     client_lib_thread_interdependency_test

--- a/test/integration/Client/CMakeLists.txt
+++ b/test/integration/Client/CMakeLists.txt
@@ -9,10 +9,12 @@ message("Building CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
 message("Build target: ClientExamples")
 
 set(client_examples 
+    client_lib_basic_example 
     client_lib_connect_rpc_test client_lib_metadata_rpc_test 
     client_lib_multi_argobots_test client_lib_multi_pthread_test  
     client_lib_thread_interdependency_test
-    client_lib_multi_storytellers client_lib_story_reader)
+    client_lib_multi_storytellers 
+    client_lib_story_reader)
 
 # Custom target to copy server_list.in file
 add_custom_target(copyserverlist ALL

--- a/test/integration/Client/client_lib_basic_example.cpp
+++ b/test/integration/Client/client_lib_basic_example.cpp
@@ -9,18 +9,21 @@ int main() {
     chronolog::Client client(portalConf);
 
     // Connect to ChronoVisor
-    client.Connect();
+    int ret = client.Connect();
+    assert(ret != chronolog::CL_SUCCESS);
 
     // Create a chronicle
     std::string chronicle_name = "MyChronicle";
     std::map<std::string, std::string> chronicle_attrs;
     int flags = 0;
-    client.CreateChronicle(chronicle_name, chronicle_attrs, flags);
+    ret = client.CreateChronicle(chronicle_name, chronicle_attrs, flags);
+    assert(ret != chronolog::CL_SUCCESS);
 
     // Acquire a story
     std::string story_name = "MyStory";
     std::map<std::string, std::string> story_attrs;
     auto acquire_result = client.AcquireStory(chronicle_name, story_name, story_attrs, flags);
+    assert(acquire_ret.first == chronolog::CL_SUCCESS);
     auto story_handle = acquire_result.second;
 
     // Log a few events to the story
@@ -31,16 +34,23 @@ int main() {
     // TODO: Replay the story to read logged events
 
     // Release the story
-    client.ReleaseStory(chronicle_name, story_name);
+    ret = client.ReleaseStory(chronicle_name, story_name);
+    assert(ret != chronolog::CL_SUCCESS);
 
     // Destroy the story
-    client.DestroyStory(chronicle_name, story_name);
+    ret = client.DestroyStory(chronicle_name, story_name);
+    assert(ret != chronolog::CL_SUCCESS);
 
     // Destroy the chronicle
-    client.DestroyChronicle(chronicle_name);
+    ret = client.DestroyChronicle(chronicle_name);
+    assert(ret != chronolog::CL_SUCCESS);
 
     // Disconnect from ChronoVisor
-    client.Disconnect();
+    ret = client.Disconnect();
+    assert(ret != chronolog::CL_SUCCESS);
+
+    // Clean up
+    delete client;
 
     return 0;
 }

--- a/test/integration/Client/client_lib_basic_example.cpp
+++ b/test/integration/Client/client_lib_basic_example.cpp
@@ -1,0 +1,46 @@
+#include <chronolog_client.h>
+#include <common.h>
+
+int main() {
+    // Configure the client connection
+    chronolog::ClientPortalServiceConf portalConf("ofi+sockets", "127.0.0.1", 5555, 55);
+
+    // Create a ChronoLog client
+    chronolog::Client client(portalConf);
+
+    // Connect to ChronoVisor
+    client.Connect();
+
+    // Create a chronicle
+    std::string chronicle_name = "MyChronicle";
+    std::map<std::string, std::string> chronicle_attrs;
+    int flags = 0;
+    client.CreateChronicle(chronicle_name, chronicle_attrs, flags);
+
+    // Acquire a story
+    std::string story_name = "MyStory";
+    std::map<std::string, std::string> story_attrs;
+    auto acquire_result = client.AcquireStory(chronicle_name, story_name, story_attrs, flags);
+    auto story_handle = acquire_result.second;
+
+    // Log a few events to the story
+    story_handle->log_event("Event 1");
+    story_handle->log_event("Event 2");
+    story_handle->log_event("Event 3");
+
+    // TODO: Replay the story to read logged events
+
+    // Release the story
+    client.ReleaseStory(chronicle_name, story_name);
+
+    // Destroy the story
+    client.DestroyStory(chronicle_name, story_name);
+
+    // Destroy the chronicle
+    client.DestroyChronicle(chronicle_name);
+
+    // Disconnect from ChronoVisor
+    client.Disconnect();
+
+    return 0;
+}


### PR DESCRIPTION
This PR introduces a simplified example program (client_lib_basic_example.cpp) that demonstrates basic usage of the ChronoLog client library. It avoids threading, error checking, and logging, providing a clear and minimal illustration of key APIs like Connect, CreateChronicle, AcquireStory, log_event, and Disconnect.

Note: The read/replay pipeline is not included yet, as it is still under development.

CMakeLists.txt updated accordingly.