### PR TITLE
334-fix-chronoplayer-issue-on-handling-archive-story-files

### DIFF
--- a/ChronoPlayer/ArchiveReadingAgent.cpp
+++ b/ChronoPlayer/ArchiveReadingAgent.cpp
@@ -43,12 +43,14 @@ void chronolog::ArchiveReadingAgent::archiveReadingTask()
 
         theReadingAgent.readArchivedStory(readingRequest.chronicleName, readingRequest.storyName, readingRequest.startTime, readingRequest.endTime, listOfChunks);
 
-        while( !listOfChunks.empty())
+        LOG_DEBUG("[ReadingAgent] Read {} StoryChunks for Chronicle={}, Story={}, TimeRange=[{}, {})"
+                  , listOfChunks.size(), readingRequest.chronicleName, readingRequest.storyName
+                  , readingRequest.startTime, readingRequest.endTime);
+        while(!listOfChunks.empty())
         {
             readingRequest.storyChunkQueue->stashStoryChunk(listOfChunks.front());
             listOfChunks.pop_front();
         }
-                
     }
 
 }

--- a/ChronoPlayer/HDF5ArchiveReadingAgent.cpp
+++ b/ChronoPlayer/HDF5ArchiveReadingAgent.cpp
@@ -68,9 +68,9 @@ int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName &c
             "[HDF5ArchiveReadingAgent] End iterator: chronicle name: {}, story name: {}, start time: {}, file name: {}"
             , std::get <0>(end_it->first), std::get <1>(end_it->first), std::get <2>(end_it->first), end_it->second);
 
-    while(start_it != end_it)
+    for(auto it = start_it; it != end_it; ++it)
     {
-        fs::path file_full_path = fs::path(start_it++->second);
+        fs::path file_full_path = fs::path(it->second);
         std::string file_name = file_full_path.string();
         std::unique_ptr <H5::H5File> file;
         StoryChunk *story_chunk = nullptr;

--- a/ChronoPlayer/HDF5ArchiveReadingAgent.cpp
+++ b/ChronoPlayer/HDF5ArchiveReadingAgent.cpp
@@ -70,7 +70,7 @@ int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName &c
             , std::get <0>(end_it->first), std::get <1>(end_it->first), std::get <2>(end_it->first), end_it->second);
     do
     {
-        fs::path file_full_path = fs::path(archive_path_) / fs::path(start_it->second);
+        fs::path file_full_path = fs::path(start_it->second);
         std::string file_name = file_full_path.string();
         std::unique_ptr <H5::H5File> file;
         StoryChunk *story_chunk = nullptr;

--- a/ChronoPlayer/HDF5ArchiveReadingAgent.cpp
+++ b/ChronoPlayer/HDF5ArchiveReadingAgent.cpp
@@ -1,5 +1,6 @@
 #include <sys/inotify.h>
 #include <H5Cpp.h>
+#include <filesystem>
 
 #include "chronolog_errcode.h"
 #include "StoryChunkWriter.h"
@@ -9,34 +10,75 @@ namespace tl = thallium;
 
 namespace chronolog
 {
+struct ErrorReport
+{
+    std::vector <std::string> messages;
+};
+
+herr_t error_walker(unsigned int n, const H5E_error2_t *err_desc, void *client_data)
+{
+    // Cast the client_data back to our ErrorReport struct
+    auto *report = static_cast<ErrorReport *>(client_data);
+
+    // Get the major and minor error strings
+    char maj[256], min[256];
+    H5Eget_msg(err_desc->maj_num, nullptr, maj, 256);
+    H5Eget_msg(err_desc->min_num, nullptr, min, 256);
+
+    // Format the detailed error message
+    std::string msg =
+            "HDF5 Error #" + std::to_string(n) + ":\n" + "  File: " + err_desc->file_name + "\n" + "  Line: " +
+            std::to_string(err_desc->line) + "\n" + "  Function: " + err_desc->func_name + "\n" + "  Major Error: " +
+            maj + "\n" + "  Minor Error: " + min + "\n" + "  Description: " + err_desc->desc;
+
+    // Add the formatted message to our report
+    report->messages.push_back(msg);
+
+    // Return 0 to continue walking the stack
+    return 0;
+}
+
 int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName &chronicleName, const StoryName &storyName
-                                               , uint64_t startTime, uint64_t endTime
-                                               , std::list <StoryChunk *> &listOfChunks)
+                                                          , uint64_t startTime, uint64_t endTime
+                                                          , std::list <StoryChunk *> &listOfChunks)
 {
     // find all HDF5 files in the archive directory the start time of which falls in the range [startTime, endTime)
     // for each file, read Events in the StoryChunk and add matched ones to the list of StoryChunks
     // return the list of StoryChunks
     std::lock_guard <std::mutex> lock(start_time_file_name_map_mutex_);
-    auto start_it = start_time_file_name_map_.lower_bound(std::make_tuple(chronicleName, storyName
-                                                                          , startTime / 1000000000));
-    auto end_it = start_time_file_name_map_.upper_bound(std::make_tuple(chronicleName, storyName
-                                                                        , endTime / 1000000000));
-    LOG_DEBUG("[HDF5ArchiveReadingAgent] readArchiveStory {}-{} range{}-{}", chronicleName,storyName, startTime,endTime);
+    auto start_it = start_time_file_name_map_.lower_bound(std::make_tuple(chronicleName, storyName, startTime));
+    auto end_it = start_time_file_name_map_.upper_bound(std::make_tuple(chronicleName, storyName, endTime));
+    LOG_DEBUG("[HDF5ArchiveReadingAgent] readArchiveStory {}-{} range {}-{}", chronicleName, storyName, startTime
+              , endTime);
 
 
-    if(start_it == start_time_file_name_map_.end())
+    if(start_it == end_it)
     {
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] No matching files found for story {}-{} in range {}-{}" , chronicleName, storyName, startTime,endTime);
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] No matching files found for story {}-{} in range {}-{}", chronicleName
+                  , storyName, startTime, endTime);
         return CL_ERR_UNKNOWN;
     }
 
