### PR TITLE
Fix dynamic_deploy.sh to generate description for the last container

### DIFF
--- a/CI/docker/dynamic_deploy.sh
+++ b/CI/docker/dynamic_deploy.sh
@@ -90,7 +90,7 @@ services:
 EOF
 
 # Generate the regular container services
-for i in $(seq 1 $(($NUM_CONTAINERS-1))); do
+for i in $(seq 1 $NUM_CONTAINERS); do
     cat >> dynamic-compose.yaml << EOF
   c$i:
     <<: *x-common


### PR DESCRIPTION
Changes in this PR:

- Fix the bug that `dynamic_deploy.sh` script fails to deploy containers