### PR TITLE
Optimize chronkvs get calls with specific time ranges

### DIFF
--- a/Plugins/chronokvs/src/chronokvs_mapper.cpp
+++ b/Plugins/chronokvs/src/chronokvs_mapper.cpp
@@ -23,9 +23,11 @@ std::string ChronoKVSMapper::retrieveByKeyAndTs(const std::string &key, std::uin
         return "";
     }
     
-    // Return the first event's value - the narrow range should only contain
-    // events with the exact timestamp we're looking for
-    return events[0].value;
+    // Return the first event's value only if its timestamp matches the requested timestamp
+    if (events[0].timestamp == timestamp) {
+        return events[0].value;
+    }
+    return "";
 }
 
 std::vector<EventData> ChronoKVSMapper::retrieveByKey(const std::string &key)

--- a/Plugins/chronokvs/src/chronokvs_mapper.cpp
+++ b/Plugins/chronokvs/src/chronokvs_mapper.cpp
@@ -3,9 +3,6 @@
 namespace chronokvs
 {
 
-// Constants for time range boundaries
-constexpr uint64_t MIN_TIMESTAMP = 1;  // Earliest possible timestamp
-constexpr uint64_t MAX_TIMESTAMP = 2000000000000000000;  // ~May 18, 2033 03:33:20 UTC
 
 ChronoKVSMapper::ChronoKVSMapper()
 {
@@ -19,27 +16,24 @@ std::uint64_t ChronoKVSMapper::storeKeyValue(const std::string &key, const std::
 
 std::string ChronoKVSMapper::retrieveByKeyAndTs(const std::string &key, std::uint64_t timestamp)
 {
-    // TODO(Performance): Current implementation fetches all events due to issues with narrow time ranges
-    // causing timeouts. This should be optimized to use [timestamp, timestamp + 1) once the underlying
-    // timing issues are resolved.
-    auto events = chronoClientAdapter->retrieveEvents(key, MIN_TIMESTAMP, MAX_TIMESTAMP);
+    // Retrieve events in the narrow time range [timestamp, timestamp + 1)
+    auto events = chronoClientAdapter->retrieveEvents(key, timestamp, timestamp + 1);
     
     if (events.empty()) {
         return "";
     }
     
-    // Search for exact timestamp match in the retrieved events
-    for (const auto& event : events) {
-        if (event.timestamp == timestamp) {
-            return event.value;
-        }
-    }
-    
-    return "";
+    // Return the first event's value - the narrow range should only contain
+    // events with the exact timestamp we're looking for
+    return events[0].value;
 }
 
 std::vector<EventData> ChronoKVSMapper::retrieveByKey(const std::string &key)
 {
+    // Constants for time range boundaries
+    constexpr uint64_t MIN_TIMESTAMP = 1;  // Earliest possible timestamp
+    constexpr uint64_t MAX_TIMESTAMP = 2000000000000000000;  // ~May 18, 2033 03:33:20 UTC
+    
     // Retrieve all events for the given key using the full time range.
     // This ensures we capture all events regardless of their timestamp,
     // avoiding any potential data loss from timing uncertainties.


### PR DESCRIPTION
After solving issues with specific time ranges on replayStory() calls we have been able to optimize chronokvs calls for data replay with specific timestamp and key. 