-    LOG_DEBUG("[HDF5ArchiveReadingAgent] Found  matching files for story {}-{} in range {}-{}", chronicleName, storyName, startTime,endTime);
+    LOG_DEBUG("[HDF5ArchiveReadingAgent] Found matching files for story {}-{} in range {}-{}", chronicleName, storyName
+              , startTime, endTime);
+    LOG_DEBUG(
+            "[HDF5ArchiveReadingAgent] Start iterator: chronicle name: {}, story name: {}, start time: {}, file name: {}"
+            , std::get <0>(start_it->first), std::get <1>(start_it->first), std::get <2>(start_it->first)
+            , start_it->second);
+    LOG_DEBUG(
+            "[HDF5ArchiveReadingAgent] End iterator: chronicle name: {}, story name: {}, start time: {}, file name: {}"
+            , std::get <0>(end_it->first), std::get <1>(end_it->first), std::get <2>(end_it->first), end_it->second);
     do
     {
-        std::string file_name = start_it->second;
+        fs::path file_full_path = fs::path(archive_path_) / fs::path(start_it->second);
+        std::string file_name = file_full_path.string();
         std::unique_ptr <H5::H5File> file;
+        StoryChunk *story_chunk = nullptr;
+        uint64_t event_count = 0;
         try
         {
+            H5::Exception::dontPrint();
+
             LOG_DEBUG("[HDF5ArchiveReadingAgent] Opening file: {}", file_name);
             file = std::make_unique <H5::H5File>(file_name, H5F_ACC_SWMR_READ);
 
@@ -46,13 +88,15 @@ int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName &c
             H5::DataSpace dataspace = dataset.getSpace();
             hsize_t dims_out[2] = {0, 0};
             dataspace.getSimpleExtentDims(dims_out, nullptr);
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading dataset {} with {} events", file_name,dims_out[0]);
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading dataset {} with {} events", file_name, dims_out[0]);
 
             H5::CompType defined_comp_type = StoryChunkWriter::createEventCompoundType();
             H5::CompType probed_data_type = dataset.getCompType();
             if(probed_data_type.getNmembers() != defined_comp_type.getNmembers())
             {
-                LOG_WARNING("[HDF5ArchiveReadingAgent] Error reading dataset {} : Not a compound type with the same #members", file_name);
+                LOG_WARNING(
+                        "[HDF5ArchiveReadingAgent] Error reading dataset {} : Not a compound type with the same #members"
+                        , file_name);
                 return CL_ERR_UNKNOWN;
             }
             if(probed_data_type != defined_comp_type)
@@ -61,43 +105,71 @@ int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName &c
                 return CL_ERR_UNKNOWN;
             }
 
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading data from dataset {}",file_name);
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading data from dataset {}", file_name);
             std::vector <LogEventHVL> data;
             data.resize(dims_out[0]);
             dataset.read(data.data(), defined_comp_type);
 
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] Creating StoryChunk {}-{} range {}-{}...", chronicleName,storyName, startTime, endTime);
-            auto *story_chunk = new StoryChunk(chronicleName, storyName, 0, startTime, endTime);
-            uint64_t event_count = 0;
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] Creating StoryChunk {}-{} range {}-{}...", chronicleName, storyName
+                      , startTime, endTime);
+            story_chunk = new StoryChunk(chronicleName, storyName, 0, startTime, endTime);
             for(auto const &event_hvl: data)
             {
-                if(event_hvl.eventTime < startTime || event_hvl.eventTime > endTime)
+                if(event_hvl.eventTime < startTime)
                 {
+                    LOG_DEBUG("[HDF5ArchiveReadingAgent] Skipping event with time {} outside range {}-{}"
+                              , event_hvl.eventTime, startTime, endTime);
                     continue;
                 }
+                if(event_hvl.eventTime >= endTime)
+                {
+                    LOG_DEBUG("[HDF5ArchiveReadingAgent] Stopping reading events at time {} outside range {}-{}"
+                              , event_hvl.eventTime, startTime, endTime);
+                    break;
+                }
 
-                LogEvent event(event_hvl.storyId, event_hvl.eventTime
-                               , event_hvl.clientId, event_hvl.eventIndex
+                LogEvent event(event_hvl.storyId, event_hvl.eventTime, event_hvl.clientId, event_hvl.eventIndex
                                , std::string(static_cast<char *>(event_hvl.logRecord.p), event_hvl.logRecord.len));
                 story_chunk->insertEvent(event);
                 event_count++;
             }
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] Inserted {} events into StoryChunk {}-{} range {}-{}"
-                      , event_count, chronicleName, storyName,startTime, endTime);
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] Inserted {} events into StoryChunk {}-{} range {}-{}", event_count
+                      , chronicleName, storyName, startTime, endTime);
 
