### PR TITLE
232 installed executables cannot find libchronolog_client.so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cmake-build-*/
 
 # qt creator
 CMakeLists.txt.user
+
+# spack
+.spack-env/

--- a/CI/docker/local.dockerfile
+++ b/CI/docker/local.dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     git vim fuse sudo curl wget \
     libfuse-dev libssl-dev \
     python3 python3-dev python3-pip \
-    bzip2 xz-utils jq net-tools lsof htop pssh procps bind9-dnsutils
+    bzip2 xz-utils jq net-tools lsof htop pssh procps bind9-dnsutils chrpath
 
 RUN apt-get -y install --no-install-recommends \
     openssh-server openssh-client \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,16 @@ set(CHRONOLOG_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 set(CHRONOLOG_INSTALL_BIN_DIR ${CMAKE_INSTALL_PREFIX}/bin)
 set(CHRONOLOG_INSTALL_CONF_DIR ${CMAKE_INSTALL_PREFIX}/conf)
 
+# Disable using link paths as RPATH
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+
+# Set the RPATH explicitly
+set(CMAKE_INSTALL_RPATH "${CHRONOLOG_INSTALL_LIB_DIR}")
+
+# Make sure RPATH is not stripped during install
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+
 #------------------------------------------------------------------------------
 # Disallow in-source build. This checks that there is a defined and separate /build folder
 #------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,9 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 # Set the RPATH explicitly
 set(CMAKE_INSTALL_RPATH "${CHRONOLOG_INSTALL_LIB_DIR}")
 
-# Make sure RPATH is not stripped during install
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-set(CMAKE_SKIP_BUILD_RPATH FALSE)
+# Force RUNPATH instead of RPATH (RUNPATH has lower precedence)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--enable-new-dtags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--enable-new-dtags")
 
 #------------------------------------------------------------------------------
 # Disallow in-source build. This checks that there is a defined and separate /build folder

--- a/ChronoGrapher/CMakeLists.txt
+++ b/ChronoGrapher/CMakeLists.txt
@@ -31,8 +31,6 @@ target_sources(chrono_grapher PRIVATE
 target_link_libraries(chrono_grapher chronolog_client thallium)
 target_link_libraries(chrono_grapher ${HDF5_LIBRARIES})
 
-set_target_properties(chrono_grapher PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 # install binary
 install(
     TARGETS chrono_grapher DESTINATION bin

--- a/ChronoGrapher/CMakeLists.txt
+++ b/ChronoGrapher/CMakeLists.txt
@@ -31,6 +31,11 @@ target_sources(chrono_grapher PRIVATE
 target_link_libraries(chrono_grapher chronolog_client thallium)
 target_link_libraries(chrono_grapher ${HDF5_LIBRARIES})
 
+set_target_properties(chrono_grapher PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    SKIP_BUILD_RPATH TRUE
+)
+
 # install binary
 install(
     TARGETS chrono_grapher DESTINATION bin

--- a/ChronoKeeper/CMakeLists.txt
+++ b/ChronoKeeper/CMakeLists.txt
@@ -30,8 +30,6 @@ target_sources(chrono_keeper PRIVATE
 
 target_link_libraries(chrono_keeper chronolog_client thallium)
 
-set_target_properties(chrono_keeper PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 # install binary
 install(
     TARGETS chrono_keeper DESTINATION bin

--- a/ChronoKeeper/CMakeLists.txt
+++ b/ChronoKeeper/CMakeLists.txt
@@ -30,6 +30,11 @@ target_sources(chrono_keeper PRIVATE
 
 target_link_libraries(chrono_keeper chronolog_client thallium)
 
+set_target_properties(chrono_keeper PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    SKIP_BUILD_RPATH TRUE
+)
+
 # install binary
 install(
     TARGETS chrono_keeper DESTINATION bin

--- a/ChronoPlayer/CMakeLists.txt
+++ b/ChronoPlayer/CMakeLists.txt
@@ -31,6 +31,11 @@ target_sources(chrono_player PRIVATE
 target_link_libraries(chrono_player chronolog_client thallium)
 target_link_libraries(chrono_player ${HDF5_LIBRARIES})
 
+set_target_properties(chrono_player PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    SKIP_BUILD_RPATH TRUE
+)
+
 #### TransferAgentTest
 add_executable(transfer_agent_test
     src/TransferAgentTest.cpp
@@ -43,6 +48,11 @@ target_include_directories(transfer_agent_test PRIVATE
     ${CMAKE_SOURCE_DIR}/chrono_common/include
 )
 target_link_libraries(transfer_agent_test chronolog_client thallium)
+
+set_target_properties(transfer_agent_test PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    SKIP_BUILD_RPATH TRUE
+)
 
 #### PlaybackServiceTest
 add_executable(playback_service_test
@@ -57,6 +67,11 @@ target_include_directories(playback_service_test PRIVATE
     ${CMAKE_SOURCE_DIR}/chrono_common/include
 )
 target_link_libraries(playback_service_test chronolog_client thallium)
+
+set_target_properties(playback_service_test PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    SKIP_BUILD_RPATH TRUE
+)
 
 #### HDF5 ArchiveReader Test
 add_executable(hdf5_archive_reader_test
@@ -75,6 +90,11 @@ target_link_directories(hdf5_archive_reader_test PRIVATE ${HDF5_LIBRARY_DIRS})
 
 target_link_libraries(hdf5_archive_reader_test chronolog_client thallium)
 target_link_libraries(hdf5_archive_reader_test ${HDF5_LIBRARIES})
+
+set_target_properties(hdf5_archive_reader_test PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    SKIP_BUILD_RPATH TRUE
+)
 
 ####
 

--- a/ChronoPlayer/CMakeLists.txt
+++ b/ChronoPlayer/CMakeLists.txt
@@ -31,8 +31,6 @@ target_sources(chrono_player PRIVATE
 target_link_libraries(chrono_player chronolog_client thallium)
 target_link_libraries(chrono_player ${HDF5_LIBRARIES})
 
-set_target_properties(chrono_player PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 #### TransferAgentTest
 add_executable(transfer_agent_test
     src/TransferAgentTest.cpp

--- a/ChronoVisor/CMakeLists.txt
+++ b/ChronoVisor/CMakeLists.txt
@@ -32,7 +32,10 @@ target_include_directories(chronovisor_server PRIVATE
 
 target_link_libraries(chronovisor_server chronolog_client thallium)
 
-#add_test(NAME ChronoVisorServerTest COMMAND chronovisor_server)
+set_target_properties(chronovisor_server PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    SKIP_BUILD_RPATH TRUE
+)
 
 # Install binary
 install(

--- a/ChronoVisor/CMakeLists.txt
+++ b/ChronoVisor/CMakeLists.txt
@@ -34,8 +34,6 @@ target_link_libraries(chronovisor_server chronolog_client thallium)
 
 #add_test(NAME ChronoVisorServerTest COMMAND chronovisor_server)
 
-set_target_properties(chronovisor_server PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 # Install binary
 install(
     TARGETS chronovisor_server DESTINATION ${CHRONOLOG_INSTALL_BIN_DIR}

--- a/test/integration/Client/CMakeLists.txt
+++ b/test/integration/Client/CMakeLists.txt
@@ -21,6 +21,10 @@ foreach(client ${client_examples})
     add_executable(${client} ${client}.cpp)
     target_include_directories(${client} PRIVATE ${CMAKE_BINARY_DIR}/Client/include)
     target_link_libraries(${client} chronolog_client -lpthread -lrt)
+    set_target_properties(${client} PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+        SKIP_BUILD_RPATH TRUE
+    )
 endforeach()
 
 set(client_openmp client_lib_multi_openmp_test)
@@ -29,6 +33,10 @@ foreach(client ${client_openmp})
     add_executable(${client} ${client}.cpp)
     target_include_directories(${client} PRIVATE ${CMAKE_BINARY_DIR}/Client/include)
     target_link_libraries(${client} chronolog_client OpenMP::OpenMP_CXX)
+    set_target_properties(${client} PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+        SKIP_BUILD_RPATH TRUE
+    )
 endforeach()
 
 set(client_mpi client_lib_hybrid_argobots_test)
@@ -37,6 +45,10 @@ foreach(client ${client_mpi})
     add_executable(${client} ${client}.cpp)
     target_include_directories(${client} PRIVATE ${CMAKE_BINARY_DIR}/Client/include ${MPI_CXX_INCLUDE_DIRS})
     target_link_libraries(${client} chronolog_client ${MPI_CXX_LIBRARIES} -lpthread -lrt)
+    set_target_properties(${client} PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+        SKIP_BUILD_RPATH TRUE
+    )
 endforeach()
 
 # install binaries

--- a/test/synthetic_workload/perf_test.sh
+++ b/test/synthetic_workload/perf_test.sh
@@ -38,9 +38,9 @@ for i in $(seq 1 ${REP})
 do
     echo "======================================================================================" >> ${OUTPUT_LOG_FILE}
     echo "Iteration ${i}" >> ${OUTPUT_LOG_FILE}
-    echo LD_LIBRARY_PATH=${CHRONOLOG_LIB_DIR} ${MPIEXEC_BIN} -n ${NUM_PROCS} -f "${HOST_FILE}.${NUM_NODES}" \
+    echo ${MPIEXEC_BIN} -n ${NUM_PROCS} -f "${HOST_FILE}.${NUM_NODES}" \
         "${CLIENT_ADMIN_BIN}" -c "${CONF_FILE}" ${cli_args}
-    LD_LIBRARY_PATH=${CHRONOLOG_LIB_DIR} ${MPIEXEC_BIN} -n ${NUM_PROCS} -f "${HOST_FILE}.${NUM_NODES}" \
+    ${MPIEXEC_BIN} -n ${NUM_PROCS} -f "${HOST_FILE}.${NUM_NODES}" \
         "${CLIENT_ADMIN_BIN}" -c "${CONF_FILE}" ${cli_args} >>${OUTPUT_LOG_FILE} 2>&1
 done
 

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -11,6 +11,11 @@ add_executable(client_admin client_admin.cpp)
 
 target_link_libraries(client_admin chronolog_client ${MPI_CXX_LIBRARIES})
 
+set_target_properties(client_admin PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    SKIP_BUILD_RPATH TRUE
+)
+
 configure_file(${CMAKE_SOURCE_DIR}/default_conf.json.in
     ${CMAKE_CURRENT_BINARY_DIR}/default_conf.json COPYONLY)
 

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -14,8 +14,6 @@ target_link_libraries(client_admin chronolog_client ${MPI_CXX_LIBRARIES})
 configure_file(${CMAKE_SOURCE_DIR}/default_conf.json.in
     ${CMAKE_CURRENT_BINARY_DIR}/default_conf.json COPYONLY)
 
-set_target_properties(client_admin PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 # install binary
 install(
     TARGETS client_admin DESTINATION bin

--- a/tools/deploy/ChronoLog/install.sh
+++ b/tools/deploy/ChronoLog/install.sh
@@ -67,7 +67,7 @@ copy_shared_libs_recursive() {
     echo -e "${DEBUG}Copying ${lib_path} recursively ...${NC}"
     while [ "$final_dest_lib_copies" != true ]
     do
-        cp --update=none "$lib_path" "$dest_path/"
+        cp -n "$lib_path" "$dest_path/"
         if [ "$lib_path" == "$linked_to_lib_path" ]
         then
             final_dest_lib_copies=true

--- a/tools/deploy/ChronoLog/install.sh
+++ b/tools/deploy/ChronoLog/install.sh
@@ -99,8 +99,34 @@ copy_shared_libs() {
 
 update_rpath() {
     echo -e "${DEBUG}Updating RPATH...${NC}"
-    chrpath -r ${LIB_DIR} ${BIN_DIR}/* > /dev/null
-    chrpath -r ${LIB_DIR} ${LIB_DIR}/* > /dev/null
+
+    # Update RPATH for binaries
+    shopt -s nullglob
+    bin_files=("${BIN_DIR}"/*)
+    if [ ${#bin_files[@]} -eq 0 ]; then
+        echo -e "${INFO}No binaries found in ${BIN_DIR} to update RPATH.${NC}"
+    else
+        for f in "${bin_files[@]}"; do
+            if [ -f "$f" ]; then
+                chrpath -r "${LIB_DIR}" "$f" > /dev/null 2>&1 || \
+                    echo -e "${INFO}Skipping RPATH update for $f (no RPATH or not a valid ELF file).${NC}"
+            fi
+        done
+    fi
+
+    # Update RPATH for libraries
+    lib_files=("${LIB_DIR}"/*)
+    if [ ${#lib_files[@]} -eq 0 ]; then
+        echo -e "${INFO}No libraries found in ${LIB_DIR} to update RPATH.${NC}"
+    else
+        for f in "${lib_files[@]}"; do
+            if [ -f "$f" ]; then
+                chrpath -r "${LIB_DIR}" "$f" > /dev/null 2>&1 || \
+                    echo -e "${INFO}Skipping RPATH update for $f (no RPATH or not a valid ELF file).${NC}"
+            fi
+        done
+    fi
+    shopt -u nullglob
     echo -e "${DEBUG}RPATH updated${NC}"
 }
 

--- a/tools/deploy/ChronoLog/install.sh
+++ b/tools/deploy/ChronoLog/install.sh
@@ -87,8 +87,6 @@ copy_shared_libs() {
         all_shared_libs=$(echo -e "${all_shared_libs}\n$(extract_shared_libraries ${bin_file})" | sort | uniq)
     done
 
-    echo -e "${DEBUG}All shared libraries: ${all_shared_libs}${NC}"
-
     for lib in ${all_shared_libs}; do
         if [[ -n ${lib} ]]
         then
@@ -101,8 +99,8 @@ copy_shared_libs() {
 
 update_rpath() {
     echo -e "${DEBUG}Updating RPATH...${NC}"
-    chrpath -r ${LIB_DIR} ${BIN_DIR}/*
-    chrpath -r ${LIB_DIR} ${LIB_DIR}/*
+    chrpath -r ${LIB_DIR} ${BIN_DIR}/* > /dev/null
+    chrpath -r ${LIB_DIR} ${LIB_DIR}/* > /dev/null
     echo -e "${DEBUG}RPATH updated${NC}"
 }
 

--- a/tools/deploy/ChronoLog/install.sh
+++ b/tools/deploy/ChronoLog/install.sh
@@ -67,7 +67,7 @@ copy_shared_libs_recursive() {
     echo -e "${DEBUG}Copying ${lib_path} recursively ...${NC}"
     while [ "$final_dest_lib_copies" != true ]
     do
-        cp -P "$lib_path" "$dest_path/"
+        cp --update=none "$lib_path" "$dest_path/"
         if [ "$lib_path" == "$linked_to_lib_path" ]
         then
             final_dest_lib_copies=true
@@ -87,6 +87,8 @@ copy_shared_libs() {
         all_shared_libs=$(echo -e "${all_shared_libs}\n$(extract_shared_libraries ${bin_file})" | sort | uniq)
     done
 
+    echo -e "${DEBUG}All shared libraries: ${all_shared_libs}${NC}"
+
     for lib in ${all_shared_libs}; do
         if [[ -n ${lib} ]]
         then
@@ -95,6 +97,13 @@ copy_shared_libs() {
     done
 
     echo -e "${DEBUG}Copy shared libraries done${NC}"
+}
+
+update_rpath() {
+    echo -e "${DEBUG}Updating RPATH...${NC}"
+    chrpath -r ${LIB_DIR} ${BIN_DIR}/*
+    chrpath -r ${LIB_DIR} ${LIB_DIR}/*
+    echo -e "${DEBUG}RPATH updated${NC}"
 }
 
 activate_spack_environment() {
@@ -155,6 +164,7 @@ main() {
     navigate_to_build_directory
     make install
     copy_shared_libs
+    update_rpath
     echo -e "${INFO}ChronoLog Installed.${NC}"
 }
 main "$@"

--- a/tools/deploy/ChronoLog/local_single_user_deploy.sh
+++ b/tools/deploy/ChronoLog/local_single_user_deploy.sh
@@ -45,7 +45,7 @@ start_service() {
     local args="$2"
     local monitor_file="$3"
     echo -e "${DEBUG}Launching $bin $args ...${NC}"
-    LD_LIBRARY_PATH=${LIB_DIR} nohup ${bin} ${args} > ${MONITOR_DIR}/${monitor_file} 2>&1 &
+    nohup ${bin} ${args} > ${MONITOR_DIR}/${monitor_file} 2>&1 &
 }
 
 kill_service() {

--- a/tools/deploy/ChronoLog/single_user_deploy.sh
+++ b/tools/deploy/ChronoLog/single_user_deploy.sh
@@ -628,7 +628,7 @@ parallel_remote_check_processes() {
     local hosts_file=$1
     local bin_filename=$2
 
-    parallel-ssh -h ${hosts_file} -i "pgrep -fla ${bin_filename}" 2>/dev/null | grep -vE '^\[' | sed '/^$/d'
+    parallel-ssh -h ${hosts_file} -i "pgrep -fla ${bin_filename}" 2>/dev/null | sed '/^$/d' | grep -vE '^\[|ssh'
 }
 
 parallel_remote_check_all() {

--- a/tools/deploy/ChronoLog/single_user_deploy.sh
+++ b/tools/deploy/ChronoLog/single_user_deploy.sh
@@ -311,6 +311,13 @@ get_host_ip() {
     echo "${host_ip}"
 }
 
+get_remote_hostname() {
+    local hostname=$1
+    local remote_hostname=""
+    remote_hostname=$(ssh -n ${hostname} hostname)
+    echo "${remote_hostname}"
+}
+
 update_visor_ip() {
     visor_host=$(head -1 ${VISOR_HOSTS})
     visor_ip=$(get_host_ip ${visor_host})
@@ -347,7 +354,7 @@ generate_conf_for_each_keeper() {
     local keeper_hosts_file=$2
     [[ "${verbose}" == "true" ]] && echo -e "${DEBUG}Generating conf files for all ChronoKeepers in ${keeper_hosts_file} based on conf file ${base_conf_file} ...${NC}"
     while IFS= read -r keeper_host; do
-        remote_keeper_hostname=$(LD_LIBRARY_PATH="${SYS_LIB_DIR}" ssh -n ${keeper_host} hostname)
+        remote_keeper_hostname=$(get_remote_hostname ${keeper_host})
         [[ -z "${remote_keeper_hostname}" ]] && echo -e "${ERR}Cannot get hostname from ${keeper_host}, exiting ...${NC}" >&2 && exit 1
         [[ "${verbose}" == "true" ]] && echo -e "${DEBUG}Generating conf file ${base_conf_file}.keeper.${remote_keeper_hostname} for ChronoKeeper ${remote_keeper_hostname} ...${NC}"
         jq ".chrono_keeper.Monitoring.monitor.file = \"${MONITOR_DIR}/chrono_keeper.${remote_keeper_hostname}.log\"" "${base_conf_file}" >"${base_conf_file}.keeper.${remote_keeper_hostname}"
@@ -364,7 +371,7 @@ generate_conf_for_each_grapher() {
     local grapher_hosts_file=$2
     [[ "${verbose}" == "true" ]] && echo -e "${DEBUG}Generating conf files for all ChronoGraphers in ${grapher_hosts_file} based on conf file ${base_conf_file} ...${NC}"
     while IFS= read -r grapher_host; do
-        remote_grapher_hostname=$(LD_LIBRARY_PATH="${SYS_LIB_DIR}" ssh -n ${grapher_host} hostname)
+        remote_grapher_hostname=$(get_remote_hostname ${grapher_host})
         [[ -z "${remote_grapher_hostname}" ]] && echo -e "${ERR}Cannot get hostname from ${grapher_host}, exiting ...${NC}" >&2 && exit 1
         [[ "${verbose}" == "true" ]] && echo -e "${DEBUG}Generating conf file ${base_conf_file}.grapher.${remote_grapher_hostname} for ChronoGrapher ${remote_grapher_hostname} ...${NC}"
         jq ".chrono_grapher.Monitoring.monitor.file = \"${MONITOR_DIR}/chrono_grapher.${remote_grapher_hostname}.log\"" "${base_conf_file}" >"${base_conf_file}.grapher.${remote_grapher_hostname}"
@@ -381,7 +388,7 @@ generate_conf_for_each_player() {
     local player_hosts_file=$2
     [[ "${verbose}" == "true" ]] && echo -e "${DEBUG}Generating conf files for all ChronoPlayers in ${player_hosts_file} based on conf file ${base_conf_file} ...${NC}"
     while IFS= read -r player_host; do
-        remote_player_hostname=$(LD_LIBRARY_PATH="${SYS_LIB_DIR}" ssh -n ${player_host} hostname)
+        remote_player_hostname=$(get_remote_hostname ${player_host})
         [[ -z "${remote_player_hostname}" ]] && echo -e "${ERR}Cannot get hostname from ${player_host}, exiting ...${NC}" >&2 && exit 1
         [[ "${verbose}" == "true" ]] && echo -e "${DEBUG}Generating conf file ${base_conf_file}.player.${remote_player_hostname} for ChronoPlayer ${remote_player_hostname} ...${NC}"
         jq ".chrono_player.Monitoring.monitor.file = \"${MONITOR_DIR}/chrono_player.${remote_player_hostname}.log\"" "${base_conf_file}" >"${base_conf_file}.player.${remote_player_hostname}"
@@ -408,13 +415,13 @@ generate_conf_for_each_recording_group() {
         # get IP of Grapher node
         grapher_hostname=$(head -1 ${grapher_hosts_file})
         grapher_ip=$(get_host_ip ${grapher_hostname})
-#        remote_grapher_hostname=$(LD_LIBRARY_PATH="${SYS_LIB_DIR}" ssh -n ${grapher_hostname} hostname)
+#        remote_grapher_hostname=$(get_remote_hostname ${grapher_hostname})
 #        [[ -z "${remote_grapher_hostname}" ]] && echo -e "${ERR}Cannot get hostname from ${grapher_hostname}, exiting ...${NC}" >&2 && exit 1
 
         # get IP of Player node
         player_hostname=$(head -1 ${player_hosts_file})
         player_ip=$(get_host_ip ${player_hostname})
-#        remote_player_hostname=$(LD_LIBRARY_PATH="${SYS_LIB_DIR}" ssh -n ${player_hostname} hostname)
+#        remote_player_hostname=$(get_remote_hostname ${player_hostname})
 #        [[ -z "${remote_player_hostname}" ]] && echo -e "${ERR}Cannot get hostname from ${player_hostname}, exiting ...${NC}" >&2 && exit 1
 
         # update conf file for Grapher, Keeper and Player
@@ -589,7 +596,7 @@ parallel_remote_launch_processes() {
     fi
 
     bin_path=${bin_dir}/${bin_filename}
-    LD_LIBRARY_PATH="${SYS_LIB_DIR}" pssh -h ${hosts_file} -i "cd ${bin_dir}; LD_LIBRARY_PATH=${lib_dir} nohup ${bin_path} ${args} > ${MONITOR_DIR}/${bin_filename}${hostname_suffix}.launch.log 2>&1 &" | grep "${simple_output_grep_keyword}" 2>&1
+    pssh -h ${hosts_file} -i "cd ${bin_dir}; nohup ${bin_path} ${args} > ${MONITOR_DIR}/${bin_filename}${hostname_suffix}.launch.log 2>&1 &" | grep "${simple_output_grep_keyword}" 2>&1
 }
 
 parallel_remote_stop_processes() {
@@ -597,7 +604,7 @@ parallel_remote_stop_processes() {
     local bin_filename=$2
 
     local timer=0
-    LD_LIBRARY_PATH="${SYS_LIB_DIR}" pssh -h ${hosts_file} -i "pkill --signal 15 -ef ${bin_filename}" 2>/dev/null
+    pssh -h ${hosts_file} -i "pkill --signal 15 -ef ${bin_filename}" 2>/dev/null
     while [[ -n $(parallel_remote_check_processes ${hosts_file} ${bin_filename}) ]]; do
         echo -e "${DEBUG}Some processes are still running, waiting for 10 seconds ...${NC}"
         sleep 10
@@ -614,14 +621,14 @@ parallel_remote_kill_processes() {
     local hosts_file=$1
     local bin_filename=$2
 
-    LD_LIBRARY_PATH="${SYS_LIB_DIR}" pssh -h ${hosts_file} -i "pkill --signal 9 -ef ${bin_filename}" 2>/dev/null
+    pssh -h ${hosts_file} -i "pkill --signal 9 -ef ${bin_filename}" 2>/dev/null
 }
 
 parallel_remote_check_processes() {
     local hosts_file=$1
     local bin_filename=$2
 
-    LD_LIBRARY_PATH="${SYS_LIB_DIR}" pssh -h ${hosts_file} -i "pgrep -fla ${bin_filename}" 2>/dev/null | grep -vE '^\[' | sed '/^$/d'
+    pssh -h ${hosts_file} -i "pgrep -fla ${bin_filename}" 2>/dev/null | grep -vE '^\[' | sed '/^$/d'
 }
 
 parallel_remote_check_all() {

--- a/tools/deploy/ChronoLog/single_user_deploy.sh
+++ b/tools/deploy/ChronoLog/single_user_deploy.sh
@@ -140,7 +140,7 @@ usage() {
 }
 
 check_dependencies() {
-    local dependencies=("jq" "pssh" "ssh" "ldd" "nohup" "pkill" "readlink" "realpath")
+    local dependencies=("jq" "parallel-ssh" "ssh" "ldd" "nohup" "pkill" "readlink" "realpath")
 
     echo -e "${DEBUG}Checking required dependencies...${NC}"
     for dep in "${dependencies[@]}"; do
@@ -596,7 +596,7 @@ parallel_remote_launch_processes() {
     fi
 
     bin_path=${bin_dir}/${bin_filename}
-    pssh -h ${hosts_file} -i "cd ${bin_dir}; nohup ${bin_path} ${args} > ${MONITOR_DIR}/${bin_filename}${hostname_suffix}.launch.log 2>&1 &" | grep "${simple_output_grep_keyword}" 2>&1
+    parallel-ssh -h ${hosts_file} -i "cd ${bin_dir}; nohup ${bin_path} ${args} > ${MONITOR_DIR}/${bin_filename}${hostname_suffix}.launch.log 2>&1 &" | grep "${simple_output_grep_keyword}" 2>&1
 }
 
 parallel_remote_stop_processes() {
@@ -604,7 +604,7 @@ parallel_remote_stop_processes() {
     local bin_filename=$2
 
     local timer=0
-    pssh -h ${hosts_file} -i "pkill --signal 15 -ef ${bin_filename}" 2>/dev/null
+    parallel-ssh -h ${hosts_file} -i "pkill --signal 15 -ef ${bin_filename}" 2>/dev/null
     while [[ -n $(parallel_remote_check_processes ${hosts_file} ${bin_filename}) ]]; do
         echo -e "${DEBUG}Some processes are still running, waiting for 10 seconds ...${NC}"
         sleep 10
@@ -621,14 +621,14 @@ parallel_remote_kill_processes() {
     local hosts_file=$1
     local bin_filename=$2
 
-    pssh -h ${hosts_file} -i "pkill --signal 9 -ef ${bin_filename}" 2>/dev/null
+    parallel-ssh -h ${hosts_file} -i "pkill --signal 9 -ef ${bin_filename}" 2>/dev/null
 }
 
 parallel_remote_check_processes() {
     local hosts_file=$1
     local bin_filename=$2
 
-    pssh -h ${hosts_file} -i "pgrep -fla ${bin_filename}" 2>/dev/null | grep -vE '^\[' | sed '/^$/d'
+    parallel-ssh -h ${hosts_file} -i "pgrep -fla ${bin_filename}" 2>/dev/null | grep -vE '^\[' | sed '/^$/d'
 }
 
 parallel_remote_check_all() {


### PR DESCRIPTION
Changes in this PR:

- `INSTALL_RPATH_USE_LINK_PATH` is set to `FALSE` to not use Spack dependencies directories during install
- Set `INSTALL_RPATH` to `install_dir/lib` manually to make sure all installed bins and libs search in that directory for dependencies
- Fix bug in copying shared libs during install
- Use `chrpath` to set `RUNPATH` explicitly for all installed bins and libs after their entire dependency trees are copied to the install dir