-            listOfChunks.emplace_back(story_chunk);
-
-//            dataset.close();
-//            dataspace.close();
-//            file->close();
+            if(event_count != 0)
+            {
+                listOfChunks.emplace_back(story_chunk);
+            }
+            else
+            {
+                delete story_chunk;
+            }
         }
         catch(H5::FileIException &error)
         {
-            LOG_ERROR("[HDF5ArchiveReadingAgent] reading file{} : FileIException: {}", file_name, error.getCDetailMsg());
-// INNA:  there's potential memory leak here ... need to cleanup the memory allocated for the StoryChunk.. 
-#ifdef DEBUG
-            H5::FileIException::printErrorStack();
-#endif
+            LOG_ERROR("[HDF5ArchiveReadingAgent] reading file {} : FileIException: {} in C Function: {}", file_name
+                      , error.getCDetailMsg(), error.getCFuncName());
+            ErrorReport report;
+            H5::Exception::walkErrorStack(H5E_WALK_UPWARD, error_walker, &report);
+            for(const auto &msg: report.messages)
+            {
+                LOG_ERROR("[HDF5ArchiveReadingAgent] {}", msg);
+            }
+
+            delete story_chunk;
+            return CL_ERR_UNKNOWN;
+        }
+        catch(H5::Exception &error)
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] reading file {} : Exception: {} in C Function: {}", file_name
+                      , error.getCDetailMsg(), error.getCFuncName());
+            ErrorReport report;
+            H5::Exception::walkErrorStack(H5E_WALK_UPWARD, error_walker, &report);
+            for(const auto &msg: report.messages)
+            {
+                LOG_ERROR("[HDF5ArchiveReadingAgent] {}", msg);
+            }
+            delete story_chunk;
             return CL_ERR_UNKNOWN;
         }
     } while(++start_it != end_it);
@@ -107,7 +179,7 @@ int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName &c
 
 int chronolog::HDF5ArchiveReadingAgent::setUpFsMonitoring()
 {
-    LOG_DEBUG("[HDF5ArchiveReadingAgent] Setting up file system monitoring for archive directory: '{}'."
+    LOG_DEBUG("[HDF5ArchiveReadingAgent] Setting up file system monitoring for archive directory: '{}' recursively."
               , archive_path_);
     tl::managed <tl::xstream> es = tl::xstream::create();
     archive_dir_monitoring_stream_ = std::move(es);
@@ -118,22 +190,37 @@ int chronolog::HDF5ArchiveReadingAgent::setUpFsMonitoring()
     return 0;
 }
 
+void chronolog::HDF5ArchiveReadingAgent::addRecursiveWatch(int inotify_fd, const std::string &path
+                                                           , std::map <int, std::string> &wd_to_path)
+{
+    int wd = inotify_add_watch(inotify_fd, path.c_str(), IN_CREATE|IN_DELETE|IN_MOVED_FROM|IN_MOVED_TO);
+    if(wd < 0)
+    {
+        LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to add inotify watch on {}: {}", path, strerror(errno));
+        return;
+    }
+    wd_to_path[wd] = fs::absolute(path).string();
+
+    for(const auto &entry: fs::directory_iterator(path))
+    {
+        if(fs::is_directory(entry.status()))
+        {
+            addRecursiveWatch(inotify_fd, entry.path().string(), wd_to_path);
+        }
+    }
+}
+
 int chronolog::HDF5ArchiveReadingAgent::fsMonitoringThreadFunc()
 {
     int inotifyFd = inotify_init();
     if(inotifyFd < 0)
     {
-        perror("inotify_init");
+        LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to initialize inotify: {}", strerror(errno));
         return -1;
     }
 
-    int watchFd = inotify_add_watch(inotifyFd, archive_path_.c_str(), IN_CREATE|IN_DELETE|IN_MOVED_FROM|IN_MOVED_TO);
-    if(watchFd < 0)
-    {
-        perror("inotify_add_watch");
-        close(inotifyFd);
-        return -1;
-    }
+    std::map <int, std::string> wd_to_path;
+    addRecursiveWatch(inotifyFd, archive_path_, wd_to_path);
 
     const size_t eventSize = sizeof(struct inotify_event);
     const size_t bufLen = 1024 * (eventSize + 16);
@@ -141,43 +228,69 @@ int chronolog::HDF5ArchiveReadingAgent::fsMonitoringThreadFunc()
 
     while(true)
     {
-        int length = read(inotifyFd, buffer, bufLen);
+        ssize_t length = read(inotifyFd, buffer, bufLen);
         if(length < 0)
         {
-            perror("read");
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to read inotify events: {}", strerror(errno));
             break;
         }
 
         std::string old_file_name;
-        for(int i = 0; i < length; i += eventSize + ((struct inotify_event *)&buffer[i])->len)
+        for(ssize_t i = 0; i < length; i += (ssize_t)eventSize + ((struct inotify_event *)&buffer[i])->len)
         {
             auto *event = (struct inotify_event *)&buffer[i];
+            std::string path;
+            if(event->len)
+            {
+                path = (fs::path(wd_to_path[event->wd]) / event->name).string();
+            }
+
             if(event->mask&(IN_CREATE))
             {
-                LOG_DEBUG("[HDF5ArchiveReadingAgent] file {} created, updating file map...", event->name);
-                addFileToStartTimeFileNameMap(event->name);
+                if(event->mask&IN_ISDIR)
+                {
+                    // If a directory is created, we need to add a watch for it recursively
+                    LOG_DEBUG("[HDF5ArchiveReadingAgent] Directory {} created, updating inotify watch ..."
+                              , path);
+                    addRecursiveWatch(inotifyFd, fs::absolute(path), wd_to_path);
+                }
+                else
+                {
+                    LOG_DEBUG("[HDF5ArchiveReadingAgent] File {} created, updating file map...", path);
+                    addFileToStartTimeFileNameMap(path);
+                }
             }
             else if(event->mask&(IN_DELETE))
             {
-                LOG_DEBUG("[HDF5ArchiveReadingAgent] file {} deleted, updating file map...", event->name);
-                removeFileFromStartTimeFileNameMap(event->name);
+                if(event->mask&IN_ISDIR)
+                {
+                    LOG_DEBUG("[HDF5ArchiveReadingAgent] Directory {} deleted, removing inotify watch ..."
+                              , path);
+                    // Remove the watch for the deleted directory
+                    wd_to_path.erase(event->wd);
+                }
+                else
+                {
+                    LOG_DEBUG("[HDF5ArchiveReadingAgent] File {} deleted, updating file map...", path);
+                    removeFileFromStartTimeFileNameMap(path);
+                }
             }
             else if(event->mask&(IN_MOVED_FROM))
             {
-                LOG_DEBUG("[HDF5ArchiveReadingAgent] file is renamed from {}", event->name);
-                old_file_name = event->name;
+                LOG_DEBUG("[HDF5ArchiveReadingAgent] File is renamed from {}", path);
+                old_file_name = path;
             }
             else if(event->mask&(IN_MOVED_TO))
             {
                 if(old_file_name.empty())
                 {
-                    LOG_DEBUG("[HDF5ArchiveReadingAgent] file {} created, updating file map...", event->name);
-                    addFileToStartTimeFileNameMap(event->name);
+                    LOG_DEBUG("[HDF5ArchiveReadingAgent] File {} created, updating file map...", path);
+                    addFileToStartTimeFileNameMap(path);
                 }
                 else
                 {
-                    LOG_DEBUG("[HDF5ArchiveReadingAgent] file is renamed to {}, updating file map...",event->name);
-                    std::string new_file_name = event->name;
+                    LOG_DEBUG("[HDF5ArchiveReadingAgent] File is renamed to {}, updating file map...", path);
+                    std::string new_file_name = path;
                     renameFileInStartTimeFileNameMap(old_file_name, new_file_name);
                     old_file_name.clear();
                 }
@@ -185,7 +298,11 @@ int chronolog::HDF5ArchiveReadingAgent::fsMonitoringThreadFunc()
         }
     }
 
-    inotify_rm_watch(inotifyFd, watchFd);
+    for(const auto &entry: wd_to_path)
+    {
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] Removing inotify watch for {} with wd {}", entry.second, entry.first);
+        inotify_rm_watch(inotifyFd, entry.first);
+    }
     close(inotifyFd);
 
     return 0;

--- a/ChronoPlayer/HDF5ArchiveReadingAgent.h
+++ b/ChronoPlayer/HDF5ArchiveReadingAgent.h
@@ -11,6 +11,7 @@
 #include "StoryChunkIngestionQueue.h"
 
 namespace tl = thallium;
+namespace fs = std::filesystem;
 
 namespace chronolog
 {
@@ -19,15 +20,15 @@ class HDF5ArchiveReadingAgent
 {
 public:
     explicit HDF5ArchiveReadingAgent(std::string const &archive_path)
-        : archive_path_(archive_path)
+        : archive_path_(fs::absolute(expandTilde(fs::path(archive_path))).make_preferred().string())
     {}
 
     ~HDF5ArchiveReadingAgent() = default;
 
     int initialize()
     {
-        LOG_INFO("[HDF5ArchiveReadingAgent] Initializing,scanning archive path {} to create the map ...",
-                 archive_path_);
+        LOG_INFO("[HDF5ArchiveReadingAgent] Initializing, scanning archive path {} recursively to create the map ..."
+                 , archive_path_);
         createStartTimeFileNameMap();
         return setUpFsMonitoring();
     }
@@ -44,7 +45,7 @@ public:
     static std::string getChronicleName(const std::string &file_name)
     {
         // Example file name: /home/kfeng/chronolog/Debug/output/chronicle_0_0.story_0_0.1736806500.vlen.h5
-        std::string base_name = file_name.substr(file_name.find_last_of("/\\") + 1);
+        std::string base_name = fs::path(file_name).filename().string();
         std::string chronicle_name = base_name.substr(0, base_name.find_first_of('.'));
         return chronicle_name;
     }
@@ -52,7 +53,7 @@ public:
     static std::string getStoryName(const std::string &file_name)
     {
         // Example file name: /home/kfeng/chronolog/Debug/output/chronicle_0_0.story_0_0.1736806500.vlen.h5
-        std::string base_name = file_name.substr(file_name.find_last_of("/\\") + 1);
+        std::string base_name = fs::path(file_name).filename().string();
         size_t first_dot = base_name.find_first_of('.');
         size_t second_dot = base_name.find_first_of('.', first_dot + 1);
         std::string story_name = base_name.substr(first_dot + 1, second_dot - first_dot - 1);
@@ -62,16 +63,98 @@ public:
     static uint64_t getStartTime(const std::string &file_name)
     {
         // Example file name: /home/kfeng/chronolog/Debug/output/chronicle_0_0.story_0_0.1736806500.vlen.h5
-        std::string base_name = file_name.substr(file_name.find_last_of("/\\") + 1);
+//        LOG_DEBUG("[HDF5ArchiveReadingAgent] Extracting start time from file name: {}", file_name);
+        std::string base_name = fs::path(file_name).filename().string();
         size_t first_dot = base_name.find_first_of('.');
         size_t second_dot = base_name.find_first_of('.', first_dot + 1);
         size_t third_dot = base_name.find_first_of('.', second_dot + 1);
         std::string start_time_str = base_name.substr(second_dot + 1, third_dot - second_dot - 1);
-        return std::stoull(start_time_str);
+//        LOG_DEBUG("[HDF5ArchiveReadingAgent] Extracted start time: {}", start_time_str);
+        uint64_t start_time_in_ns = 0;
+        try
+        {
+            start_time_in_ns = std::stoull(start_time_str) * 1000000000;
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] Use start time={} for file map", start_time_in_ns);
+        }
+        catch(const std::exception &e)
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to convert start time string '{}' to uint64_t: {}"
+                      , start_time_str, e.what());
+        }
+        return start_time_in_ns;
     }
 
 private:
+    fs::path expandTilde(fs::path path)
+    {
+        if(!path.empty() && path.string()[0] == '~')
+        {
+            const char *home = getenv("HOME");
+            if(home)
+            {
+                fs::path expanded_path = fs::path(home) / path.string().substr(1);
+                LOG_DEBUG("[HDF5ArchiveReadingAgent] Expanding archive path from {} to {}"
+                          , path.string(), expanded_path.string());
+                return expanded_path;
+            }
+            else
+            {
+                LOG_ERROR("[HDF5ArchiveReadingAgent] HOME environment variable is not set. Cannot expand tilde in path: {}"
+                          , path.string());
+                return path; // Return the original path if HOME is not set
+            }
+        }
+        return path;
+    }
+
+    bool isValidArchiveFile(const std::string &file_name)
+    {
+        fs::path expanded_full_path = fs::absolute(fs::path(file_name));
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] Checking if file {} is a valid archive file.", expanded_full_path.string());
+        fs::directory_entry entry(expanded_full_path);
+        std::error_code ec;
+        if(!fs::exists(entry, ec))
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] File {} does not exist. Skipping this file.", file_name);
+            return false; // Skip files that do not exist
+        }
+        entry.refresh(ec);
+        if(ec)
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Error accessing file {}: {}", file_name, ec.message());
+            return false; // Skip files that cannot be accessed
+        }
+        if(entry.is_regular_file(ec))
+        {
+            if(entry.path().extension() != ".h5")
+            {
+                LOG_ERROR("[HDF5ArchiveReadingAgent] File {} is not an HDF5 file. Skipping this file."
+                          , entry.path().string());
+                return false; // Skip non-HDF5 files
+            }
+        }
+        else if(ec)
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Error checking file {}: {}", entry.path().string(), ec.message());
+            return false; // Skip files that cannot be accessed
+        }
+        else
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] File {} is not a regular file. Skipping this file.", entry.path().string());
+            return false; // Skip non-regular files
+        }
+        std::ifstream file(entry.path());
+        if(!file.is_open())
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to open file: {}. Skipping this file.", entry.path().string());
+            return false; // Skip files that cannot be opened
+        }
+        return true;
+    }
+
     int setUpFsMonitoring();
+
+    void addRecursiveWatch(int inotify_fd, const std::string& path, std::map<int, std::string>& wd_to_path);
 
     int fsMonitoringThreadFunc();
 
@@ -79,24 +162,62 @@ private:
     {
         // iterate over the HDF5 files in the archive directory to get the list of files
         // update the start_time_file_name_map_ with the start time and file name
-        std::lock_guard<std::mutex> lock(start_time_file_name_map_mutex_);
-        for(const auto &entry : std::filesystem::directory_iterator(archive_path_)) {
+        std::lock_guard <std::mutex> lock(start_time_file_name_map_mutex_);
+        std::error_code ec;
+        auto it = fs::recursive_directory_iterator(archive_path_, fs::directory_options::skip_permission_denied, ec);
+        if(ec)
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to iterate recursively over archive directory '{}': {}"
+                      , archive_path_, ec.message());
+            return -1; // Return error code on failure
+        }
+        for(const auto &entry: it)
+        {
+            if(ec)
+            {
+                LOG_ERROR("[HDF5ArchiveReadingAgent] Error accessing path: {}", ec.message());
+                // Clear the error to continue iteration on other branches.
+                ec.clear();
+                continue;
+            }
+            if(!isValidArchiveFile(entry.path().string()))
+            {
+                LOG_ERROR("[HDF5ArchiveReadingAgent] Invalid archive file: {}. Skipping this file.", entry.path().string());
+                continue; // Skip invalid files
+            }
             std::string chronicle_name = getChronicleName(entry.path().string());
             std::string story_name = getStoryName(entry.path().string());
             uint64_t start_time = getStartTime(entry.path().string());
+            if(start_time == 0)
+            {
+                LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to extract start time from file: {}. Skipping this file."
+                          , entry.path().string());
+                continue; // Skip files with invalid start time
+            }
             start_time_file_name_map_[std::make_tuple(chronicle_name, story_name, start_time)] = entry.path().string();
         }
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] Created start_time_file_name_map_ with {} entries.",
-                  start_time_file_name_map_.size());
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] Created start_time_file_name_map_ with {} entries."
+                  , start_time_file_name_map_.size());
         return 0;
     }
 
     int addFileToStartTimeFileNameMap(const std::string &file_name)
     {
         std::lock_guard<std::mutex> lock(start_time_file_name_map_mutex_);
+        if(!isValidArchiveFile(file_name))
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Invalid archive file: {}. Skipping this file.", file_name);
+            return -1; // Skip invalid files
+        }
         std::string chronicle_name = getChronicleName(file_name);
         std::string story_name = getStoryName(file_name);
         uint64_t start_time = getStartTime(file_name);
+        if(start_time == 0)
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to extract start time from file: {}. Skipping this file."
+                      , file_name);
+            return -1; // Skip files with invalid start time
+        }
         start_time_file_name_map_[std::make_tuple(chronicle_name, story_name, start_time)] = file_name;
         LOG_DEBUG("[HDF5ArchiveReadingAgent] Added file {} to start_time_file_name_map_.", file_name);
         LOG_DEBUG("[HDF5ArchiveReadingAgent] start_time_file_name_map_ has {} entries.",
@@ -110,6 +231,12 @@ private:
         std::string chronicle_name = getChronicleName(file_name);
         std::string story_name = getStoryName(file_name);
         uint64_t start_time = getStartTime(file_name);
+        if(start_time == 0)
+        {
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to extract start time from file: {}. Skipping this file.",
+                      file_name);
+            return -1; // Skip files with invalid start time
+        }
         start_time_file_name_map_.erase(std::make_tuple(chronicle_name, story_name, start_time));
         LOG_DEBUG("[HDF5ArchiveReadingAgent] Removed file {} from start_time_file_name_map_.", file_name);
         LOG_DEBUG("[HDF5ArchiveReadingAgent] start_time_file_name_map_ has {} entries.",

--- a/Client/ChronoAdmin/client_admin.cpp
+++ b/Client/ChronoAdmin/client_admin.cpp
@@ -528,7 +528,7 @@ std::vector <std::string> &command_subs)
                     assert(command_subs.size() == 2);
                     std::string event_payload = command_subs[1];
                     ret_u = test_write_event(story_handle, event_payload);
-                    if(ret_i > 0)
+                    if(ret_u > 0)
                     {
                         std::cout << "Event written successfully, payload length: " << event_payload.length()
                                   << std::endl;

--- a/Client/ChronoAdmin/client_admin.cpp
+++ b/Client/ChronoAdmin/client_admin.cpp
@@ -259,10 +259,10 @@ test_acquire_story(chronolog::Client &client, const std::string &chronicle_name,
     return acq_ret.second;
 }
 
-int test_write_event(chronolog::StoryHandle*story_handle, const std::string &event_payload)
+uint64_t test_write_event(chronolog::StoryHandle*story_handle, const std::string &event_payload)
 {
-    int ret = story_handle->log_event(event_payload);
-    assert(ret == 1);
+    uint64_t ret = story_handle->log_event(event_payload);
+    assert(ret > 0);
     return ret;
 }
 
@@ -443,7 +443,8 @@ int main(int argc, char**argv)
     TimerWrapper destroyChronicleTimer(workload_args.perf_test, "DestroyChronicle");
     TimerWrapper disconnectTimer(workload_args.perf_test, "Disconnect");
 
-    int ret;
+    int ret_i;
+    uint64_t ret_u;
     uint64_t event_payload_size_per_rank = 0;
 
     std::string client_id = gen_random(8);
@@ -456,8 +457,8 @@ int main(int argc, char**argv)
     std::string server_address = server_protoc + "://" + server_ip + ":" + server_port + "@" + server_provider_id;
 
     std::string username = getpwuid(getuid())->pw_name;
-    ret = connectTimer.timeBlock(&chronolog::Client::Connect, client);
-    assert(ret == chronolog::CL_SUCCESS);
+    ret_i = connectTimer.timeBlock(&chronolog::Client::Connect, client);
+    assert(ret_i == chronolog::CL_SUCCESS);
 
     std::cout << "Connected to server address: " << server_address << std::endl;
     std::string payload_str(MAX_EVENT_SIZE, 'a');
@@ -478,8 +479,8 @@ std::vector <std::string> &command_subs)
         {
             assert(command_subs.size() == 2);
             std::string chronicle_name = command_subs[1];
-            ret = test_create_chronicle(client, chronicle_name);
-            if(ret == chronolog::CL_SUCCESS)
+            ret_i = test_create_chronicle(client, chronicle_name);
+            if(ret_i == chronolog::CL_SUCCESS)
             {
                 std::cout << "Chronicle created successfully: " << chronicle_name << std::endl;
             }
@@ -508,13 +509,13 @@ std::vector <std::string> &command_subs)
                         assert(command_subs.size() == 4);
                         std::string chronicle_name = command_subs[2];
                         std::string story_name = command_subs[3];
-                        ret = test_release_story(client, chronicle_name, story_name);
-                        if(ret == chronolog::CL_SUCCESS)
+                        ret_i = test_release_story(client, chronicle_name, story_name);
+                        if(ret_i == chronolog::CL_SUCCESS)
                         {
                             std::cout << "Story released successfully: " << story_name << " in Chronicle "
                                       << chronicle_name << std::endl;
                         }
-                        else if(ret == chronolog::CL_ERR_NOT_EXIST)
+                        else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
                         {
                             std::cout << "Story does not exist: " << story_name << " in Chronicle "
                                       << chronicle_name << std::endl;
@@ -526,8 +527,8 @@ std::vector <std::string> &command_subs)
                 {
                     assert(command_subs.size() == 2);
                     std::string event_payload = command_subs[1];
-                    ret = test_write_event(story_handle, event_payload);
-                    if(ret == 1)
+                    ret_u = test_write_event(story_handle, event_payload);
+                    if(ret_i > 0)
                     {
                         std::cout << "Event written successfully, payload length: " << event_payload.length()
                                   << std::endl;
@@ -540,16 +541,16 @@ std::vector <std::string> &command_subs)
                     {
                         assert(command_subs.size() == 3);
                         std::string chronicle_name = command_subs[2];
-                        ret = test_destroy_chronicle(client, chronicle_name);
-                        if(ret == chronolog::CL_SUCCESS)
+                        ret_i = test_destroy_chronicle(client, chronicle_name);
+                        if(ret_i == chronolog::CL_SUCCESS)
                         {
                             std::cout << "Chronicle destroyed successfully: " << chronicle_name << std::endl;
                         }
-                        else if(ret == chronolog::CL_ERR_ACQUIRED)
+                        else if(ret_i == chronolog::CL_ERR_ACQUIRED)
                         {
                             std::cout << "Chronicle is still acquired, cannot destroy: " << chronicle_name << std::endl;
                         }
-                        else if(ret == chronolog::CL_ERR_NOT_EXIST)
+                        else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
                         {
                             std::cout << "Chronicle does not exist: " << chronicle_name << std::endl;
                         }
@@ -559,18 +560,18 @@ std::vector <std::string> &command_subs)
                         assert(command_subs.size() == 4);
                         std::string chronicle_name = command_subs[2];
                         std::string story_name = command_subs[3];
-                        ret = test_destroy_story(client, chronicle_name, story_name);
-                        if(ret == chronolog::CL_SUCCESS)
+                        ret_i = test_destroy_story(client, chronicle_name, story_name);
+                        if(ret_i == chronolog::CL_SUCCESS)
                         {
                             std::cout << "Story destroyed successfully: " << story_name << " in Chronicle "
                                       << chronicle_name << std::endl;
                         }
-                        else if(ret == chronolog::CL_ERR_ACQUIRED)
+                        else if(ret_i == chronolog::CL_ERR_ACQUIRED)
                         {
                             std::cout << "Story is still acquired, cannot destroy: " << story_name << " in Chronicle "
                                       << chronicle_name << std::endl;
                         }
-                        else if(ret == chronolog::CL_ERR_NOT_EXIST)
+                        else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
                         {
                             std::cout << "Story does not exist: " << story_name << " in Chronicle "
                                       << chronicle_name << std::endl;
@@ -605,7 +606,7 @@ std::vector <std::string> &command_subs)
                 chronicle_name = "chronicle_" + std::to_string(i);
             else
                 chronicle_name = "chronicle_" + std::to_string(rank) + "_" + std::to_string(i);
-            ret = createChronicleTimer.timeBlock(test_create_chronicle, client, chronicle_name);
+            ret_i = createChronicleTimer.timeBlock(test_create_chronicle, client, chronicle_name);
             if(workload_args.barrier)
                 MPI_Barrier(MPI_COMM_WORLD);
 
@@ -650,7 +651,7 @@ std::vector <std::string> &command_subs)
                                             event_payload = payload_str.substr(0, event_size);
                                             event_payload_size_per_rank += event_size;
                                             writeEventTimer.resumeTimer();
-                                            ret = test_write_event(story_handle, event_payload);
+                                            ret_u = test_write_event(story_handle, event_payload);
                                             if(workload_args.barrier)
                                                 MPI_Barrier(MPI_COMM_WORLD);
 
@@ -699,7 +700,7 @@ std::vector <std::string> &command_subs)
                                                     last_event_timestamp = event_timestamp;
                                                     event_payload_size_per_rank += event_payload.size();
                                                     writeEventTimer.resumeTimer();
-                                                    ret = test_write_event(story_handle, event_payload);
+                                                    ret_u = test_write_event(story_handle, event_payload);
                                                     if(workload_args.barrier)
                                                         MPI_Barrier(MPI_COMM_WORLD);
                                                 }
@@ -715,26 +716,26 @@ std::vector <std::string> &command_subs)
                                 });
 
                 // release story test
-                ret = releaseStoryTimer.timeBlock(test_release_story, client, chronicle_name, story_name);
+                ret_i = releaseStoryTimer.timeBlock(test_release_story, client, chronicle_name, story_name);
                 if(workload_args.barrier)
                     MPI_Barrier(MPI_COMM_WORLD);
 
                 // destroy story test
-                ret = destroyStoryTimer.timeBlock(test_destroy_story, client, chronicle_name, story_name);
+                ret_i = destroyStoryTimer.timeBlock(test_destroy_story, client, chronicle_name, story_name);
                 if(workload_args.barrier)
                     MPI_Barrier(MPI_COMM_WORLD);
             }
 
             // destroy chronicle test
-            ret = destroyChronicleTimer.timeBlock(test_destroy_chronicle, client, chronicle_name);
+            ret_i = destroyChronicleTimer.timeBlock(test_destroy_chronicle, client, chronicle_name);
             if(workload_args.barrier)
                 MPI_Barrier(MPI_COMM_WORLD);
         }
     }
     double local_e2e_end = MPI_Wtime();
 
-    ret = disconnectTimer.timeBlock(&chronolog::Client::Disconnect, client);
-    assert(ret == chronolog::CL_SUCCESS);
+    ret_i = disconnectTimer.timeBlock(&chronolog::Client::Disconnect, client);
+    assert(ret_i == chronolog::CL_SUCCESS);
     if(workload_args.barrier)
         MPI_Barrier(MPI_COMM_WORLD);
 

--- a/chrono_common/ConfigurationManager.cpp
+++ b/chrono_common/ConfigurationManager.cpp
@@ -127,7 +127,7 @@ void ChronoLog::ConfigurationManager::parseGrapherConf(json_object*json_conf)
 
 void ChronoLog::ConfigurationManager::parsePlayerConf(json_object*json_conf)
 {
-    std::cerr << "[ConfigurationManager] [chrono_player] Parsing ChronoPlayer configuration"<<std::endl;
+    std::cout << "[ConfigurationManager] [chrono_player] Parsing ChronoPlayer configuration"<<std::endl;
     json_object_object_foreach(json_conf, key, val)
     {
         if(strcmp(key, "RecordingGroup") == 0)

--- a/deploy/local_single_user_deploy.sh
+++ b/deploy/local_single_user_deploy.sh
@@ -162,6 +162,7 @@ generate_config_files() {
         player_monitoring_file=$(jq -r '.chrono_player.Monitoring.monitor.file' "$default_conf")
         player_monitoring_file_name=$(basename "$player_monitoring_file")
         jq --arg monitor_dir "$monitor_dir" \
+            --arg output_dir "$output_dir" \
             --argjson new_port_player_datastore $new_port_player_datastore \
             --argjson new_port_player_playback $new_port_player_playback \
             --argjson player_index "$player_index" \
@@ -169,7 +170,8 @@ generate_config_files() {
            '.chrono_player.RecordingGroup = $player_index |
             .chrono_player.PlayerStoreAdminService.rpc.service_base_port = $new_port_player_datastore |
             .chrono_player.PlaybackQueryService.rpc.service_base_port = $new_port_player_playback |
-            .chrono_player.Monitoring.monitor.file = ($monitor_dir + "/" + ($player_index | tostring) + "_" + $player_monitoring_file_name)' "$default_conf" > "$player_output_file"
+            .chrono_player.Monitoring.monitor.file = ($monitor_dir + "/" + ($player_index | tostring) + "_" + $player_monitoring_file_name) |
+            .chrono_grapher.Extractors.story_files_dir = ($output_dir + "/")' "$default_conf" >"$player_output_file"
 
         echo "Generated $player_output_file with port $new_port_player_datastore"
     done
@@ -329,19 +331,16 @@ start() {
     start_service ${VISOR_BIN} "--config ${CONF_DIR}/visor_conf.json" "visor.launch.log"
     sleep 2
     num_record_group=${NUM_RECORDING_GROUPS}
-    for (( i=1; i<=num_record_group; i++ ))
-    do
+    for ((i = 1; i <= num_record_group; i++)); do
         start_service ${GRAPHER_BIN} "--config ${CONF_DIR}/grapher_conf_$i.json" "grapher_$i.launch.log"
     done
     sleep 2
-    for (( i=1; i<=num_record_group; i++ ))
-    do
+    for ((i = 1; i <= num_record_group; i++)); do
         start_service ${PLAYER_BIN} "--config ${CONF_DIR}/player_conf_$i.json" "player_$i.launch.log"
     done
     sleep 2
     num_keepers=${NUM_KEEPERS}
-    for (( i=1; i<=num_keepers; i++ ))
-    do
+    for ((i = 1; i <= num_keepers; i++)); do
         start_service ${KEEPER_BIN} "--config ${CONF_DIR}/keeper_conf_$i.json" "keeper_$i.launch.log"
     done
     echo -e "${INFO}ChronoLog Started.${NC}"


### PR DESCRIPTION
Changes in this PR:

- Fix ChronoPlayer crashes and failure to recognize existing archive Story files
- Recursively monitor the output directory
- Use std::filesystem for file operations instead of DIY