### PR TITLE
456 fix hidden include dependencies in source files

### DIFF
--- a/ChronoGrapher/include/CSVFileChunkExtractor.h
+++ b/ChronoGrapher/include/CSVFileChunkExtractor.h
@@ -3,9 +3,9 @@
 
 #include <string>
 
-#include <chronolog_types.h>
 #include <StoryChunk.h>
 #include <StoryChunkExtractor.h>
+#include <chronolog_types.h>
 
 
 namespace chronolog

--- a/ChronoGrapher/include/CSVFileChunkExtractor.h
+++ b/ChronoGrapher/include/CSVFileChunkExtractor.h
@@ -15,7 +15,7 @@ class CSVFileStoryChunkExtractor: public StoryChunkExtractorBase
 {
 
 public:
-    CSVFileStoryChunkExtractor(std::string const & chrono_process_id_card, std::string const &csv_files_root_dir);
+    CSVFileStoryChunkExtractor(std::string const& chrono_process_id_card, std::string const& csv_files_root_dir);
 
     ~CSVFileStoryChunkExtractor();
 
@@ -24,10 +24,8 @@ public:
 private:
     std::string chrono_process_id;
     std::string rootDirectory;
-
-
 };
 
 
-}
+} // namespace chronolog
 #endif

--- a/ChronoGrapher/include/CSVFileChunkExtractor.h
+++ b/ChronoGrapher/include/CSVFileChunkExtractor.h
@@ -1,7 +1,10 @@
 #ifndef CSV_FILE_CHUNK_EXTRACTOR_H
 #define CSV_FILE_CHUNK_EXTRACTOR_H
 
+#include <string>
+
 #include <chronolog_types.h>
+#include <StoryChunk.h>
 #include <StoryChunkExtractor.h>
 
 

--- a/ChronoGrapher/include/GrapherDataStore.h
+++ b/ChronoGrapher/include/GrapherDataStore.h
@@ -5,6 +5,7 @@
 #include <list>
 #include <map>
 #include <mutex>
+#include <unordered_map>
 #include <thallium.hpp>
 
 #include <StoryPipeline.h>

--- a/ChronoGrapher/include/GrapherDataStore.h
+++ b/ChronoGrapher/include/GrapherDataStore.h
@@ -14,7 +14,6 @@
 #include "ChunkIngestionQueue.h"
 
 
-
 namespace chronolog
 {
 
@@ -24,15 +23,19 @@ class GrapherDataStore
 
     enum DataStoreState
     {
-        UNKNOWN = 0, RUNNING = 1,    //  active stories
-        SHUTTING_DOWN = 2    // Shutting down services
+        UNKNOWN = 0,
+        RUNNING = 1,      //  active stories
+        SHUTTING_DOWN = 2 // Shutting down services
     };
 
 
 public:
-    GrapherDataStore(ChunkIngestionQueue &ingestion_queue, StoryChunkExtractionQueue &extraction_queue
-                    , uint32_t max_chunk_size = 4096, uint32_t story_chunk_duration_secs = 60
-                    , uint32_t acceptance_window_secs = 180, uint32_t inactive_pipeline_delay_secs = 300 )
+    GrapherDataStore(ChunkIngestionQueue& ingestion_queue,
+                     StoryChunkExtractionQueue& extraction_queue,
+                     uint32_t max_chunk_size = 4096,
+                     uint32_t story_chunk_duration_secs = 60,
+                     uint32_t acceptance_window_secs = 180,
+                     uint32_t inactive_pipeline_delay_secs = 300)
         : state(UNKNOWN)
         , theIngestionQueue(ingestion_queue)
         , theExtractionQueue(extraction_queue)
@@ -44,15 +47,13 @@ public:
 
     ~GrapherDataStore();
 
-    bool is_running() const
-    { return (RUNNING == state); }
+    bool is_running() const { return (RUNNING == state); }
 
-    bool is_shutting_down() const
-    { return (SHUTTING_DOWN == state); }
+    bool is_shutting_down() const { return (SHUTTING_DOWN == state); }
 
-    int startStoryRecording(ChronicleName const &, StoryName const &, StoryId const &, uint64_t start_time);
+    int startStoryRecording(ChronicleName const&, StoryName const&, StoryId const&, uint64_t start_time);
 
-    int stopStoryRecording(StoryId const &);
+    int stopStoryRecording(StoryId const&);
 
     void collectIngestedEvents();
 
@@ -67,28 +68,27 @@ public:
     void dataCollectionTask();
 
 private:
-    GrapherDataStore(GrapherDataStore const &) = delete;
+    GrapherDataStore(GrapherDataStore const&) = delete;
 
-    GrapherDataStore &operator=(GrapherDataStore const &) = delete;
+    GrapherDataStore& operator=(GrapherDataStore const&) = delete;
 
     DataStoreState state;
     std::mutex dataStoreStateMutex;
-    ChunkIngestionQueue &theIngestionQueue;
-    StoryChunkExtractionQueue &theExtractionQueue;
+    ChunkIngestionQueue& theIngestionQueue;
+    StoryChunkExtractionQueue& theExtractionQueue;
 
     uint32_t story_chunk_size;
     uint32_t story_chunk_duration_secs;
     uint32_t acceptance_window_secs;
     uint32_t inactive_pipeline_delay_secs;
-    
-    std::vector <thallium::managed <thallium::xstream>> dataStoreStreams;
-    std::vector <thallium::managed <thallium::thread>> dataStoreThreads;
+
+    std::vector<thallium::managed<thallium::xstream>> dataStoreStreams;
+    std::vector<thallium::managed<thallium::thread>> dataStoreThreads;
 
     std::mutex dataStoreMutex;
-    std::unordered_map <StoryId, StoryPipeline*> theMapOfStoryPipelines;
-    std::unordered_map <StoryId, std::pair <StoryPipeline*, uint64_t>> pipelinesWaitingForExit;
-
+    std::unordered_map<StoryId, StoryPipeline*> theMapOfStoryPipelines;
+    std::unordered_map<StoryId, std::pair<StoryPipeline*, uint64_t>> pipelinesWaitingForExit;
 };
 
-}
+} // namespace chronolog
 #endif

--- a/ChronoGrapher/include/GrapherRecordingService.h
+++ b/ChronoGrapher/include/GrapherRecordingService.h
@@ -22,12 +22,12 @@ namespace tl = thallium;
 
 namespace chronolog
 {
-class GrapherRecordingService: public tl::provider <GrapherRecordingService>
+class GrapherRecordingService: public tl::provider<GrapherRecordingService>
 {
 public:
     // RecordingService should be created on the heap not the stack thus the constructor is private...
     static GrapherRecordingService*
-    CreateRecordingService(tl::engine &tl_engine, uint16_t service_provider_id, ChunkIngestionQueue &ingestion_queue)
+    CreateRecordingService(tl::engine& tl_engine, uint16_t service_provider_id, ChunkIngestionQueue& ingestion_queue)
     {
         return new GrapherRecordingService(tl_engine, service_provider_id, ingestion_queue);
     }
@@ -38,39 +38,41 @@ public:
         get_engine().pop_finalize_callback(this);
     }
 
-    void record_story_chunk(tl::request const &request, tl::bulk &b)
+    void record_story_chunk(tl::request const& request, tl::bulk& b)
     {
         try
         {
-            std::vector <char> mem_vec(b.size());
+            std::vector<char> mem_vec(b.size());
             std::chrono::high_resolution_clock::time_point start, end;
             LOG_DEBUG("[GrapherRecordingService] StoryChunk recording RPC invoked, ThreadID={}", tl::thread::self_id());
             tl::endpoint ep = request.get_endpoint();
             LOG_DEBUG("[GrapherRecordingService] Endpoint obtained, ThreadID={}", tl::thread::self_id());
-            std::vector <std::pair <void*, std::size_t>> segments(1);
+            std::vector<std::pair<void*, std::size_t>> segments(1);
             segments[0].first = (void*)(&mem_vec[0]);
             segments[0].second = mem_vec.size();
-            LOG_DEBUG("[GrapherRecordingService] Bulk memory prepared, size: {}, ThreadID={}", mem_vec.size()
-                      , tl::thread::self_id());
+            LOG_DEBUG("[GrapherRecordingService] Bulk memory prepared, size: {}, ThreadID={}",
+                      mem_vec.size(),
+                      tl::thread::self_id());
             tl::engine tl_engine = get_engine();
-            LOG_DEBUG("[GrapherRecordingService] Engine addr: {}, ThreadID={}", (void*)&tl_engine
-                      , tl::thread::self_id());
+            LOG_DEBUG("[GrapherRecordingService] Engine addr: {}, ThreadID={}",
+                      (void*)&tl_engine,
+                      tl::thread::self_id());
             tl::bulk local = tl_engine.expose(segments, tl::bulk_mode::write_only);
             LOG_DEBUG("[GrapherRecordingService] Bulk memory exposed, ThreadID={}", tl::thread::self_id());
             b.on(ep) >> local;
-            LOG_DEBUG("[GrapherRecordingService] Received {} bytes of StoryChunk data, ThreadID={}", b.size()
-                      , tl::thread::self_id());
+            LOG_DEBUG("[GrapherRecordingService] Received {} bytes of StoryChunk data, ThreadID={}",
+                      b.size(),
+                      tl::thread::self_id());
 
-            StoryChunk*story_chunk = new StoryChunk();
+            StoryChunk* story_chunk = new StoryChunk();
 #ifndef NDEBUG
             start = std::chrono::high_resolution_clock::now();
 #endif
-            int ret = deserializedWithCereal(&mem_vec[0], b.size()
-                                             , *story_chunk);
+            int ret = deserializedWithCereal(&mem_vec[0], b.size(), *story_chunk);
             if(ret != chronolog::CL_SUCCESS)
             {
-                LOG_ERROR("[GrapherRecordingService] Failed to deserialize a story chunk, ThreadID={}"
-                          , tl::thread::self_id());
+                LOG_ERROR("[GrapherRecordingService] Failed to deserialize a story chunk, ThreadID={}",
+                          tl::thread::self_id());
                 delete story_chunk;
                 ret = 10000000 + tl::thread::self_id(); // arbitrary error code encoded with thread id
                 LOG_ERROR("[GrapherRecordingService] Discarding the story chunk, responding {} to Keeper", ret);
@@ -80,39 +82,43 @@ public:
 #ifndef NDEBUG
             end = std::chrono::high_resolution_clock::now();
             LOG_INFO("[GrapherRecordingService] Deserialization took {} us, ThreadID={}",
-                    std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0
-                     , tl::thread::self_id());
+                     std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count() / 1000.0,
+                     tl::thread::self_id());
 #endif
-            LOG_DEBUG("[GrapherRecordingService] StoryChunk received: StoryId {} StartTime {} eventCount {} ThreadID={}"
-                      , story_chunk->getStoryId(), story_chunk->getStartTime(), story_chunk->getEventCount()
-                      , tl::thread::self_id());
+            LOG_DEBUG(
+                    "[GrapherRecordingService] StoryChunk received: StoryId {} StartTime {} eventCount {} ThreadID={}",
+                    story_chunk->getStoryId(),
+                    story_chunk->getStartTime(),
+                    story_chunk->getEventCount(),
+                    tl::thread::self_id());
 
             request.respond(b.size());
-            LOG_DEBUG("[GrapherRecordingService] StoryChunk recording RPC responded {}, ThreadID={}", b.size()
-                      , tl::thread::self_id());
+            LOG_DEBUG("[GrapherRecordingService] StoryChunk recording RPC responded {}, ThreadID={}",
+                      b.size(),
+                      tl::thread::self_id());
 
             theIngestionQueue.ingestStoryChunk(story_chunk);
         }
-        catch(std::bad_alloc const &ex)
+        catch(std::bad_alloc const& ex)
         {
-            LOG_ERROR("[GrapherRecordingService] Failed to allocate memory for StoryChunk data, ThreadID={}"
-                      , tl::thread::self_id());
+            LOG_ERROR("[GrapherRecordingService] Failed to allocate memory for StoryChunk data, ThreadID={}",
+                      tl::thread::self_id());
             request.respond(20000000 + tl::thread::self_id());
             return;
         }
     }
 
 private:
-    GrapherRecordingService(tl::engine &tl_engine, uint16_t service_provider_id, ChunkIngestionQueue &ingestion_queue)
-            : tl::provider <GrapherRecordingService>(tl_engine, service_provider_id), theIngestionQueue(ingestion_queue)
+    GrapherRecordingService(tl::engine& tl_engine, uint16_t service_provider_id, ChunkIngestionQueue& ingestion_queue)
+        : tl::provider<GrapherRecordingService>(tl_engine, service_provider_id)
+        , theIngestionQueue(ingestion_queue)
     {
         define("record_story_chunk", &GrapherRecordingService::record_story_chunk, tl::ignore_return_value());
         //set up callback for the case when the engine is being finalized while this provider is still alive
-        get_engine().push_finalize_callback(this, [p = this]()
-        { delete p; });
+        get_engine().push_finalize_callback(this, [p = this]() { delete p; });
     }
 
-    int deserializedWithCereal(char *buffer, size_t size, StoryChunk &story_chunk)
+    int deserializedWithCereal(char* buffer, size_t size, StoryChunk& story_chunk)
     {
         std::stringstream ss(std::ios::binary | std::ios::in | std::ios::out);
         try
@@ -122,35 +128,40 @@ private:
             iarchive(story_chunk);
             return chronolog::CL_SUCCESS;
         }
-        catch(cereal::Exception const &ex)
+        catch(cereal::Exception const& ex)
         {
             LOG_ERROR("[GrapherRecordingService] Failed to deserialize a story chunk, size={}, ThreadID={}. "
-                      "Cereal exception encountered.", ss.str().size(), tl::thread::self_id());
+                      "Cereal exception encountered.",
+                      ss.str().size(),
+                      tl::thread::self_id());
             LOG_ERROR("[GrapherRecordingService] Exception: {}", ex.what());
             return chronolog::CL_ERR_UNKNOWN;
         }
-        catch(std::exception const &ex)
+        catch(std::exception const& ex)
         {
             LOG_ERROR("[GrapherRecordingService] Failed to deserialize a story chunk, size={}, ThreadID={}. "
-                      "std::exception encountered.", ss.str().size(), tl::thread::self_id());
+                      "std::exception encountered.",
+                      ss.str().size(),
+                      tl::thread::self_id());
             LOG_ERROR("[GrapherRecordingService] Exception: {}", ex.what());
             return chronolog::CL_ERR_UNKNOWN;
         }
         catch(...)
         {
             LOG_ERROR("[GrapherRecordingService] Failed to deserialize a story chunk, ThreadID={}. Unknown exception "
-                      "encountered.", tl::thread::self_id());
+                      "encountered.",
+                      tl::thread::self_id());
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
 
-    GrapherRecordingService(GrapherRecordingService const &) = delete;
+    GrapherRecordingService(GrapherRecordingService const&) = delete;
 
-    GrapherRecordingService &operator=(GrapherRecordingService const &) = delete;
+    GrapherRecordingService& operator=(GrapherRecordingService const&) = delete;
 
-    ChunkIngestionQueue &theIngestionQueue;
+    ChunkIngestionQueue& theIngestionQueue;
 };
 
-}// namespace chronolog
+} // namespace chronolog
 
 #endif

--- a/ChronoGrapher/include/GrapherRecordingService.h
+++ b/ChronoGrapher/include/GrapherRecordingService.h
@@ -2,6 +2,10 @@
 #define GRAPHER_RECORDING_SERVICE_H
 
 #include <iostream>
+#include <vector>
+#include <chrono>
+#include <sstream>
+#include <exception>
 #include <margo.h>
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>
@@ -10,6 +14,7 @@
 #include <chronolog_errcode.h>
 #include <KeeperIdCard.h>
 #include <chronolog_types.h>
+#include <StoryChunk.h>
 
 #include "ChunkIngestionQueue.h"
 

--- a/ChronoGrapher/include/GrapherRegClient.h
+++ b/ChronoGrapher/include/GrapherRegClient.h
@@ -2,10 +2,10 @@
 #define GRAPHER_REG_CLIENT_H
 
 #include <iostream>
-#include <string>
 #include <sstream>
-#include <thallium/serialization/stl/string.hpp>
+#include <string>
 #include <thallium.hpp>
+#include <thallium/serialization/stl/string.hpp>
 
 #include <GrapherIdCard.h>
 #include <GrapherRegistrationMsg.h>

--- a/ChronoGrapher/include/GrapherRegClient.h
+++ b/ChronoGrapher/include/GrapherRegClient.h
@@ -24,21 +24,20 @@ class GrapherRegistryClient
 
 public:
     static GrapherRegistryClient*
-    CreateRegistryClient(tl::engine &tl_engine, std::string const &registry_service_addr
-                               , uint16_t registry_provider_id)
+    CreateRegistryClient(tl::engine& tl_engine, std::string const& registry_service_addr, uint16_t registry_provider_id)
     {
         try
         {
             return new GrapherRegistryClient(tl_engine, registry_service_addr, registry_provider_id);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[GrapherRegistryClient] Failed to create GrapherRegistryClient");
             return nullptr;
         }
     }
 
-    int send_register_msg(GrapherRegistrationMsg const & grapherMsg)
+    int send_register_msg(GrapherRegistrationMsg const& grapherMsg)
     {
         try
         {
@@ -47,14 +46,14 @@ public:
             LOG_DEBUG("[GrapherRegistryClient] Sending Registration Message: {}", ss.str());
             return register_grapher.on(reg_service_ph)(grapherMsg);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[GrapherRegistryClient] Failed Sending Registration Message.");
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
 
-    int send_unregister_msg(GrapherIdCard const &grapherIdCard)
+    int send_unregister_msg(GrapherIdCard const& grapherIdCard)
     {
         try
         {
@@ -63,14 +62,14 @@ public:
             LOG_DEBUG("[GrapherRegistryClient] Sending Unregister Message: {}", ss.str());
             return unregister_grapher.on(reg_service_ph)(grapherIdCard);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[GrapherRegistryClient] Failed Sending Unregistered Message.");
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
 
-    void send_stats_msg(GrapherStatsMsg const & statsMsg)
+    void send_stats_msg(GrapherStatsMsg const& statsMsg)
     {
         try
         {
@@ -79,7 +78,7 @@ public:
             LOG_DEBUG("[GrapherRegistryClient] Sending Stats Message: {}", stats.str());
             handle_grapher_stats_msg.on(reg_service_ph)(statsMsg);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[GrapherRegisterClient] Failed Sending Stats Message.");
         }
@@ -94,25 +93,27 @@ public:
     }
 
 private:
-    std::string reg_service_addr;     // na address of Keeper Registry Service 
-    uint16_t reg_service_provider_id;          // KeeperRegistryService provider id
-    tl::provider_handle reg_service_ph;  //provider_handle for remote registry service
+    std::string reg_service_addr;       // na address of Keeper Registry Service
+    uint16_t reg_service_provider_id;   // KeeperRegistryService provider id
+    tl::provider_handle reg_service_ph; //provider_handle for remote registry service
     tl::remote_procedure register_grapher;
     tl::remote_procedure unregister_grapher;
     tl::remote_procedure handle_grapher_stats_msg;
 
     // constructor is private to make sure thalium rpc objects are created on the heap, not stack
-    GrapherRegistryClient(tl::engine &tl_engine, std::string const &registry_addr, uint16_t registry_provider_id)
-            : reg_service_addr(registry_addr), reg_service_provider_id(registry_provider_id), reg_service_ph(
-            tl_engine.lookup(registry_addr), registry_provider_id)
+    GrapherRegistryClient(tl::engine& tl_engine, std::string const& registry_addr, uint16_t registry_provider_id)
+        : reg_service_addr(registry_addr)
+        , reg_service_provider_id(registry_provider_id)
+        , reg_service_ph(tl_engine.lookup(registry_addr), registry_provider_id)
     {
-        LOG_DEBUG("[GrapherRegistryClient] Initialized for RegistryService at {} with ProviderID={}", registry_addr
-             , registry_provider_id);
+        LOG_DEBUG("[GrapherRegistryClient] Initialized for RegistryService at {} with ProviderID={}",
+                  registry_addr,
+                  registry_provider_id);
         register_grapher = tl_engine.define("register_grapher");
         unregister_grapher = tl_engine.define("unregister_grapher");
         handle_grapher_stats_msg = tl_engine.define("handle_grapher_stats_msg").disable_response();
     }
 };
-}
+} // namespace chronolog
 
 #endif

--- a/ChronoGrapher/include/GrapherRegClient.h
+++ b/ChronoGrapher/include/GrapherRegClient.h
@@ -2,6 +2,8 @@
 #define GRAPHER_REG_CLIENT_H
 
 #include <iostream>
+#include <string>
+#include <sstream>
 #include <thallium/serialization/stl/string.hpp>
 #include <thallium.hpp>
 

--- a/ChronoGrapher/include/HDF5FileChunkExtractor.h
+++ b/ChronoGrapher/include/HDF5FileChunkExtractor.h
@@ -12,17 +12,17 @@ namespace chronolog
 class HDF5FileChunkExtractor: public StoryChunkExtractorBase
 {
 public:
-    HDF5FileChunkExtractor(std::string const &chrono_process_id_card, std::string const &hdf5_files_root_dir);
+    HDF5FileChunkExtractor(std::string const& chrono_process_id_card, std::string const& hdf5_files_root_dir);
 
     ~HDF5FileChunkExtractor();
 
-    virtual int processStoryChunk(StoryChunk *);
+    virtual int processStoryChunk(StoryChunk*);
 
 private:
     std::string chrono_process_id;
     std::string rootDirectory;
 };
 
-} // chronolog
+} // namespace chronolog
 
 #endif //CHRONOLOG_HDF5_FILE_CHUNK_EXTRACTOR_H

--- a/ChronoGrapher/include/HDF5FileChunkExtractor.h
+++ b/ChronoGrapher/include/HDF5FileChunkExtractor.h
@@ -1,6 +1,9 @@
 #ifndef CHRONOLOG_HDF5_FILE_CHUNK_EXTRACTOR_H
 #define CHRONOLOG_HDF5_FILE_CHUNK_EXTRACTOR_H
 
+#include <string>
+
+#include <StoryChunk.h>
 #include <StoryChunkExtractor.h>
 
 namespace chronolog

--- a/ChronoGrapher/src/CSVFileChunkExtractor.cpp
+++ b/ChronoGrapher/src/CSVFileChunkExtractor.cpp
@@ -8,9 +8,10 @@
 
 namespace tl = thallium;
 
-chronolog::CSVFileStoryChunkExtractor::CSVFileStoryChunkExtractor(std::string const &process_id_card
-                                                                  , std::string const &csv_files_root_dir)
-        : chrono_process_id(process_id_card), rootDirectory(csv_files_root_dir)
+chronolog::CSVFileStoryChunkExtractor::CSVFileStoryChunkExtractor(std::string const& process_id_card,
+                                                                  std::string const& csv_files_root_dir)
+    : chrono_process_id(process_id_card)
+    , rootDirectory(csv_files_root_dir)
 {}
 
 /////////////
@@ -20,7 +21,7 @@ chronolog::CSVFileStoryChunkExtractor::~CSVFileStoryChunkExtractor()
 }
 
 /////////////
-int chronolog::CSVFileStoryChunkExtractor::processStoryChunk(chronolog::StoryChunk*story_chunk)
+int chronolog::CSVFileStoryChunkExtractor::processStoryChunk(chronolog::StoryChunk* story_chunk)
 {
     std::ofstream chunk_fstream;
     std::string chunk_filename(rootDirectory);
@@ -29,14 +30,17 @@ int chronolog::CSVFileStoryChunkExtractor::processStoryChunk(chronolog::StoryChu
                       std::to_string(story_chunk->getEndTime() / 1000000000) + ".csv";
 
     tl::xstream es = tl::xstream::self();
-    LOG_DEBUG("[CSVFileStoryChunkExtractor] Processing StoryChunk: ES={}, ULT={}, StoryID={}, StartTime={}"
-              , es.get_rank(), tl::thread::self_id(), story_chunk->getStoryId(), story_chunk->getStartTime());
-    // current thread if the only one that has this storyChunk and the only one that's writing to this chunk csv file 
-    // thus no additional locking is needed ... 
-    chunk_fstream.open(chunk_filename, std::ofstream::out|std::ofstream::app);
+    LOG_DEBUG("[CSVFileStoryChunkExtractor] Processing StoryChunk: ES={}, ULT={}, StoryID={}, StartTime={}",
+              es.get_rank(),
+              tl::thread::self_id(),
+              story_chunk->getStoryId(),
+              story_chunk->getStartTime());
+    // current thread if the only one that has this storyChunk and the only one that's writing to this chunk csv file
+    // thus no additional locking is needed ...
+    chunk_fstream.open(chunk_filename, std::ofstream::out | std::ofstream::app);
     for(auto event_iter = story_chunk->begin(); event_iter != story_chunk->end(); ++event_iter)
     {
-        chronolog::LogEvent const &event = (*event_iter).second;
+        chronolog::LogEvent const& event = (*event_iter).second;
         chunk_fstream << event << std::endl;
     }
     chunk_fstream.close();

--- a/ChronoGrapher/src/CSVFileChunkExtractor.cpp
+++ b/ChronoGrapher/src/CSVFileChunkExtractor.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <fstream>
+#include <string>
 #include <thallium.hpp>
 
 #include <chronolog_types.h>

--- a/ChronoGrapher/src/CSVFileChunkExtractor.cpp
+++ b/ChronoGrapher/src/CSVFileChunkExtractor.cpp
@@ -1,10 +1,11 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <thallium.hpp>
 
 #include <chronolog_types.h>
-#include <CSVFileChunkExtractor.h>
+
+#include "CSVFileChunkExtractor.h"
 
 namespace tl = thallium;
 

--- a/ChronoGrapher/src/ChronoGrapher.cpp
+++ b/ChronoGrapher/src/ChronoGrapher.cpp
@@ -26,8 +26,7 @@ namespace chl = chronolog;
 
 // we will be using a combination of the uint32_t representation of the service IP address
 // and uint16_t representation of the port number
-int
-service_endpoint_from_dotted_string(std::string const &ip_string, int port, std::pair <uint32_t, uint16_t> &endpoint)
+int service_endpoint_from_dotted_string(std::string const& ip_string, int port, std::pair<uint32_t, uint16_t>& endpoint)
 {
     // we will be using a combination of the uint32_t representation of the service IP address
     // and uint16_t representation of the port number
@@ -46,7 +45,7 @@ service_endpoint_from_dotted_string(std::string const &ip_string, int port, std:
     // translate 32bit ip from network into the host byte order
     uint32_t ntoh_ip_addr = ntohl(sa.sin_addr.s_addr);
     uint16_t ntoh_port = port;
-    endpoint = std::pair <uint32_t, uint16_t>(ntoh_ip_addr, ntoh_port);
+    endpoint = std::pair<uint32_t, uint16_t>(ntoh_ip_addr, ntoh_port);
 
     LOG_DEBUG("[ChronoGrapher] Service endpoint created: IP={}, Port={}", ip_string, port);
     return 1;
@@ -63,7 +62,7 @@ void sigterm_handler(int)
 
 ///////////////////////////////////////////////
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     int exit_code = 0;
     signal(SIGTERM, sigterm_handler);
@@ -73,25 +72,25 @@ int main(int argc, char**argv)
     conf_file_path = parse_conf_path_arg(argc, argv);
     if(conf_file_path.empty())
     {
-        std::cerr <<" ChronoGrapher needs the configuration file to start";
+        std::cerr << " ChronoGrapher needs the configuration file to start";
         std::exit(EXIT_FAILURE);
     }
 
     chronolog::ConfigurationManager confManager(conf_file_path);
     chronolog::GrapherConfiguration GRAPHER_CONF = confManager.GRAPHER_CONF;
 
-    std::cout << "ChronoGrapher Configuration "<< GRAPHER_CONF.to_String()<<std::endl;
+    std::cout << "ChronoGrapher Configuration " << GRAPHER_CONF.to_String() << std::endl;
 
-    int result = chronolog::chrono_monitor::initialize(GRAPHER_CONF.LOG_CONF.LOGTYPE
-                                                       , GRAPHER_CONF.LOG_CONF.LOGFILE
-                                                       , GRAPHER_CONF.LOG_CONF.LOGLEVEL
-                                                       , GRAPHER_CONF.LOG_CONF.LOGNAME
-                                                       , GRAPHER_CONF.LOG_CONF.LOGFILESIZE
-                                                       , GRAPHER_CONF.LOG_CONF.LOGFILENUM
-                                                       , GRAPHER_CONF.LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize(GRAPHER_CONF.LOG_CONF.LOGTYPE,
+                                                       GRAPHER_CONF.LOG_CONF.LOGFILE,
+                                                       GRAPHER_CONF.LOG_CONF.LOGLEVEL,
+                                                       GRAPHER_CONF.LOG_CONF.LOGNAME,
+                                                       GRAPHER_CONF.LOG_CONF.LOGFILESIZE,
+                                                       GRAPHER_CONF.LOG_CONF.LOGFILENUM,
+                                                       GRAPHER_CONF.LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
-        std::cerr <<" ChronoGrapher failed to initialize chrono_monitor, check the configuration settings";
+        std::cerr << " ChronoGrapher failed to initialize chrono_monitor, check the configuration settings";
         exit(EXIT_FAILURE);
     }
 
@@ -104,9 +103,8 @@ int main(int argc, char**argv)
     /// DataStoreAdminService setup ____________________________________________________________________________________
     std::string datastore_service_ip = GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.IP;
     int datastore_service_port = GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.BASE_PORT;
-    std::string DATASTORE_SERVICE_NA_STRING =
-            GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF + "://" + datastore_service_ip + ":" +
-            std::to_string(datastore_service_port);
+    std::string DATASTORE_SERVICE_NA_STRING = GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF + "://" +
+                                              datastore_service_ip + ":" + std::to_string(datastore_service_port);
 
     uint16_t datastore_service_provider_id = GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.SERVICE_PROVIDER_ID;
 
@@ -118,9 +116,10 @@ int main(int argc, char**argv)
         LOG_CRITICAL("[ChronoGrapher] Failed to start DataStoreAdminService. Invalid endpoint provided.");
         return (-1);
     }
-    
+
     chronolog::ServiceId dataStoreServiceId(GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF,
-                datastore_endpoint, GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.SERVICE_PROVIDER_ID);
+                                            datastore_endpoint,
+                                            GRAPHER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.SERVICE_PROVIDER_ID);
 
     // Instantiate GrapherRecordingService
     chronolog::RecordingGroupId recording_group_id = GRAPHER_CONF.RECORDING_GROUP;
@@ -128,16 +127,16 @@ int main(int argc, char**argv)
     std::string RECORDING_SERVICE_IP = GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.IP;
     uint16_t RECORDING_SERVICE_PORT = GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.BASE_PORT;
     uint16_t recording_service_provider_id = GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.SERVICE_PROVIDER_ID;
-    
+
     chl::ServiceId recordingServiceId(GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.PROTO_CONF,
-                GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.IP,
-                GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.BASE_PORT,
-                GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.SERVICE_PROVIDER_ID);
+                                      GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.IP,
+                                      GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.BASE_PORT,
+                                      GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.SERVICE_PROVIDER_ID);
 
 
     std::string RECORDING_SERVICE_NA_STRING;
     recordingServiceId.get_service_as_string(RECORDING_SERVICE_NA_STRING);
-    
+
     // validate ip address, instantiate Recording Service and create IdCard
 
     chronolog::service_endpoint recording_endpoint;
@@ -157,34 +156,36 @@ int main(int argc, char**argv)
     chronolog::ChunkIngestionQueue ingestionQueue;
     std::string csv_files_directory = GRAPHER_CONF.EXTRACTOR_CONF.story_files_dir;
 
-//    chronolog::CSVFileStoryChunkExtractor storyExtractor(process_id_string.str(), csv_files_directory);
+    //    chronolog::CSVFileStoryChunkExtractor storyExtractor(process_id_string.str(), csv_files_directory);
     chronolog::HDF5FileChunkExtractor storyExtractor(chl::to_string(processIdCard), csv_files_directory);
 
-    chronolog::GrapherDataStore theDataStore(ingestionQueue, storyExtractor.getExtractionQueue(),
-                GRAPHER_CONF.DATA_STORE_CONF.max_story_chunk_size,
-                GRAPHER_CONF.DATA_STORE_CONF.story_chunk_duration_secs,
-                GRAPHER_CONF.DATA_STORE_CONF.acceptance_window_secs,
-                GRAPHER_CONF.DATA_STORE_CONF.inactive_story_delay_secs);
+    chronolog::GrapherDataStore theDataStore(ingestionQueue,
+                                             storyExtractor.getExtractionQueue(),
+                                             GRAPHER_CONF.DATA_STORE_CONF.max_story_chunk_size,
+                                             GRAPHER_CONF.DATA_STORE_CONF.story_chunk_duration_secs,
+                                             GRAPHER_CONF.DATA_STORE_CONF.acceptance_window_secs,
+                                             GRAPHER_CONF.DATA_STORE_CONF.inactive_story_delay_secs);
 
-    tl::engine*dataAdminEngine = nullptr;
+    tl::engine* dataAdminEngine = nullptr;
 
-    chronolog::DataStoreAdminService*grapherDataAdminService = nullptr;
+    chronolog::DataStoreAdminService* grapherDataAdminService = nullptr;
 
     try
     {
-        margo_instance_id collection_margo_id = margo_init(DATASTORE_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1
-                                                           , 1);
+        margo_instance_id collection_margo_id =
+                margo_init(DATASTORE_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1, 1);
 
         dataAdminEngine = new tl::engine(collection_margo_id);
 
         std::stringstream s3;
         s3 << dataAdminEngine->self();
         LOG_DEBUG("[ChronoGrapher] starting DataStoreAdminService at {} ", chl::to_string(dataStoreServiceId));
-        grapherDataAdminService = chronolog::DataStoreAdminService::CreateDataStoreAdminService(*dataAdminEngine
-                                                                                                , datastore_service_provider_id
-                                                                                                , theDataStore);
+        grapherDataAdminService =
+                chronolog::DataStoreAdminService::CreateDataStoreAdminService(*dataAdminEngine,
+                                                                              datastore_service_provider_id,
+                                                                              theDataStore);
     }
-    catch(tl::exception const &)
+    catch(tl::exception const&)
     {
         LOG_ERROR("[ChronoGrapher]  failed to create DataStoreAdminService");
         grapherDataAdminService = nullptr;
@@ -198,8 +199,8 @@ int main(int argc, char**argv)
     LOG_INFO("[ChronoGrapher] DataStoreAdminService started successfully.");
 
     // Instantiate RecordingService
-    tl::engine*recordingEngine = nullptr;
-    chronolog::GrapherRecordingService*grapherRecordingService = nullptr;
+    tl::engine* recordingEngine = nullptr;
+    chronolog::GrapherRecordingService* grapherRecordingService = nullptr;
 
     try
     {
@@ -208,13 +209,15 @@ int main(int argc, char**argv)
 
         std::stringstream s1;
         s1 << recordingEngine->self();
-        LOG_INFO("[ChronoGrapher] starting RecordingService at {} with provider_id {}", s1.str()
-                 , recording_service_provider_id);
-        grapherRecordingService = chronolog::GrapherRecordingService::CreateRecordingService(*recordingEngine
-                                                                                             , recording_service_provider_id
-                                                                                             , ingestionQueue);
+        LOG_INFO("[ChronoGrapher] starting RecordingService at {} with provider_id {}",
+                 s1.str(),
+                 recording_service_provider_id);
+        grapherRecordingService =
+                chronolog::GrapherRecordingService::CreateRecordingService(*recordingEngine,
+                                                                           recording_service_provider_id,
+                                                                           ingestionQueue);
     }
-    catch(tl::exception const &)
+    catch(tl::exception const&)
     {
         LOG_ERROR("[ChronoGrapher] failed to create RecordingService");
         grapherRecordingService = nullptr;
@@ -235,8 +238,10 @@ int main(int argc, char**argv)
 
     uint16_t REGISTRY_SERVICE_PROVIDER_ID = GRAPHER_CONF.VISOR_REGISTRY_SERVICE_CONF.SERVICE_PROVIDER_ID;
 
-    chronolog::GrapherRegistryClient*grapherRegistryClient = chronolog::GrapherRegistryClient::CreateRegistryClient(
-            *dataAdminEngine, REGISTRY_SERVICE_NA_STRING, REGISTRY_SERVICE_PROVIDER_ID);
+    chronolog::GrapherRegistryClient* grapherRegistryClient =
+            chronolog::GrapherRegistryClient::CreateRegistryClient(*dataAdminEngine,
+                                                                   REGISTRY_SERVICE_NA_STRING,
+                                                                   REGISTRY_SERVICE_PROVIDER_ID);
 
     if(nullptr == grapherRegistryClient)
     {
@@ -250,7 +255,7 @@ int main(int argc, char**argv)
     // try to register with chronoVisor a few times than log ERROR and exit...
     int registration_status = grapherRegistryClient->send_register_msg(
             chronolog::GrapherRegistrationMsg(processIdCard, dataStoreServiceId));
-    //if the first attemp failes retry 
+    //if the first attemp failes retry
     int retries = 5;
     while((chronolog::CL_SUCCESS != registration_status) && (retries > 0))
     {

--- a/ChronoGrapher/src/ChronoGrapher.cpp
+++ b/ChronoGrapher/src/ChronoGrapher.cpp
@@ -1,6 +1,13 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <signal.h>
+#include <string>
+#include <iostream>
+#include <cstdlib>
+#include <utility>
+#include <sstream>
+#include <mutex>
+#include <chrono>
 
 #include <GrapherIdCard.h>
 #include <GrapherRecordingService.h>

--- a/ChronoGrapher/src/GrapherDataStore.cpp
+++ b/ChronoGrapher/src/GrapherDataStore.cpp
@@ -15,11 +15,15 @@ namespace tl = thallium;
 
 ////////////////////////
 
-int chronolog::GrapherDataStore::startStoryRecording(std::string const &chronicle, std::string const &story
-                                                    , chronolog::StoryId const &story_id, uint64_t start_time)
+int chronolog::GrapherDataStore::startStoryRecording(std::string const& chronicle,
+                                                     std::string const& story,
+                                                     chronolog::StoryId const& story_id,
+                                                     uint64_t start_time)
 {
-    LOG_INFO("[GrapherDataStore] Start recording story: Chronicle={}, Story={}, StoryId={}"
-             , chronicle, story, story_id);
+    LOG_INFO("[GrapherDataStore] Start recording story: Chronicle={}, Story={}, StoryId={}",
+             chronicle,
+             story,
+             story_id);
 
     // Get dataStoreMutex, check for story_id_presence & add new StoryPipeline if needed
     std::lock_guard storeLock(dataStoreMutex);
@@ -39,28 +43,35 @@ int chronolog::GrapherDataStore::startStoryRecording(std::string const &chronicl
     }
 
     auto result = theMapOfStoryPipelines.emplace(
-            std::pair <chl::StoryId, chl::StoryPipeline*>(story_id, new chl::StoryPipeline(theExtractionQueue, chronicle, story, story_id, start_time
-                                                        , story_chunk_duration_secs, acceptance_window_secs)));
+            std::pair<chl::StoryId, chl::StoryPipeline*>(story_id,
+                                                         new chl::StoryPipeline(theExtractionQueue,
+                                                                                chronicle,
+                                                                                story,
+                                                                                story_id,
+                                                                                start_time,
+                                                                                story_chunk_duration_secs,
+                                                                                acceptance_window_secs)));
 
     if(result.second)
     {
         LOG_INFO("[GrapherDataStore] New StoryPipeline created successfully. StoryId {}", story_id);
         pipeline_iter = result.first;
         //engage StoryPipeline with the IngestionQueue
-        chl::StoryChunkIngestionHandle*ingestionHandle = (*pipeline_iter).second->getActiveIngestionHandle();
+        chl::StoryChunkIngestionHandle* ingestionHandle = (*pipeline_iter).second->getActiveIngestionHandle();
         theIngestionQueue.addStoryIngestionHandle(story_id, ingestionHandle);
         return chronolog::CL_SUCCESS;
     }
     else
     {
-        LOG_ERROR("[GrapherDataStore] Failed to create StoryPipeline for StoryId: {}. Possible memory or resource issue."
-                  , story_id);
+        LOG_ERROR(
+                "[GrapherDataStore] Failed to create StoryPipeline for StoryId: {}. Possible memory or resource issue.",
+                story_id);
         return chronolog::CL_ERR_UNKNOWN;
     }
 }
 ////////////////////////
 
-int chronolog::GrapherDataStore::stopStoryRecording(chronolog::StoryId const &story_id)
+int chronolog::GrapherDataStore::stopStoryRecording(chronolog::StoryId const& story_id)
 {
     LOG_DEBUG("[GrapherDataStore] Initiating stop recording for StoryId={}", story_id);
     // we do not yet disengage the StoryPipeline from the IngestionQueue right away
@@ -71,13 +82,18 @@ int chronolog::GrapherDataStore::stopStoryRecording(chronolog::StoryId const &st
     auto pipeline_iter = theMapOfStoryPipelines.find(story_id);
     if(pipeline_iter != theMapOfStoryPipelines.end())
     {
-        uint64_t exit_time = std::chrono::high_resolution_clock::now().time_since_epoch().count() + inactive_pipeline_delay_secs*1000000000;
-                            // (*pipeline_iter).second->getAcceptanceWindow();
-        pipelinesWaitingForExit[(*pipeline_iter).first] = (std::pair <chl::StoryPipeline*, uint64_t>(
-                (*pipeline_iter).second, exit_time));
-        LOG_INFO("[GrapherDataStore] Scheduled pipeline to retire: StoryId {} timeline {}-{} acceptanceWindow {} retirementTime {}",
-                (*pipeline_iter).second->getStoryId(), (*pipeline_iter).second->TimelineStart(), (*pipeline_iter).second->TimelineEnd(),
-                (*pipeline_iter).second->getAcceptanceWindow(), exit_time);
+        uint64_t exit_time = std::chrono::high_resolution_clock::now().time_since_epoch().count() +
+                             inactive_pipeline_delay_secs * 1000000000;
+        // (*pipeline_iter).second->getAcceptanceWindow();
+        pipelinesWaitingForExit[(*pipeline_iter).first] =
+                (std::pair<chl::StoryPipeline*, uint64_t>((*pipeline_iter).second, exit_time));
+        LOG_INFO("[GrapherDataStore] Scheduled pipeline to retire: StoryId {} timeline {}-{} acceptanceWindow {} "
+                 "retirementTime {}",
+                 (*pipeline_iter).second->getStoryId(),
+                 (*pipeline_iter).second->TimelineStart(),
+                 (*pipeline_iter).second->TimelineEnd(),
+                 (*pipeline_iter).second->getAcceptanceWindow(),
+                 exit_time);
     }
     else
     {
@@ -91,13 +107,16 @@ int chronolog::GrapherDataStore::stopStoryRecording(chronolog::StoryId const &st
 void chronolog::GrapherDataStore::collectIngestedEvents()
 {
     LOG_DEBUG("[GrapherDataStore] Initiating collection of ingested story chunks. Current state={}, Active "
-              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-              , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
     theIngestionQueue.drainOrphanChunks();
 
     std::lock_guard storeLock(dataStoreMutex);
-    for(auto pipeline_iter = theMapOfStoryPipelines.begin();
-        pipeline_iter != theMapOfStoryPipelines.end(); ++pipeline_iter)
+    for(auto pipeline_iter = theMapOfStoryPipelines.begin(); pipeline_iter != theMapOfStoryPipelines.end();
+        ++pipeline_iter)
     {
         //INNA: this can be delegated to different threads handling individual storylines...
         (*pipeline_iter).second->collectIngestedEvents();
@@ -107,14 +126,18 @@ void chronolog::GrapherDataStore::collectIngestedEvents()
 ////////////////////////
 void chronolog::GrapherDataStore::extractDecayedStoryChunks()
 {
-    LOG_DEBUG("[GrapherDataStore] Initiating extraction of decayed story chunks. Current state={}, Active StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-              , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+    LOG_DEBUG("[GrapherDataStore] Initiating extraction of decayed story chunks. Current state={}, Active "
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
 
     uint64_t current_time = std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
     std::lock_guard storeLock(dataStoreMutex);
-    for(auto pipeline_iter = theMapOfStoryPipelines.begin();
-        pipeline_iter != theMapOfStoryPipelines.end(); ++pipeline_iter)
+    for(auto pipeline_iter = theMapOfStoryPipelines.begin(); pipeline_iter != theMapOfStoryPipelines.end();
+        ++pipeline_iter)
     {
         (*pipeline_iter).second->extractDecayedStoryChunks(current_time);
     }
@@ -123,8 +146,12 @@ void chronolog::GrapherDataStore::extractDecayedStoryChunks()
 
 void chronolog::GrapherDataStore::retireDecayedPipelines()
 {
-    LOG_TRACE("[GrapherDataStore] Initiating retirement of decayed pipelines. Current state={}, Active StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-              , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+    LOG_TRACE("[GrapherDataStore] Initiating retirement of decayed pipelines. Current state={}, Active "
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
 
     if(!theMapOfStoryPipelines.empty())
     {
@@ -136,22 +163,32 @@ void chronolog::GrapherDataStore::retireDecayedPipelines()
             if(current_time >= (*pipeline_iter).second.second)
             {
                 //current_time >= pipeline exit_time
-                StoryPipeline * pipeline = (*pipeline_iter).second.first;
-                LOG_DEBUG("[GrapherDataStore] retiring pipeline StoryId {} timeline {}-{} acceptanceWindow {} retirementTime {}",
-                        pipeline->getStoryId(), pipeline->TimelineStart(), pipeline->TimelineEnd(), pipeline->getAcceptanceWindow(), (*pipeline_iter).second.second);
+                StoryPipeline* pipeline = (*pipeline_iter).second.first;
+                LOG_DEBUG("[GrapherDataStore] retiring pipeline StoryId {} timeline {}-{} acceptanceWindow {} "
+                          "retirementTime {}",
+                          pipeline->getStoryId(),
+                          pipeline->TimelineStart(),
+                          pipeline->TimelineEnd(),
+                          pipeline->getAcceptanceWindow(),
+                          (*pipeline_iter).second.second);
                 theMapOfStoryPipelines.erase(pipeline->getStoryId());
                 theIngestionQueue.removeStoryIngestionHandle(pipeline->getStoryId());
                 pipeline_iter = pipelinesWaitingForExit.erase(pipeline_iter);
                 delete pipeline;
             }
             else
-            { pipeline_iter++; }
-
+            {
+                pipeline_iter++;
+            }
         }
     }
 
-    LOG_TRACE("[GrapherDataStore] Completed retirement of decayed pipelines. Current state={}, Active StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-              , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+    LOG_TRACE("[GrapherDataStore] Completed retirement of decayed pipelines. Current state={}, Active "
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
 }
 
 void chronolog::GrapherDataStore::dataCollectionTask()
@@ -160,13 +197,15 @@ void chronolog::GrapherDataStore::dataCollectionTask()
     // or there're still events left to collect and
     // storyPipelines left to retire...
     tl::xstream es = tl::xstream::self();
-    LOG_DEBUG("[GrapherDataStore] Initiating DataCollectionTask. ESrank={}, ThreadID={}", es.get_rank()
-              , tl::thread::self_id());
+    LOG_DEBUG("[GrapherDataStore] Initiating DataCollectionTask. ESrank={}, ThreadID={}",
+              es.get_rank(),
+              tl::thread::self_id());
 
     while(!is_shutting_down() || !theIngestionQueue.is_empty() || !theMapOfStoryPipelines.empty())
     {
-        LOG_DEBUG("[GrapherDataStore] Running DataCollection iteration. ESrank={}, ThreadID={}", es.get_rank()
-                  , tl::thread::self_id());
+        LOG_DEBUG("[GrapherDataStore] Running DataCollection iteration. ESrank={}, ThreadID={}",
+                  es.get_rank(),
+                  tl::thread::self_id());
         for(int i = 0; i < 6; ++i)
         {
             collectIngestedEvents();
@@ -188,31 +227,36 @@ void chronolog::GrapherDataStore::startDataCollection(int stream_count)
         return;
     }
 
-    LOG_INFO("[GrapherDataStore] Starting data collection. StreamCount={}, ThreadID={}", stream_count
-             , tl::thread::self_id());
+    LOG_INFO("[GrapherDataStore] Starting data collection. StreamCount={}, ThreadID={}",
+             stream_count,
+             tl::thread::self_id());
     state = RUNNING;
 
     for(int i = 0; i < stream_count; ++i)
     {
-        tl::managed <tl::xstream> es = tl::xstream::create();
+        tl::managed<tl::xstream> es = tl::xstream::create();
         dataStoreStreams.push_back(std::move(es));
     }
 
     for(int i = 0; i < 2 * stream_count; ++i)
     {
-        tl::managed <tl::thread> th = dataStoreStreams[i % (dataStoreStreams.size())]->make_thread([p = this]()
-                                                                                                   { p->dataCollectionTask(); });
+        tl::managed<tl::thread> th =
+                dataStoreStreams[i % (dataStoreStreams.size())]->make_thread([p = this]() { p->dataCollectionTask(); });
         dataStoreThreads.push_back(std::move(th));
     }
-    LOG_INFO("[GrapherDataStore] Data collection started successfully. Stream count={}, ThreadID={}", stream_count
-             , tl::thread::self_id());
+    LOG_INFO("[GrapherDataStore] Data collection started successfully. Stream count={}, ThreadID={}",
+             stream_count,
+             tl::thread::self_id());
 }
 //////////////////////////////
 
 void chronolog::GrapherDataStore::shutdownDataCollection()
 {
-    LOG_INFO("[GrapherDataStore] Initiating shutdown of DataCollection. CurrentState={}, Active StoryPipelines={}, PipelinesWaitingForExit={}"
-             , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size());
+    LOG_INFO("[GrapherDataStore] Initiating shutdown of DataCollection. CurrentState={}, Active StoryPipelines={}, "
+             "PipelinesWaitingForExit={}",
+             state,
+             theMapOfStoryPipelines.size(),
+             pipelinesWaitingForExit.size());
 
     // switch the state to shuttingDown
     std::lock_guard storeLock(dataStoreStateMutex);
@@ -229,14 +273,14 @@ void chronolog::GrapherDataStore::shutdownDataCollection()
         std::lock_guard storeLock(dataStoreMutex);
         uint64_t current_time = std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
-        for(auto pipeline_iter = theMapOfStoryPipelines.begin();
-            pipeline_iter != theMapOfStoryPipelines.end(); ++pipeline_iter)
+        for(auto pipeline_iter = theMapOfStoryPipelines.begin(); pipeline_iter != theMapOfStoryPipelines.end();
+            ++pipeline_iter)
         {
             if(pipelinesWaitingForExit.find((*pipeline_iter).first) == pipelinesWaitingForExit.end())
             {
                 uint64_t exit_time = current_time + (*pipeline_iter).second->getAcceptanceWindow();
-                pipelinesWaitingForExit[(*pipeline_iter).first] = (std::pair <chl::StoryPipeline*, uint64_t>(
-                        (*pipeline_iter).second, exit_time));
+                pipelinesWaitingForExit[(*pipeline_iter).first] =
+                        (std::pair<chl::StoryPipeline*, uint64_t>((*pipeline_iter).second, exit_time));
             }
         }
     }
@@ -244,16 +288,10 @@ void chronolog::GrapherDataStore::shutdownDataCollection()
     // Join threads & execution streams while holding stateMutex
     // and just wait until all the events are collected and
     // all the storyPipelines decay and retire
-    for(auto &th: dataStoreThreads)
-    {
-        th->join();
-    }
+    for(auto& th: dataStoreThreads) { th->join(); }
     LOG_INFO("[GrapherDataStore] All data collection threads have been joined.");
 
-    for(auto &es: dataStoreStreams)
-    {
-        es->join();
-    }
+    for(auto& es: dataStoreStreams) { es->join(); }
     LOG_INFO("[GrapherDataStore] All data collection streams have been joined.");
     LOG_INFO("[GrapherDataStore] DataCollection shutdown completed.");
 }
@@ -263,9 +301,9 @@ void chronolog::GrapherDataStore::shutdownDataCollection()
 //
 chronolog::GrapherDataStore::~GrapherDataStore()
 {
-    LOG_INFO("[GrapherDataStore] Destructor called. Initiating shutdown. Active StoryPipelines count={}"
-             , theMapOfStoryPipelines.size());
+    LOG_INFO("[GrapherDataStore] Destructor called. Initiating shutdown. Active StoryPipelines count={}",
+             theMapOfStoryPipelines.size());
     shutdownDataCollection();
-    LOG_INFO("[GrapherDataStore] Shutdown completed successfully. Active StoryPipelines count={}"
-             , theMapOfStoryPipelines.size());
+    LOG_INFO("[GrapherDataStore] Shutdown completed successfully. Active StoryPipelines count={}",
+             theMapOfStoryPipelines.size());
 }

--- a/ChronoGrapher/src/GrapherDataStore.cpp
+++ b/ChronoGrapher/src/GrapherDataStore.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <mutex>
 #include <chrono>
+#include <utility>
 #include <thallium.hpp>
 
 #include <chronolog_errcode.h>

--- a/ChronoGrapher/src/HDF5FileChunkExtractor.cpp
+++ b/ChronoGrapher/src/HDF5FileChunkExtractor.cpp
@@ -1,3 +1,6 @@
+#include <string>
+#include <thallium.hpp>
+
 #include <HDF5FileChunkExtractor.h>
 #include <StoryChunkWriter.h>
 

--- a/ChronoGrapher/src/HDF5FileChunkExtractor.cpp
+++ b/ChronoGrapher/src/HDF5FileChunkExtractor.cpp
@@ -1,8 +1,9 @@
 #include <string>
 #include <thallium.hpp>
 
-#include <HDF5FileChunkExtractor.h>
 #include <StoryChunkWriter.h>
+
+#include "HDF5FileChunkExtractor.h"
 
 namespace tl = thallium;
 

--- a/ChronoGrapher/src/HDF5FileChunkExtractor.cpp
+++ b/ChronoGrapher/src/HDF5FileChunkExtractor.cpp
@@ -8,10 +8,10 @@ namespace tl = thallium;
 
 namespace chronolog
 {
-HDF5FileChunkExtractor::HDF5FileChunkExtractor(const std::string &chrono_process_id_card
-                                               , const std::string &hdf5_files_root_dir)
-                                               : chrono_process_id(chrono_process_id_card)
-                                               , rootDirectory(hdf5_files_root_dir)
+HDF5FileChunkExtractor::HDF5FileChunkExtractor(const std::string& chrono_process_id_card,
+                                               const std::string& hdf5_files_root_dir)
+    : chrono_process_id(chrono_process_id_card)
+    , rootDirectory(hdf5_files_root_dir)
 {}
 
 HDF5FileChunkExtractor::~HDF5FileChunkExtractor()
@@ -19,7 +19,7 @@ HDF5FileChunkExtractor::~HDF5FileChunkExtractor()
     LOG_INFO("[HDF5FileChunkExtractor] Destructor called. Cleaning up...");
 }
 
-int HDF5FileChunkExtractor::processStoryChunk(StoryChunk *story_chunk)
+int HDF5FileChunkExtractor::processStoryChunk(StoryChunk* story_chunk)
 {
     LOG_INFO("[HDF5FileChunkExtractor] Writing StoryChunk...");
     StoryChunkWriter chunkWriter(rootDirectory, "story_chunks", "data");
@@ -36,4 +36,4 @@ int HDF5FileChunkExtractor::processStoryChunk(StoryChunk *story_chunk)
     LOG_DEBUG("[HDF5FileChunkExtractor] Finished processing StoryChunk.");
     return ret;
 }
-} // chronolog
+} // namespace chronolog

--- a/ChronoKeeper/include/CSVFileChunkExtractor.h
+++ b/ChronoKeeper/include/CSVFileChunkExtractor.h
@@ -17,7 +17,7 @@ class CSVFileStoryChunkExtractor: public StoryChunkExtractorBase
 {
 
 public:
-    CSVFileStoryChunkExtractor(KeeperIdCard const &keeper_id_card, std::string const &csv_files_root_dir);
+    CSVFileStoryChunkExtractor(KeeperIdCard const& keeper_id_card, std::string const& csv_files_root_dir);
 
     ~CSVFileStoryChunkExtractor();
 
@@ -26,10 +26,8 @@ public:
 private:
     KeeperIdCard keeperIdCard;
     std::string rootDirectory;
-
-
 };
 
 
-}
+} // namespace chronolog
 #endif

--- a/ChronoKeeper/include/CSVFileChunkExtractor.h
+++ b/ChronoKeeper/include/CSVFileChunkExtractor.h
@@ -1,9 +1,12 @@
 #ifndef CSV_FILE_CHUNK_EXTRACTOR_H
 #define CSV_FILE_CHUNK_EXTRACTOR_H
 
+#include <string>
+
 #include <chronolog_types.h>
 #include <KeeperIdCard.h>
 
+#include "StoryChunk.h"
 #include "StoryChunkExtractor.h"
 
 

--- a/ChronoKeeper/include/DataStoreAdminService.h
+++ b/ChronoKeeper/include/DataStoreAdminService.h
@@ -18,12 +18,12 @@ namespace tl = thallium;
 namespace chronolog
 {
 
-class DataStoreAdminService: public tl::provider <DataStoreAdminService>
+class DataStoreAdminService: public tl::provider<DataStoreAdminService>
 {
 public:
     // Service should be created on the heap not the stack thus the constructor is private...
     static DataStoreAdminService*
-    CreateDataStoreAdminService(tl::engine &tl_engine, uint16_t service_provider_id, KeeperDataStore &dataStoreInstance)
+    CreateDataStoreAdminService(tl::engine& tl_engine, uint16_t service_provider_id, KeeperDataStore& dataStoreInstance)
     {
         return new DataStoreAdminService(tl_engine, service_provider_id, dataStoreInstance);
     }
@@ -35,28 +35,27 @@ public:
         get_engine().pop_finalize_callback(this);
     }
 
-    void collection_service_available(tl::request const &request)
-    {
-        request.respond(1);
-    }
+    void collection_service_available(tl::request const& request) { request.respond(1); }
 
-    void shutdown_data_collection(tl::request const &request)
+    void shutdown_data_collection(tl::request const& request)
     {
         int status = 1;
         theDataStore.shutdownDataCollection();
         request.respond(status);
     }
 
-    void
-    StartStoryRecording(tl::request const &request, std::string const &chronicle_name, std::string const &story_name
-                        , StoryId const &story_id, uint64_t start_time)
+    void StartStoryRecording(tl::request const& request,
+                             std::string const& chronicle_name,
+                             std::string const& story_name,
+                             StoryId const& story_id,
+                             uint64_t start_time)
     {
         LOG_INFO("[DataStoreAdminService] Starting Story Recording: StoryName={}, StoryID={}", story_name, story_id);
         int return_code = theDataStore.startStoryRecording(chronicle_name, story_name, story_id, start_time);
         request.respond(return_code);
     }
 
-    void StopStoryRecording(tl::request const &request, StoryId const &story_id)
+    void StopStoryRecording(tl::request const& request, StoryId const& story_id)
     {
         LOG_INFO("[DataStoreAdminService] Stopping Story Recording: StoryID={}", story_id);
         int return_code = theDataStore.stopStoryRecording(story_id);
@@ -64,29 +63,29 @@ public:
     }
 
 private:
-    DataStoreAdminService(tl::engine &tl_engine, uint16_t service_provider_id, KeeperDataStore &data_store_instance)
-            : tl::provider <DataStoreAdminService>(tl_engine, service_provider_id), theDataStore(data_store_instance)
+    DataStoreAdminService(tl::engine& tl_engine, uint16_t service_provider_id, KeeperDataStore& data_store_instance)
+        : tl::provider<DataStoreAdminService>(tl_engine, service_provider_id)
+        , theDataStore(data_store_instance)
     {
         define("collection_service_available", &DataStoreAdminService::collection_service_available);
         define("shutdown_data_collection", &DataStoreAdminService::shutdown_data_collection);
         define("start_story_recording", &DataStoreAdminService::StartStoryRecording);
         define("stop_story_recording", &DataStoreAdminService::StopStoryRecording);
         //set up callback for the case when the engine is being finalized while this provider is still alive
-        get_engine().push_finalize_callback(this, [p = this]()
-        { delete p; });
+        get_engine().push_finalize_callback(this, [p = this]() { delete p; });
 
         std::stringstream ss;
         ss << get_engine().self();
         LOG_INFO("[DataStoreAdminService] Constructed at {}. ProviderID={}", ss.str(), service_provider_id);
     }
 
-    DataStoreAdminService(DataStoreAdminService const &) = delete;
+    DataStoreAdminService(DataStoreAdminService const&) = delete;
 
-    DataStoreAdminService &operator=(DataStoreAdminService const &) = delete;
+    DataStoreAdminService& operator=(DataStoreAdminService const&) = delete;
 
-    KeeperDataStore &theDataStore;
+    KeeperDataStore& theDataStore;
 };
 
-}// namespace chronolog
+} // namespace chronolog
 
 #endif

--- a/ChronoKeeper/include/DataStoreAdminService.h
+++ b/ChronoKeeper/include/DataStoreAdminService.h
@@ -2,6 +2,9 @@
 #define DataStoreAdmin_SERVICE_H
 
 #include <iostream>
+#include <string>
+#include <cstdint>
+
 #include <margo.h>
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>

--- a/ChronoKeeper/include/DataStoreAdminService.h
+++ b/ChronoKeeper/include/DataStoreAdminService.h
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <string>
 #include <cstdint>
-
 #include <margo.h>
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>

--- a/ChronoKeeper/include/IngestionQueue.h
+++ b/ChronoKeeper/include/IngestionQueue.h
@@ -5,6 +5,8 @@
 #include <deque>
 #include <unordered_map>
 #include <mutex>
+#include <string>
+#include <sstream>
 
 #include <chrono_monitor.h>
 #include <chronolog_types.h>

--- a/ChronoKeeper/include/IngestionQueue.h
+++ b/ChronoKeeper/include/IngestionQueue.h
@@ -21,33 +21,35 @@
 namespace chronolog
 {
 
-typedef std::deque <LogEvent> EventDeque;
+typedef std::deque<LogEvent> EventDeque;
 
 class IngestionQueue
 {
 public:
-    IngestionQueue()
-    {}
+    IngestionQueue() {}
 
-    ~IngestionQueue()
-    { shutDown(); }
+    ~IngestionQueue() { shutDown(); }
 
-    void addStoryIngestionHandle(StoryId const &story_id, StoryIngestionHandle*ingestion_handle)
+    void addStoryIngestionHandle(StoryId const& story_id, StoryIngestionHandle* ingestion_handle)
     {
-        std::lock_guard <std::mutex> lock(ingestionQueueMutex);
-        storyIngestionHandles.emplace(std::pair <StoryId, StoryIngestionHandle*>(story_id, ingestion_handle));
-        LOG_DEBUG("[IngestionQueue] Added handle for StoryID={}: HandleAddress={}, StoryIngestionHandles={}, HandleMapSize={}"
-             , story_id, static_cast<void*>(ingestion_handle), reinterpret_cast<void*>(&storyIngestionHandles)
-             , storyIngestionHandles.size());
+        std::lock_guard<std::mutex> lock(ingestionQueueMutex);
+        storyIngestionHandles.emplace(std::pair<StoryId, StoryIngestionHandle*>(story_id, ingestion_handle));
+        LOG_DEBUG("[IngestionQueue] Added handle for StoryID={}: HandleAddress={}, StoryIngestionHandles={}, "
+                  "HandleMapSize={}",
+                  story_id,
+                  static_cast<void*>(ingestion_handle),
+                  reinterpret_cast<void*>(&storyIngestionHandles),
+                  storyIngestionHandles.size());
     }
 
-    void removeIngestionHandle(StoryId const &story_id)
+    void removeIngestionHandle(StoryId const& story_id)
     {
-        std::lock_guard <std::mutex> lock(ingestionQueueMutex);
+        std::lock_guard<std::mutex> lock(ingestionQueueMutex);
         if(storyIngestionHandles.erase(story_id))
         {
-            LOG_DEBUG("[IngestionQueue] Removed handle for StoryID={}. Current handle MapSize={}", story_id
-                 , storyIngestionHandles.size());
+            LOG_DEBUG("[IngestionQueue] Removed handle for StoryID={}. Current handle MapSize={}",
+                      story_id,
+                      storyIngestionHandles.size());
         }
         else
         {
@@ -55,17 +57,19 @@ public:
         }
     }
 
-    void ingestLogEvent(LogEvent const &event)
+    void ingestLogEvent(LogEvent const& event)
     {
         std::stringstream ss;
         ss << event;
-        LOG_DEBUG("[IngestionQueue] Received event for StoryID={}: Event Details={}, HandleMapSize={}", event.storyId
-             , ss.str(), storyIngestionHandles.size());
+        LOG_DEBUG("[IngestionQueue] Received event for StoryID={}: Event Details={}, HandleMapSize={}",
+                  event.storyId,
+                  ss.str(),
+                  storyIngestionHandles.size());
         auto ingestionHandle_iter = storyIngestionHandles.find(event.storyId);
         if(ingestionHandle_iter == storyIngestionHandles.end())
         {
             LOG_WARNING("[IngestionQueue] Orphan event for story {}. Storing for later processing.", event.storyId);
-            std::lock_guard <std::mutex> lock(ingestionQueueMutex);
+            std::lock_guard<std::mutex> lock(ingestionQueueMutex);
             orphanEventQueue.push_back(event);
         }
         else
@@ -82,7 +86,7 @@ public:
             LOG_DEBUG("[IngestionQueue] Orphan event queue is empty. No actions taken.");
             return;
         }
-        std::lock_guard <std::mutex> lock(ingestionQueueMutex);
+        std::lock_guard<std::mutex> lock(ingestionQueueMutex);
         for(EventDeque::iterator iter = orphanEventQueue.begin(); iter != orphanEventQueue.end();)
         {
             auto ingestionHandle_iter = storyIngestionHandles.find((*iter).storyId);
@@ -101,38 +105,35 @@ public:
         LOG_DEBUG("[IngestionQueue] Drained {} orphan events into known handles.", orphanEventQueue.size());
     }
 
-    bool is_empty() const
-    {
-        return (orphanEventQueue.empty() && storyIngestionHandles.empty());
-    }
+    bool is_empty() const { return (orphanEventQueue.empty() && storyIngestionHandles.empty()); }
 
     void shutDown()
     {
-        LOG_INFO("[IngestionQueue] Initiating shutdown. HandleMapSize={}, Orphan EventQueueSize={}"
-             , storyIngestionHandles.size(), orphanEventQueue.size());
+        LOG_INFO("[IngestionQueue] Initiating shutdown. HandleMapSize={}, Orphan EventQueueSize={}",
+                 storyIngestionHandles.size(),
+                 orphanEventQueue.size());
         // last attempt to drain orphanEventQueue into known ingestionHandles
         drainOrphanEvents();
         // disengage all handles
-        std::lock_guard <std::mutex> lock(ingestionQueueMutex);
+        std::lock_guard<std::mutex> lock(ingestionQueueMutex);
         storyIngestionHandles.clear();
         LOG_INFO("[IngestionQueue] Shutdown completed. All handles disengaged.");
     }
 
 private:
-    IngestionQueue(IngestionQueue const &) = delete;
+    IngestionQueue(IngestionQueue const&) = delete;
 
-    IngestionQueue &operator=(IngestionQueue const &) = delete;
+    IngestionQueue& operator=(IngestionQueue const&) = delete;
 
     std::mutex ingestionQueueMutex;
-    std::unordered_map <StoryId, StoryIngestionHandle*> storyIngestionHandles;
+    std::unordered_map<StoryId, StoryIngestionHandle*> storyIngestionHandles;
 
     // events for unknown stories or late events for closed stories will end up
     // in orphanEventQueue that we'll periodically try to drain into the DataStore
-    std::deque <LogEvent> orphanEventQueue;
+    std::deque<LogEvent> orphanEventQueue;
 
     //Timer to triger periodic attempt to drain orphanEventQueue and collect/log statistics
 };
-}
+} // namespace chronolog
 
 #endif
-

--- a/ChronoKeeper/include/KeeperDataStore.h
+++ b/ChronoKeeper/include/KeeperDataStore.h
@@ -4,7 +4,9 @@
 #include <vector>
 #include <list>
 #include <map>
+#include <unordered_map>
 #include <mutex>
+#include <cstdint>
 
 #include <thallium.hpp>
 

--- a/ChronoKeeper/include/KeeperDataStore.h
+++ b/ChronoKeeper/include/KeeperDataStore.h
@@ -24,16 +24,20 @@ class KeeperDataStore
 
     enum DataStoreState
     {
-        UNKNOWN = 0, RUNNING = 1,    //  active stories
-        SHUTTING_DOWN = 2    // Shutting down services
+        UNKNOWN = 0,
+        RUNNING = 1,      //  active stories
+        SHUTTING_DOWN = 2 // Shutting down services
     };
 
 
 public:
-    KeeperDataStore(IngestionQueue &ingestion_queue, StoryChunkExtractionQueue &extraction_queue
-                , uint32_t max_chunk_size = 4096, uint32_t story_chunk_duration_secs = 30
-                , uint32_t acceptance_window_secs = 60, uint32_t inactive_pipeline_delay_secs = 300 )
-        : state(UNKNOWN) 
+    KeeperDataStore(IngestionQueue& ingestion_queue,
+                    StoryChunkExtractionQueue& extraction_queue,
+                    uint32_t max_chunk_size = 4096,
+                    uint32_t story_chunk_duration_secs = 30,
+                    uint32_t acceptance_window_secs = 60,
+                    uint32_t inactive_pipeline_delay_secs = 300)
+        : state(UNKNOWN)
         , theIngestionQueue(ingestion_queue)
         , theExtractionQueue(extraction_queue)
         , story_chunk_size(max_chunk_size)
@@ -45,16 +49,18 @@ public:
 
     ~KeeperDataStore();
 
-    bool is_running() const
-    { return (RUNNING == state); }
+    bool is_running() const { return (RUNNING == state); }
 
-    bool is_shutting_down() const
-    { return (SHUTTING_DOWN == state); }
+    bool is_shutting_down() const { return (SHUTTING_DOWN == state); }
 
-    int startStoryRecording(ChronicleName const &, StoryName const &, StoryId const &, uint64_t start_time
-                            , uint32_t time_chunk_ranularity = 30, uint32_t access_window = 60);
+    int startStoryRecording(ChronicleName const&,
+                            StoryName const&,
+                            StoryId const&,
+                            uint64_t start_time,
+                            uint32_t time_chunk_ranularity = 30,
+                            uint32_t access_window = 60);
 
-    int stopStoryRecording(StoryId const &);
+    int stopStoryRecording(StoryId const&);
 
     void collectIngestedEvents();
 
@@ -69,28 +75,27 @@ public:
     void dataCollectionTask();
 
 private:
-    KeeperDataStore(KeeperDataStore const &) = delete;
+    KeeperDataStore(KeeperDataStore const&) = delete;
 
-    KeeperDataStore &operator=(KeeperDataStore const &) = delete;
+    KeeperDataStore& operator=(KeeperDataStore const&) = delete;
 
     DataStoreState state;
     std::mutex dataStoreStateMutex;
-    IngestionQueue &theIngestionQueue;
-    StoryChunkExtractionQueue &theExtractionQueue;
+    IngestionQueue& theIngestionQueue;
+    StoryChunkExtractionQueue& theExtractionQueue;
 
     uint32_t story_chunk_size;
     uint32_t story_chunk_duration_secs;
     uint32_t acceptance_window_secs;
     uint32_t inactive_pipeline_delay_secs;
 
-    std::vector <thallium::managed <thallium::xstream>> dataStoreStreams;
-    std::vector <thallium::managed <thallium::thread>> dataStoreThreads;
+    std::vector<thallium::managed<thallium::xstream>> dataStoreStreams;
+    std::vector<thallium::managed<thallium::thread>> dataStoreThreads;
 
     std::mutex dataStoreMutex;
-    std::unordered_map <StoryId, StoryPipeline*> theMapOfStoryPipelines;
-    std::unordered_map <StoryId, std::pair <StoryPipeline*, uint64_t>> pipelinesWaitingForExit;
-
+    std::unordered_map<StoryId, StoryPipeline*> theMapOfStoryPipelines;
+    std::unordered_map<StoryId, std::pair<StoryPipeline*, uint64_t>> pipelinesWaitingForExit;
 };
 
-}
+} // namespace chronolog
 #endif

--- a/ChronoKeeper/include/KeeperRecordingService.h
+++ b/ChronoKeeper/include/KeeperRecordingService.h
@@ -2,6 +2,10 @@
 #define KEEPER_RECORDING_SERVICE_H
 
 #include <iostream>
+#include <string>
+#include <sstream>
+#include <cstdint>
+
 #include <margo.h>
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>

--- a/ChronoKeeper/include/KeeperRecordingService.h
+++ b/ChronoKeeper/include/KeeperRecordingService.h
@@ -5,7 +5,6 @@
 #include <string>
 #include <sstream>
 #include <cstdint>
-
 #include <margo.h>
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>

--- a/ChronoKeeper/include/KeeperRecordingService.h
+++ b/ChronoKeeper/include/KeeperRecordingService.h
@@ -20,12 +20,12 @@ namespace tl = thallium;
 
 namespace chronolog
 {
-class KeeperRecordingService: public tl::provider <KeeperRecordingService>
+class KeeperRecordingService: public tl::provider<KeeperRecordingService>
 {
 public:
     // KeeperRecordingService should be created on the heap not the stack thus the constructor is private...
     static KeeperRecordingService*
-    CreateKeeperRecordingService(tl::engine &tl_engine, uint16_t service_provider_id, IngestionQueue &ingestion_queue)
+    CreateKeeperRecordingService(tl::engine& tl_engine, uint16_t service_provider_id, IngestionQueue& ingestion_queue)
     {
         return new KeeperRecordingService(tl_engine, service_provider_id, ingestion_queue);
     }
@@ -36,7 +36,7 @@ public:
         get_engine().pop_finalize_callback(this);
     }
 
-    void record_event(tl::request const &request, LogEvent const &log_event)
+    void record_event(tl::request const& request, LogEvent const& log_event)
     {
         //  ClientId teller_id,  StoryId story_id,
         //  ChronoTick const& chrono_tick, std::string const& record)
@@ -48,22 +48,22 @@ public:
     }
 
 private:
-    KeeperRecordingService(tl::engine &tl_engine, uint16_t service_provider_id, IngestionQueue &ingestion_queue)
-            : tl::provider <KeeperRecordingService>(tl_engine, service_provider_id), theIngestionQueue(ingestion_queue)
+    KeeperRecordingService(tl::engine& tl_engine, uint16_t service_provider_id, IngestionQueue& ingestion_queue)
+        : tl::provider<KeeperRecordingService>(tl_engine, service_provider_id)
+        , theIngestionQueue(ingestion_queue)
     {
         define("record_event", &KeeperRecordingService::record_event, tl::ignore_return_value());
         //set up callback for the case when the engine is being finalized while this provider is still alive
-        get_engine().push_finalize_callback(this, [p = this]()
-        { delete p; });
+        get_engine().push_finalize_callback(this, [p = this]() { delete p; });
     }
 
-    KeeperRecordingService(KeeperRecordingService const &) = delete;
+    KeeperRecordingService(KeeperRecordingService const&) = delete;
 
-    KeeperRecordingService &operator=(KeeperRecordingService const &) = delete;
+    KeeperRecordingService& operator=(KeeperRecordingService const&) = delete;
 
-    IngestionQueue &theIngestionQueue;
+    IngestionQueue& theIngestionQueue;
 };
 
-}// namespace chronolog
+} // namespace chronolog
 
 #endif

--- a/ChronoKeeper/include/KeeperRegClient.h
+++ b/ChronoKeeper/include/KeeperRegClient.h
@@ -2,6 +2,10 @@
 #define KEEPER_REG_CLIENT_H
 
 #include <iostream>
+#include <string>
+#include <sstream>
+#include <cstdint>
+
 #include <thallium/serialization/stl/string.hpp>
 #include <thallium.hpp>
 

--- a/ChronoKeeper/include/KeeperRegClient.h
+++ b/ChronoKeeper/include/KeeperRegClient.h
@@ -24,22 +24,22 @@ class KeeperRegistryClient
 {
 
 public:
-    static KeeperRegistryClient*
-    CreateKeeperRegistryClient(tl::engine &tl_engine, std::string const &registry_service_addr
-                               , uint16_t registry_provider_id)
+    static KeeperRegistryClient* CreateKeeperRegistryClient(tl::engine& tl_engine,
+                                                            std::string const& registry_service_addr,
+                                                            uint16_t registry_provider_id)
     {
         try
         {
             return new KeeperRegistryClient(tl_engine, registry_service_addr, registry_provider_id);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[KeeperRegistryClient] Failed to create KeeperRegistryClient");
             return nullptr;
         }
     }
 
-    int send_register_msg(KeeperRegistrationMsg const &keeperMsg)
+    int send_register_msg(KeeperRegistrationMsg const& keeperMsg)
     {
         try
         {
@@ -48,14 +48,14 @@ public:
             LOG_DEBUG("[KeeperRegisterClient] Sending Register Message: {}", ss.str());
             return register_keeper.on(reg_service_ph)(keeperMsg);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[KeeperRegisterClient] Failed Sending Register Message.");
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
 
-    int send_unregister_msg(KeeperIdCard const &keeperIdCard)
+    int send_unregister_msg(KeeperIdCard const& keeperIdCard)
     {
         try
         {
@@ -64,14 +64,14 @@ public:
             LOG_DEBUG("[KeeperRegisterClient] Sending Unregister Message: {}", ss.str());
             return unregister_keeper.on(reg_service_ph)(keeperIdCard);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[KeeperRegisterClient] Failed Sending Unregistered Message.");
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
 
-    void send_stats_msg(KeeperStatsMsg const &keeperStatsMsg)
+    void send_stats_msg(KeeperStatsMsg const& keeperStatsMsg)
     {
         try
         {
@@ -80,7 +80,7 @@ public:
             LOG_DEBUG("[KeeperRegisterClient] Sending Stats Message: {}", ss.str());
             handle_stats_msg.on(reg_service_ph)(keeperStatsMsg);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[KeeperRegisterClient] Failed Sending Stats Message.");
         }
@@ -95,25 +95,27 @@ public:
     }
 
 private:
-    std::string reg_service_addr;     // na address of Keeper Registry Service 
-    uint16_t reg_service_provider_id;          // KeeperRegistryService provider id
-    tl::provider_handle reg_service_ph;  //provider_handle for remote registry service
+    std::string reg_service_addr;       // na address of Keeper Registry Service
+    uint16_t reg_service_provider_id;   // KeeperRegistryService provider id
+    tl::provider_handle reg_service_ph; //provider_handle for remote registry service
     tl::remote_procedure register_keeper;
     tl::remote_procedure unregister_keeper;
     tl::remote_procedure handle_stats_msg;
 
     // constructor is private to make sure thalium rpc objects are created on the heap, not stack
-    KeeperRegistryClient(tl::engine &tl_engine, std::string const &registry_addr, uint16_t registry_provider_id)
-            : reg_service_addr(registry_addr), reg_service_provider_id(registry_provider_id), reg_service_ph(
-            tl_engine.lookup(registry_addr), registry_provider_id)
+    KeeperRegistryClient(tl::engine& tl_engine, std::string const& registry_addr, uint16_t registry_provider_id)
+        : reg_service_addr(registry_addr)
+        , reg_service_provider_id(registry_provider_id)
+        , reg_service_ph(tl_engine.lookup(registry_addr), registry_provider_id)
     {
-        LOG_DEBUG("[KeeperRegistryClient] Initialized for RegistryService at {} with ProviderID={}", registry_addr
-             , registry_provider_id);
+        LOG_DEBUG("[KeeperRegistryClient] Initialized for RegistryService at {} with ProviderID={}",
+                  registry_addr,
+                  registry_provider_id);
         register_keeper = tl_engine.define("register_keeper");
         unregister_keeper = tl_engine.define("unregister_keeper");
         handle_stats_msg = tl_engine.define("handle_stats_msg").disable_response();
     }
 };
-}
+} // namespace chronolog
 
 #endif

--- a/ChronoKeeper/include/KeeperRegClient.h
+++ b/ChronoKeeper/include/KeeperRegClient.h
@@ -5,7 +5,6 @@
 #include <string>
 #include <sstream>
 #include <cstdint>
-
 #include <thallium/serialization/stl/string.hpp>
 #include <thallium.hpp>
 

--- a/ChronoKeeper/include/StoryChunkExtractionQueue.h
+++ b/ChronoKeeper/include/StoryChunkExtractionQueue.h
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <deque>
 #include <mutex>
+#include <string>
+#include <sstream>
 
 #include <chrono_monitor.h>
 #include <chronolog_types.h>

--- a/ChronoKeeper/include/StoryChunkExtractionQueue.h
+++ b/ChronoKeeper/include/StoryChunkExtractionQueue.h
@@ -18,8 +18,7 @@ namespace chronolog
 class StoryChunkExtractionQueue
 {
 public:
-    StoryChunkExtractionQueue()
-    {}
+    StoryChunkExtractionQueue() {}
 
     ~StoryChunkExtractionQueue()
     {
@@ -27,7 +26,7 @@ public:
         shutDown();
     }
 
-    void stashStoryChunk(StoryChunk*story_chunk)
+    void stashStoryChunk(StoryChunk* story_chunk)
     {
         if(nullptr == story_chunk)
         {
@@ -35,22 +34,23 @@ public:
             return;
         }
         {
-            std::lock_guard <std::mutex> lock(extractionQueueMutex);
+            std::lock_guard<std::mutex> lock(extractionQueueMutex);
             extractionDeque.push_back(story_chunk);
-            LOG_DEBUG("[StoryChunkExtractionQueue] Stashed story chunk with StoryID={} and StartTime={}"
-                      , story_chunk->getStoryId(), story_chunk->getStartTime());
+            LOG_DEBUG("[StoryChunkExtractionQueue] Stashed story chunk with StoryID={} and StartTime={}",
+                      story_chunk->getStoryId(),
+                      story_chunk->getStartTime());
         }
     }
 
-    StoryChunk*ejectStoryChunk()
+    StoryChunk* ejectStoryChunk()
     {
-        std::lock_guard <std::mutex> lock(extractionQueueMutex);
+        std::lock_guard<std::mutex> lock(extractionQueueMutex);
         if(extractionDeque.empty())
         {
             LOG_DEBUG("[StoryChunkExtractionQueue] No story chunks available for ejection.");
             return nullptr;
         }
-        StoryChunk*story_chunk = extractionDeque.front();
+        StoryChunk* story_chunk = extractionDeque.front();
         extractionDeque.pop_front();
 
         return story_chunk;
@@ -59,13 +59,13 @@ public:
 
     int size()
     {
-        std::lock_guard <std::mutex> lock(extractionQueueMutex);
+        std::lock_guard<std::mutex> lock(extractionQueueMutex);
         return extractionDeque.size();
     }
 
     bool empty()
     {
-        std::lock_guard <std::mutex> lock(extractionQueueMutex);
+        std::lock_guard<std::mutex> lock(extractionQueueMutex);
         return extractionDeque.empty();
     }
 
@@ -73,29 +73,32 @@ public:
     {
         LOG_INFO("[StoryChunkExtractionQueue] Initiating queue shutdown. Queue size: {}", extractionDeque.size());
         if(extractionDeque.empty())
-        { return; }
+        {
+            return;
+        }
 
         //INNA: LOG a WARNING and attempt to delay shutdown until the queue is drained by the Extraction module
         // if this fails , log an ERROR .
         // free the remaining storychunks memory...
-        std::lock_guard <std::mutex> lock(extractionQueueMutex);
+        std::lock_guard<std::mutex> lock(extractionQueueMutex);
         while(!extractionDeque.empty())
         {
             delete extractionDeque.front();
             extractionDeque.pop_front();
         }
-        LOG_INFO("[StoryChunkExtractionQueue] Queue has been successfully shut down and all story chunks have been freed.");
+        LOG_INFO("[StoryChunkExtractionQueue] Queue has been successfully shut down and all story chunks have been "
+                 "freed.");
     }
 
 private:
-    StoryChunkExtractionQueue(StoryChunkExtractionQueue const &) = delete;
+    StoryChunkExtractionQueue(StoryChunkExtractionQueue const&) = delete;
 
-    StoryChunkExtractionQueue &operator=(StoryChunkExtractionQueue const &) = delete;
+    StoryChunkExtractionQueue& operator=(StoryChunkExtractionQueue const&) = delete;
 
     std::mutex extractionQueueMutex;
-    std::deque <StoryChunk*> extractionDeque;
+    std::deque<StoryChunk*> extractionDeque;
 };
 
-}
+} // namespace chronolog
 
 #endif

--- a/ChronoKeeper/include/StoryChunkExtractorRDMA.h
+++ b/ChronoKeeper/include/StoryChunkExtractorRDMA.h
@@ -17,21 +17,22 @@ namespace chronolog
 class StoryChunkExtractorRDMA: public StoryChunkExtractorBase
 {
 public:
-    StoryChunkExtractorRDMA(tl::engine &extraction_engine, tl::remote_procedure &drain_to_grapher
-                            , tl::provider_handle &service_ph);
+    StoryChunkExtractorRDMA(tl::engine& extraction_engine,
+                            tl::remote_procedure& drain_to_grapher,
+                            tl::provider_handle& service_ph);
 
     ~StoryChunkExtractorRDMA();
 
-    int processStoryChunk(StoryChunk*story_chunk) override;
+    int processStoryChunk(StoryChunk* story_chunk) override;
 
 private:
-//    char serialized_buf[MAX_BULK_MEM_SIZE];
-    tl::engine &extraction_engine;
+    //    char serialized_buf[MAX_BULK_MEM_SIZE];
+    tl::engine& extraction_engine;
     tl::remote_procedure drain_to_grapher;
     tl::provider_handle service_ph;
 };
 
-}
+} // namespace chronolog
 
 
 #endif //CHRONOLOG_STORYCHUNKEXTRACTORRDMA_H

--- a/ChronoKeeper/include/StoryChunkExtractorRDMA.h
+++ b/ChronoKeeper/include/StoryChunkExtractorRDMA.h
@@ -1,9 +1,12 @@
 #ifndef CHRONOLOG_STORYCHUNKEXTRACTORRDMA_H
 #define CHRONOLOG_STORYCHUNKEXTRACTORRDMA_H
 
+#include <thallium.hpp>
+
 #include <chronolog_types.h>
 #include <ConfigurationManager.h>
 
+#include "StoryChunk.h"
 #include "StoryChunkExtractor.h"
 
 namespace tl = thallium;

--- a/ChronoKeeper/include/StoryPipeline.h
+++ b/ChronoKeeper/include/StoryPipeline.h
@@ -24,42 +24,45 @@ class StoryPipeline
 {
 
 public:
-    StoryPipeline(StoryChunkExtractionQueue &, std::string const &chronicle_name, std::string const &story_name
-                  , StoryId const &story_id, uint64_t start_time, uint32_t chunk_granularity = 15 // seconds
-                  , uint32_t acceptance_window = 30 // seconds
+    StoryPipeline(StoryChunkExtractionQueue&,
+                  std::string const& chronicle_name,
+                  std::string const& story_name,
+                  StoryId const& story_id,
+                  uint64_t start_time,
+                  uint32_t chunk_granularity = 15 // seconds
+                  ,
+                  uint32_t acceptance_window = 30 // seconds
     );
 
-    StoryPipeline(StoryPipeline const &) = delete;
+    StoryPipeline(StoryPipeline const&) = delete;
 
-    StoryPipeline &operator=(StoryPipeline const &) = delete;
+    StoryPipeline& operator=(StoryPipeline const&) = delete;
 
     ~StoryPipeline();
 
 
-    StoryIngestionHandle*getActiveIngestionHandle();
+    StoryIngestionHandle* getActiveIngestionHandle();
 
     void collectIngestedEvents();
 
-    void mergeEvents(std::deque <LogEvent> &);
+    void mergeEvents(std::deque<LogEvent>&);
 
     void extractDecayedStoryChunks(uint64_t);
 
-    StoryId const &getStoryId() const
-    { return storyId; }
+    StoryId const& getStoryId() const { return storyId; }
 
-    uint16_t getAcceptanceWindow() const
-    { return acceptanceWindow; }
+    uint16_t getAcceptanceWindow() const { return acceptanceWindow; }
 
-    uint64_t TimelineStart() const
-    { return (*storyTimelineMap.begin()).first; }  // storyTimelineMap is never left empty 
+    uint64_t TimelineStart() const { return (*storyTimelineMap.begin()).first; } // storyTimelineMap is never left empty
 
     uint64_t TimelineEnd() const
-    { return (*storyTimelineMap.rbegin()).second->getEndTime(); } // storyTimelineMap is never left empty
+    {
+        return (*storyTimelineMap.rbegin()).second->getEndTime();
+    } // storyTimelineMap is never left empty
 
 
 private:
-
-    StoryChunkExtractionQueue &theExtractionQueue;
+    StoryChunkExtractionQueue& theExtractionQueue;
     StoryId storyId;
     ChronicleName chronicleName;
     StoryName storyName;
@@ -72,27 +75,27 @@ private:
     // mutex used to protect the IngestionQueue from concurrent access
     // by RecordingService threads
     std::mutex ingestionMutex;
-    // two ingestion queues so that they can take turns playing 
+    // two ingestion queues so that they can take turns playing
     // active/passive ingestion duty
-    // 
-    std::deque <LogEvent> eventQueue1;
-    std::deque <LogEvent> eventQueue2;
+    //
+    std::deque<LogEvent> eventQueue1;
+    std::deque<LogEvent> eventQueue2;
 
-    StoryIngestionHandle*activeIngestionHandle;
+    StoryIngestionHandle* activeIngestionHandle;
 
-    // mutex used to protect Story sequencing operations 
+    // mutex used to protect Story sequencing operations
     // from concurrent access by the DataStore Sequencing threads
     std::mutex sequencingMutex;
 
     // map of storyChunks ordered by StoryChunck.startTime
-    std::map <chrono_time, StoryChunk*> storyTimelineMap;
+    std::map<chrono_time, StoryChunk*> storyTimelineMap;
 
-    std::map <uint64_t, StoryChunk*>::iterator prependStoryChunk();
+    std::map<uint64_t, StoryChunk*>::iterator prependStoryChunk();
 
-    std::map <uint64_t, StoryChunk*>::iterator appendStoryChunk();
+    std::map<uint64_t, StoryChunk*>::iterator appendStoryChunk();
 
     void finalize();
 };
 
-}
+} // namespace chronolog
 #endif

--- a/ChronoKeeper/include/StoryPipeline.h
+++ b/ChronoKeeper/include/StoryPipeline.h
@@ -6,6 +6,8 @@
 #include <map>
 #include <mutex>
 #include <iostream>
+#include <string>
+#include <cstdint>
 
 #include <chronolog_types.h>
 #include <StoryChunk.h>

--- a/ChronoKeeper/src/CSVFileChunkExtractor.cpp
+++ b/ChronoKeeper/src/CSVFileChunkExtractor.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <fstream>
+#include <string>
+#include <cstdint>
 #include <thallium.hpp>
 
 #include <chronolog_types.h>

--- a/ChronoKeeper/src/CSVFileChunkExtractor.cpp
+++ b/ChronoKeeper/src/CSVFileChunkExtractor.cpp
@@ -11,9 +11,10 @@
 
 namespace tl = thallium;
 
-chronolog::CSVFileStoryChunkExtractor::CSVFileStoryChunkExtractor(chronolog::KeeperIdCard const &keeper_id_card
-                                                                  , std::string const &csv_files_root_dir)
-        : keeperIdCard(keeper_id_card), rootDirectory(csv_files_root_dir)
+chronolog::CSVFileStoryChunkExtractor::CSVFileStoryChunkExtractor(chronolog::KeeperIdCard const& keeper_id_card,
+                                                                  std::string const& csv_files_root_dir)
+    : keeperIdCard(keeper_id_card)
+    , rootDirectory(csv_files_root_dir)
 {}
 
 /////////////
@@ -23,27 +24,31 @@ chronolog::CSVFileStoryChunkExtractor::~CSVFileStoryChunkExtractor()
 }
 
 /////////////
-int chronolog::CSVFileStoryChunkExtractor::processStoryChunk(StoryChunk*story_chunk)
+int chronolog::CSVFileStoryChunkExtractor::processStoryChunk(StoryChunk* story_chunk)
 {
     std::ofstream chunk_fstream;
 
     // chunk_filename: /rootDirectory/storyId.chunkStartTime.keeperIP.port.csv
 
     std::string chunk_filename(rootDirectory);
-    chunk_filename += "/" + std::to_string(story_chunk->getStoryId()) + "." + std::to_string(story_chunk->getStartTime() / 1000000000) + ".";
+    chunk_filename += "/" + std::to_string(story_chunk->getStoryId()) + "." +
+                      std::to_string(story_chunk->getStartTime() / 1000000000) + ".";
     keeperIdCard.getRecordingServiceId().get_ip_as_dotted_string(chunk_filename);
     chunk_filename += "." + std::to_string(keeperIdCard.getRecordingServiceId().getPort()) + ".csv";
 
     tl::xstream es = tl::xstream::self();
-    LOG_INFO("[CSVFileStoryChunkExtractor] Processing StoryChunk: ES={}, ULT={}, StoryID={}, StartTime={}", es.get_rank()
-         , tl::thread::self_id(), story_chunk->getStoryId(), story_chunk->getStartTime());
+    LOG_INFO("[CSVFileStoryChunkExtractor] Processing StoryChunk: ES={}, ULT={}, StoryID={}, StartTime={}",
+             es.get_rank(),
+             tl::thread::self_id(),
+             story_chunk->getStoryId(),
+             story_chunk->getStartTime());
 
-    // current thread if the only one that has this storyChunk and the only one that's writing to this chunk csv file 
-    // thus no additional locking is needed ... 
-    chunk_fstream.open(chunk_filename, std::ofstream::out|std::ofstream::app);
+    // current thread if the only one that has this storyChunk and the only one that's writing to this chunk csv file
+    // thus no additional locking is needed ...
+    chunk_fstream.open(chunk_filename, std::ofstream::out | std::ofstream::app);
     for(auto event_iter = story_chunk->begin(); event_iter != story_chunk->end(); ++event_iter)
     {
-        chronolog::LogEvent const &event = (*event_iter).second;
+        chronolog::LogEvent const& event = (*event_iter).second;
         chunk_fstream << event << std::endl;
     }
     chunk_fstream.close();

--- a/ChronoKeeper/src/ChronoKeeperInstance.cpp
+++ b/ChronoKeeper/src/ChronoKeeperInstance.cpp
@@ -1,6 +1,12 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <signal.h>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <cstdint>
 
 #include <KeeperRecordingService.h>
 #include <KeeperRegClient.h>

--- a/ChronoKeeper/src/ChronoKeeperInstance.cpp
+++ b/ChronoKeeper/src/ChronoKeeperInstance.cpp
@@ -22,8 +22,7 @@
 
 // we will be using a combination of the uint32_t representation of the service IP address
 // and uint16_t representation of the port number
-int
-service_endpoint_from_dotted_string(std::string const &ip_string, int port, std::pair <uint32_t, uint16_t> &endpoint)
+int service_endpoint_from_dotted_string(std::string const& ip_string, int port, std::pair<uint32_t, uint16_t>& endpoint)
 {
     // we will be using a combination of the uint32_t representation of the service IP address
     // and uint16_t representation of the port number
@@ -42,7 +41,7 @@ service_endpoint_from_dotted_string(std::string const &ip_string, int port, std:
     // translate 32bit ip from network into the host byte order
     uint32_t ntoh_ip_addr = ntohl(sa.sin_addr.s_addr);
     uint16_t ntoh_port = port;
-    endpoint = std::pair <uint32_t, uint16_t>(ntoh_ip_addr, ntoh_port);
+    endpoint = std::pair<uint32_t, uint16_t>(ntoh_ip_addr, ntoh_port);
 
     LOG_DEBUG("[ChronoKeeperInstance] Service endpoint created: IP={}, Port={}", ip_string, port);
     return 1;
@@ -59,7 +58,7 @@ void sigterm_handler(int)
 
 ///////////////////////////////////////////////
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     int exit_code = 0;
     signal(SIGTERM, sigterm_handler);
@@ -74,15 +73,15 @@ int main(int argc, char**argv)
     chronolog::ConfigurationManager confManager(conf_file_path);
 
     chronolog::KeeperConfiguration KEEPER_CONF = confManager.KEEPER_CONF;
-    std::cout << "ChronoKeeper Configuration "<< KEEPER_CONF.to_String()<<std::endl;
-    
-    int result = chronolog::chrono_monitor::initialize(KEEPER_CONF.LOG_CONF.LOGTYPE
-                                                       , KEEPER_CONF.LOG_CONF.LOGFILE
-                                                       , KEEPER_CONF.LOG_CONF.LOGLEVEL
-                                                       , KEEPER_CONF.LOG_CONF.LOGNAME
-                                                       , KEEPER_CONF.LOG_CONF.LOGFILESIZE
-                                                       , KEEPER_CONF.LOG_CONF.LOGFILENUM
-                                                       , KEEPER_CONF.LOG_CONF.FLUSHLEVEL);
+    std::cout << "ChronoKeeper Configuration " << KEEPER_CONF.to_String() << std::endl;
+
+    int result = chronolog::chrono_monitor::initialize(KEEPER_CONF.LOG_CONF.LOGTYPE,
+                                                       KEEPER_CONF.LOG_CONF.LOGFILE,
+                                                       KEEPER_CONF.LOG_CONF.LOGLEVEL,
+                                                       KEEPER_CONF.LOG_CONF.LOGNAME,
+                                                       KEEPER_CONF.LOG_CONF.LOGFILESIZE,
+                                                       KEEPER_CONF.LOG_CONF.LOGFILENUM,
+                                                       KEEPER_CONF.LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
@@ -90,16 +89,16 @@ int main(int argc, char**argv)
 
     LOG_INFO("Running ChronoKeeper Server.");
     LOG_INFO("[ChronoKeeper] Configuration {}", KEEPER_CONF.to_String());
-    
+
     // Instantiate ChronoKeeper MemoryDataStore
     // instantiate DataStoreAdminService
 
     /// DataStoreAdminService setup ____________________________________________________________________________________
     std::string datastore_service_ip = KEEPER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.IP;
     int datastore_service_port = KEEPER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.BASE_PORT;
-    std::string KEEPER_DATASTORE_SERVICE_NA_STRING =
-            KEEPER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF + "://" +
-            datastore_service_ip + ":" + std::to_string(datastore_service_port);
+    std::string KEEPER_DATASTORE_SERVICE_NA_STRING = KEEPER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF + "://" +
+                                                     datastore_service_ip + ":" +
+                                                     std::to_string(datastore_service_port);
 
     uint16_t datastore_service_provider_id = KEEPER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.SERVICE_PROVIDER_ID;
 
@@ -112,10 +111,11 @@ int main(int argc, char**argv)
         return (-1);
     }
 
-    chronolog::ServiceId dataStoreServiceId( KEEPER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF,
-                        datastore_endpoint, KEEPER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.SERVICE_PROVIDER_ID);
+    chronolog::ServiceId dataStoreServiceId(KEEPER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF,
+                                            datastore_endpoint,
+                                            KEEPER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.SERVICE_PROVIDER_ID);
 
- 
+
     /// KeeperRecordingService setup ___________________________________________________________________________________
     // Instantiate KeeperRecordingService
     std::string KEEPER_RECORDING_SERVICE_PROTOCOL = KEEPER_CONF.KEEPER_RECORDING_SERVICE_CONF.PROTO_CONF;
@@ -127,8 +127,9 @@ int main(int argc, char**argv)
     // validate ip address, instantiate Recording Service and create KeeperIdCard
 
     chronolog::service_endpoint recording_endpoint;
-    if(-1 == service_endpoint_from_dotted_string(KEEPER_RECORDING_SERVICE_IP, KEEPER_RECORDING_SERVICE_PORT
-                                                 , recording_endpoint))
+    if(-1 == service_endpoint_from_dotted_string(KEEPER_RECORDING_SERVICE_IP,
+                                                 KEEPER_RECORDING_SERVICE_PORT,
+                                                 recording_endpoint))
     {
         LOG_CRITICAL("[ChronoKeeperInstance] Failed to start KeeperRecordingService. Invalid endpoint provided.");
         return (-1);
@@ -137,11 +138,12 @@ int main(int argc, char**argv)
 
     // create KeeperIdCard to identify this Keeper process in ChronoVisor's KeeperRegistry
     chronolog::RecordingGroupId keeper_group_id = KEEPER_CONF.RECORDING_GROUP;
-    chronolog::KeeperIdCard keeperIdCard(keeper_group_id, 
+    chronolog::KeeperIdCard keeperIdCard(
+            keeper_group_id,
             chronolog::ServiceId(KEEPER_CONF.KEEPER_RECORDING_SERVICE_CONF.PROTO_CONF,
-            KEEPER_CONF.KEEPER_RECORDING_SERVICE_CONF.IP,
-            KEEPER_CONF.KEEPER_RECORDING_SERVICE_CONF.BASE_PORT,
-            KEEPER_CONF.KEEPER_RECORDING_SERVICE_CONF.SERVICE_PROVIDER_ID));
+                                 KEEPER_CONF.KEEPER_RECORDING_SERVICE_CONF.IP,
+                                 KEEPER_CONF.KEEPER_RECORDING_SERVICE_CONF.BASE_PORT,
+                                 KEEPER_CONF.KEEPER_RECORDING_SERVICE_CONF.SERVICE_PROVIDER_ID));
 
     std::string KEEPER_RECORDING_SERVICE_NA_STRING;
     keeperIdCard.getRecordingServiceId().get_service_as_string(KEEPER_RECORDING_SERVICE_NA_STRING);
@@ -152,23 +154,23 @@ int main(int argc, char**argv)
     chronolog::IngestionQueue ingestionQueue;
     std::string keeper_csv_files_directory = KEEPER_CONF.EXTRACTOR_CONF.story_files_dir;
     // Instantiate KeeperGrapherDrainService
-    tl::engine*extractionEngine = nullptr;
+    tl::engine* extractionEngine = nullptr;
     tl::remote_procedure drain_to_grapher;
     tl::provider_handle service_ph;
     uint16_t extraction_provider_id = KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.SERVICE_PROVIDER_ID;
     try
     {
-        extractionEngine = new tl::engine(KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.PROTO_CONF
-                                          , THALLIUM_CLIENT_MODE);
+        extractionEngine =
+                new tl::engine(KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.PROTO_CONF, THALLIUM_CLIENT_MODE);
 
         std::stringstream s1;
         s1 << extractionEngine->self();
-        LOG_INFO("[ChronoKeeperInstance] GroupID={} starting extraction engine at address {}", keeper_group_id
-                 , s1.str());
-        std::string KEEPER_GRAPHER_NA_STRING =
-                KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.PROTO_CONF + "://" +
-                KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.IP + ":" +
-                std::to_string(KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.BASE_PORT);
+        LOG_INFO("[ChronoKeeperInstance] GroupID={} starting extraction engine at address {}",
+                 keeper_group_id,
+                 s1.str());
+        std::string KEEPER_GRAPHER_NA_STRING = KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.PROTO_CONF + "://" +
+                                               KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.IP + ":" +
+                                               std::to_string(KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.BASE_PORT);
         std::string extraction_rpc_name = "record_story_chunk";
         drain_to_grapher = extractionEngine->define(extraction_rpc_name);
         LOG_DEBUG("[ChronoKeeperInstance] Looking up {} at: {} ...", extraction_rpc_name, KEEPER_GRAPHER_NA_STRING);
@@ -179,43 +181,45 @@ int main(int argc, char**argv)
             throw std::runtime_error("Failed to lookup Grapher service provider handle");
         }
     }
-    catch(tl::exception const &)
+    catch(tl::exception const&)
     {
         LOG_ERROR("[ChronoKeeperInstance] Keeper failed to create extraction engine");
     }
 
-    chronolog::StoryChunkExtractorRDMA storyExtractor = chronolog::StoryChunkExtractorRDMA(*extractionEngine
-                                                                                           , drain_to_grapher
-                                                                                           , service_ph);
-    
-    chronolog::KeeperDataStore theDataStore(ingestionQueue, storyExtractor.getExtractionQueue(),
-                KEEPER_CONF.DATA_STORE_CONF.max_story_chunk_size, 
-                KEEPER_CONF.DATA_STORE_CONF.story_chunk_duration_secs, 
-                KEEPER_CONF.DATA_STORE_CONF.acceptance_window_secs,
-                KEEPER_CONF.DATA_STORE_CONF.inactive_story_delay_secs
-                );
+    chronolog::StoryChunkExtractorRDMA storyExtractor =
+            chronolog::StoryChunkExtractorRDMA(*extractionEngine, drain_to_grapher, service_ph);
+
+    chronolog::KeeperDataStore theDataStore(ingestionQueue,
+                                            storyExtractor.getExtractionQueue(),
+                                            KEEPER_CONF.DATA_STORE_CONF.max_story_chunk_size,
+                                            KEEPER_CONF.DATA_STORE_CONF.story_chunk_duration_secs,
+                                            KEEPER_CONF.DATA_STORE_CONF.acceptance_window_secs,
+                                            KEEPER_CONF.DATA_STORE_CONF.inactive_story_delay_secs);
 
     // Instantiate KeeperRecordingService
-    tl::engine*dataAdminEngine = nullptr;
+    tl::engine* dataAdminEngine = nullptr;
 
-    chronolog::DataStoreAdminService*keeperDataAdminService = nullptr;
+    chronolog::DataStoreAdminService* keeperDataAdminService = nullptr;
 
     try
     {
-        margo_instance_id collection_margo_id = margo_init(KEEPER_DATASTORE_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE
-                                                           , 1, 1);
+        margo_instance_id collection_margo_id =
+                margo_init(KEEPER_DATASTORE_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1, 1);
 
         dataAdminEngine = new tl::engine(collection_margo_id);
 
         std::stringstream s3;
         s3 << dataAdminEngine->self();
-        LOG_DEBUG("[ChronoKeeperInstance] GroupID={} starting DataStoreAdminService at address {} with ProviderID={}"
-                  , keeper_group_id, s3.str(), datastore_service_provider_id);
-        keeperDataAdminService = chronolog::DataStoreAdminService::CreateDataStoreAdminService(*dataAdminEngine
-                                                                                               , datastore_service_provider_id
-                                                                                               , theDataStore);
+        LOG_DEBUG("[ChronoKeeperInstance] GroupID={} starting DataStoreAdminService at address {} with ProviderID={}",
+                  keeper_group_id,
+                  s3.str(),
+                  datastore_service_provider_id);
+        keeperDataAdminService =
+                chronolog::DataStoreAdminService::CreateDataStoreAdminService(*dataAdminEngine,
+                                                                              datastore_service_provider_id,
+                                                                              theDataStore);
     }
-    catch(tl::exception const &)
+    catch(tl::exception const&)
     {
         LOG_ERROR("[ChronoKeeperInstance] Keeper failed to create DataStoreAdminService");
     }
@@ -226,13 +230,15 @@ int main(int argc, char**argv)
     {
         LOG_CRITICAL("[ChronoKeeperInstance] Keeper failed to create DataStoreAdminService exiting");
         if(dataAdminEngine)
-        { delete dataAdminEngine; }
+        {
+            delete dataAdminEngine;
+        }
         return (-1);
     }
 
     // Instantiate KeeperRecordingService
-    tl::engine*recordingEngine = nullptr;
-    chronolog::KeeperRecordingService*keeperRecordingService = nullptr;
+    tl::engine* recordingEngine = nullptr;
+    chronolog::KeeperRecordingService* keeperRecordingService = nullptr;
 
     try
     {
@@ -241,13 +247,16 @@ int main(int argc, char**argv)
 
         std::stringstream s1;
         s1 << recordingEngine->self();
-        LOG_INFO("[ChronoKeeperInstance] GroupID={} starting KeeperRecordingService at {} with provider_id {}"
-                 , keeper_group_id, s1.str(), recording_service_provider_id);
-        keeperRecordingService = chronolog::KeeperRecordingService::CreateKeeperRecordingService(*recordingEngine
-                                                                                                 , recording_service_provider_id
-                                                                                                 , ingestionQueue);
+        LOG_INFO("[ChronoKeeperInstance] GroupID={} starting KeeperRecordingService at {} with provider_id {}",
+                 keeper_group_id,
+                 s1.str(),
+                 recording_service_provider_id);
+        keeperRecordingService =
+                chronolog::KeeperRecordingService::CreateKeeperRecordingService(*recordingEngine,
+                                                                                recording_service_provider_id,
+                                                                                ingestionQueue);
     }
-    catch(tl::exception const &)
+    catch(tl::exception const&)
     {
         LOG_ERROR("[ChronoKeeperInstance] Keeper failed to create KeeperRecordingService");
     }
@@ -261,15 +270,16 @@ int main(int argc, char**argv)
 
     /// KeeperRegistryClient Set Up _____________________________________________________________________________________
     // create KeeperRegistryClient and register the new KeeperRecording service with the KeeperRegistry
-    std::string KEEPER_REGISTRY_SERVICE_NA_STRING =
-            KEEPER_CONF.VISOR_REGISTRY_SERVICE_CONF.PROTO_CONF + "://" +
-            KEEPER_CONF.VISOR_REGISTRY_SERVICE_CONF.IP + ":" +
-            std::to_string(KEEPER_CONF.VISOR_REGISTRY_SERVICE_CONF.BASE_PORT);
+    std::string KEEPER_REGISTRY_SERVICE_NA_STRING = KEEPER_CONF.VISOR_REGISTRY_SERVICE_CONF.PROTO_CONF + "://" +
+                                                    KEEPER_CONF.VISOR_REGISTRY_SERVICE_CONF.IP + ":" +
+                                                    std::to_string(KEEPER_CONF.VISOR_REGISTRY_SERVICE_CONF.BASE_PORT);
 
     uint16_t KEEPER_REGISTRY_SERVICE_PROVIDER_ID = KEEPER_CONF.VISOR_REGISTRY_SERVICE_CONF.SERVICE_PROVIDER_ID;
 
-    chronolog::KeeperRegistryClient*keeperRegistryClient = chronolog::KeeperRegistryClient::CreateKeeperRegistryClient(
-            *dataAdminEngine, KEEPER_REGISTRY_SERVICE_NA_STRING, KEEPER_REGISTRY_SERVICE_PROVIDER_ID);
+    chronolog::KeeperRegistryClient* keeperRegistryClient =
+            chronolog::KeeperRegistryClient::CreateKeeperRegistryClient(*dataAdminEngine,
+                                                                        KEEPER_REGISTRY_SERVICE_NA_STRING,
+                                                                        KEEPER_REGISTRY_SERVICE_PROVIDER_ID);
 
     if(nullptr == keeperRegistryClient)
     {

--- a/ChronoKeeper/src/KeeperDataStore.cpp
+++ b/ChronoKeeper/src/KeeperDataStore.cpp
@@ -2,6 +2,9 @@
 #include <map>
 #include <mutex>
 #include <chrono>
+#include <string>
+#include <cstdint>
+#include <memory>
 #include <thallium.hpp>
 
 #include <chronolog_errcode.h>

--- a/ChronoKeeper/src/KeeperDataStore.cpp
+++ b/ChronoKeeper/src/KeeperDataStore.cpp
@@ -18,17 +18,17 @@ namespace tl = thallium;
 class ClocksourceCPPStyle
 {
 public:
-    uint64_t getTimestamp()
-    {
-        return std::chrono::steady_clock::now().time_since_epoch().count();
-    }
+    uint64_t getTimestamp() { return std::chrono::steady_clock::now().time_since_epoch().count(); }
 };
 
 ////////////////////////
 
-int chronolog::KeeperDataStore::startStoryRecording(std::string const &chronicle, std::string const &story
-                                                    , chronolog::StoryId const &story_id, uint64_t start_time
-                                                    , uint32_t time_chunk_duration, uint32_t access_window)
+int chronolog::KeeperDataStore::startStoryRecording(std::string const& chronicle,
+                                                    std::string const& story,
+                                                    chronolog::StoryId const& story_id,
+                                                    uint64_t start_time,
+                                                    uint32_t time_chunk_duration,
+                                                    uint32_t access_window)
 {
     LOG_INFO("[KeeperDataStore] Start recording story: Chronicle={}, Story={}, StoryID={}", chronicle, story, story_id);
 
@@ -50,28 +50,35 @@ int chronolog::KeeperDataStore::startStoryRecording(std::string const &chronicle
     }
 
     auto result = theMapOfStoryPipelines.emplace(
-            std::pair <chl::StoryId, chl::StoryPipeline*>(story_id, new chl::StoryPipeline(theExtractionQueue, chronicle, story, story_id, start_time
-                                        , story_chunk_duration_secs, acceptance_window_secs)));
+            std::pair<chl::StoryId, chl::StoryPipeline*>(story_id,
+                                                         new chl::StoryPipeline(theExtractionQueue,
+                                                                                chronicle,
+                                                                                story,
+                                                                                story_id,
+                                                                                start_time,
+                                                                                story_chunk_duration_secs,
+                                                                                acceptance_window_secs)));
 
     if(result.second)
     {
         LOG_INFO("[KeeperDataStore] New StoryPipeline created successfully. StoryID: {}", story_id);
         pipeline_iter = result.first;
         //engage StoryPipeline with the IngestionQueue
-        StoryIngestionHandle*ingestionHandle = (*pipeline_iter).second->getActiveIngestionHandle();
+        StoryIngestionHandle* ingestionHandle = (*pipeline_iter).second->getActiveIngestionHandle();
         theIngestionQueue.addStoryIngestionHandle(story_id, ingestionHandle);
         return chronolog::CL_SUCCESS;
     }
     else
     {
-        LOG_ERROR("[KeeperDataStore] Failed to create StoryPipeline for StoryID: {}. Possible memory or resource issue."
-                  , story_id);
+        LOG_ERROR(
+                "[KeeperDataStore] Failed to create StoryPipeline for StoryID: {}. Possible memory or resource issue.",
+                story_id);
         return chronolog::CL_ERR_UNKNOWN;
     }
 }
 ////////////////////////
 
-int chronolog::KeeperDataStore::stopStoryRecording(chronolog::StoryId const &story_id)
+int chronolog::KeeperDataStore::stopStoryRecording(chronolog::StoryId const& story_id)
 {
     LOG_DEBUG("[KeeperDataStore] Initiating stop recording for StoryID={}", story_id);
     // we do not yet disengage the StoryPipeline from the IngestionQueue right away
@@ -84,10 +91,11 @@ int chronolog::KeeperDataStore::stopStoryRecording(chronolog::StoryId const &sto
     {
         uint64_t exit_time = std::chrono::high_resolution_clock::now().time_since_epoch().count() +
                              (*pipeline_iter).second->getAcceptanceWindow();
-        pipelinesWaitingForExit[(*pipeline_iter).first] = (std::pair <chl::StoryPipeline*, uint64_t>(
-                (*pipeline_iter).second, exit_time));
-        LOG_INFO("[KeeperDataStore] Added StoryPipeline to waiting list for finalization. StoryID={}, ExitTime={}"
-                 , story_id, exit_time);
+        pipelinesWaitingForExit[(*pipeline_iter).first] =
+                (std::pair<chl::StoryPipeline*, uint64_t>((*pipeline_iter).second, exit_time));
+        LOG_INFO("[KeeperDataStore] Added StoryPipeline to waiting list for finalization. StoryID={}, ExitTime={}",
+                 story_id,
+                 exit_time);
     }
     else
     {
@@ -100,14 +108,17 @@ int chronolog::KeeperDataStore::stopStoryRecording(chronolog::StoryId const &sto
 
 void chronolog::KeeperDataStore::collectIngestedEvents()
 {
-    LOG_DEBUG(
-            "[KeeperDataStore] Initiating collection of ingested events. Current state={}, Active StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-            , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+    LOG_DEBUG("[KeeperDataStore] Initiating collection of ingested events. Current state={}, Active StoryPipelines={}, "
+              "PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
     theIngestionQueue.drainOrphanEvents();
 
     std::lock_guard storeLock(dataStoreMutex);
-    for(auto pipeline_iter = theMapOfStoryPipelines.begin();
-        pipeline_iter != theMapOfStoryPipelines.end(); ++pipeline_iter)
+    for(auto pipeline_iter = theMapOfStoryPipelines.begin(); pipeline_iter != theMapOfStoryPipelines.end();
+        ++pipeline_iter)
     {
         //INNA: this can be delegated to different threads handling individual storylines...
         (*pipeline_iter).second->collectIngestedEvents();
@@ -117,15 +128,18 @@ void chronolog::KeeperDataStore::collectIngestedEvents()
 ////////////////////////
 void chronolog::KeeperDataStore::extractDecayedStoryChunks()
 {
-    LOG_DEBUG(
-            "[KeeperDataStore] Initiating extraction of decayed story chunks. Current state={}, Active StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-            , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+    LOG_DEBUG("[KeeperDataStore] Initiating extraction of decayed story chunks. Current state={}, Active "
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
 
     uint64_t current_time = std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
     std::lock_guard storeLock(dataStoreMutex);
-    for(auto pipeline_iter = theMapOfStoryPipelines.begin();
-        pipeline_iter != theMapOfStoryPipelines.end(); ++pipeline_iter)
+    for(auto pipeline_iter = theMapOfStoryPipelines.begin(); pipeline_iter != theMapOfStoryPipelines.end();
+        ++pipeline_iter)
     {
         (*pipeline_iter).second->extractDecayedStoryChunks(current_time);
     }
@@ -134,9 +148,12 @@ void chronolog::KeeperDataStore::extractDecayedStoryChunks()
 
 void chronolog::KeeperDataStore::retireDecayedPipelines()
 {
-    LOG_DEBUG(
-            "[KeeperDataStore] Initiating retirement of decayed pipelines. Current state={}, Active StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-            , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+    LOG_DEBUG("[KeeperDataStore] Initiating retirement of decayed pipelines. Current state={}, Active "
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
 
     if(!theMapOfStoryPipelines.empty())
     {
@@ -148,21 +165,25 @@ void chronolog::KeeperDataStore::retireDecayedPipelines()
             if(current_time >= (*pipeline_iter).second.second)
             {
                 //current_time >= pipeline exit_time
-                StoryPipeline*pipeline = (*pipeline_iter).second.first;
+                StoryPipeline* pipeline = (*pipeline_iter).second.first;
                 theMapOfStoryPipelines.erase(pipeline->getStoryId());
                 theIngestionQueue.removeIngestionHandle(pipeline->getStoryId());
                 pipeline_iter = pipelinesWaitingForExit.erase(pipeline_iter); //pipeline->getStoryId());
                 delete pipeline;
             }
             else
-            { pipeline_iter++; }
-
+            {
+                pipeline_iter++;
+            }
         }
     }
     //swipe through pipelineswaiting and remove all those with nullptr
-    LOG_DEBUG(
-            "[KeeperDataStore] Completed retirement of decayed pipelines. Current state={}, Active StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-            , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+    LOG_DEBUG("[KeeperDataStore] Completed retirement of decayed pipelines. Current state={}, Active "
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
 }
 
 void chronolog::KeeperDataStore::dataCollectionTask()
@@ -171,13 +192,15 @@ void chronolog::KeeperDataStore::dataCollectionTask()
     // or there're still events left to collect and
     // storyPipelines left to retire...
     tl::xstream es = tl::xstream::self();
-    LOG_DEBUG("[KeeperDataStore] Initiating DataCollectionTask. ESrank={}, ThreadID={}", es.get_rank()
-              , tl::thread::self_id());
+    LOG_DEBUG("[KeeperDataStore] Initiating DataCollectionTask. ESrank={}, ThreadID={}",
+              es.get_rank(),
+              tl::thread::self_id());
 
     while(!is_shutting_down() || !theIngestionQueue.is_empty() || !theMapOfStoryPipelines.empty())
     {
-        LOG_DEBUG("[KeeperDataStore] Running DataCollection iteration. ESrank={}, ThreadID={}", es.get_rank()
-                  , tl::thread::self_id());
+        LOG_DEBUG("[KeeperDataStore] Running DataCollection iteration. ESrank={}, ThreadID={}",
+                  es.get_rank(),
+                  tl::thread::self_id());
         for(int i = 0; i < 6; ++i)
         {
             collectIngestedEvents();
@@ -199,32 +222,36 @@ void chronolog::KeeperDataStore::startDataCollection(int stream_count)
         return;
     }
 
-    LOG_INFO("[KeeperDataStore] Starting data collection. StreamCount={}, ThreadID={}", stream_count
-             , tl::thread::self_id());
+    LOG_INFO("[KeeperDataStore] Starting data collection. StreamCount={}, ThreadID={}",
+             stream_count,
+             tl::thread::self_id());
     state = RUNNING;
 
     for(int i = 0; i < stream_count; ++i)
     {
-        tl::managed <tl::xstream> es = tl::xstream::create();
+        tl::managed<tl::xstream> es = tl::xstream::create();
         dataStoreStreams.push_back(std::move(es));
     }
 
     for(int i = 0; i < 2 * stream_count; ++i)
     {
-        tl::managed <tl::thread> th = dataStoreStreams[i % (dataStoreStreams.size())]->make_thread([p = this]()
-                                                                                                   { p->dataCollectionTask(); });
+        tl::managed<tl::thread> th =
+                dataStoreStreams[i % (dataStoreStreams.size())]->make_thread([p = this]() { p->dataCollectionTask(); });
         dataStoreThreads.push_back(std::move(th));
     }
-    LOG_INFO("[KeeperDataStore] Data collection started successfully. Stream count={}, ThreadID={}", stream_count
-             , tl::thread::self_id());
+    LOG_INFO("[KeeperDataStore] Data collection started successfully. Stream count={}, ThreadID={}",
+             stream_count,
+             tl::thread::self_id());
 }
 //////////////////////////////
 
 void chronolog::KeeperDataStore::shutdownDataCollection()
 {
-    LOG_INFO(
-            "[KeeperDataStore] Initiating shutdown of DataCollection. CurrentState={}, Active StoryPipelines={}, PipelinesWaitingForExit={}"
-            , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size());
+    LOG_INFO("[KeeperDataStore] Initiating shutdown of DataCollection. CurrentState={}, Active StoryPipelines={}, "
+             "PipelinesWaitingForExit={}",
+             state,
+             theMapOfStoryPipelines.size(),
+             pipelinesWaitingForExit.size());
 
     // switch the state to shuttingDown
     std::lock_guard storeLock(dataStoreStateMutex);
@@ -241,14 +268,14 @@ void chronolog::KeeperDataStore::shutdownDataCollection()
         std::lock_guard storeLock(dataStoreMutex);
         uint64_t current_time = std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
-        for(auto pipeline_iter = theMapOfStoryPipelines.begin();
-            pipeline_iter != theMapOfStoryPipelines.end(); ++pipeline_iter)
+        for(auto pipeline_iter = theMapOfStoryPipelines.begin(); pipeline_iter != theMapOfStoryPipelines.end();
+            ++pipeline_iter)
         {
             if(pipelinesWaitingForExit.find((*pipeline_iter).first) == pipelinesWaitingForExit.end())
             {
                 uint64_t exit_time = current_time + (*pipeline_iter).second->getAcceptanceWindow();
-                pipelinesWaitingForExit[(*pipeline_iter).first] = (std::pair <chl::StoryPipeline*, uint64_t>(
-                        (*pipeline_iter).second, exit_time));
+                pipelinesWaitingForExit[(*pipeline_iter).first] =
+                        (std::pair<chl::StoryPipeline*, uint64_t>((*pipeline_iter).second, exit_time));
             }
         }
     }
@@ -256,16 +283,10 @@ void chronolog::KeeperDataStore::shutdownDataCollection()
     // Join threads & execution streams while holding stateMutex
     // and just wait until all the events are collected and
     // all the storyPipelines decay and retire
-    for(auto &th: dataStoreThreads)
-    {
-        th->join();
-    }
+    for(auto& th: dataStoreThreads) { th->join(); }
     LOG_INFO("[KeeperDataStore] All data collection threads have been joined.");
 
-    for(auto &es: dataStoreStreams)
-    {
-        es->join();
-    }
+    for(auto& es: dataStoreStreams) { es->join(); }
     LOG_INFO("[KeeperDataStore] All data collection streams have been joined.");
     LOG_INFO("[KeeperDataStore] DataCollection shutdown completed.");
 }
@@ -275,9 +296,9 @@ void chronolog::KeeperDataStore::shutdownDataCollection()
 //
 chronolog::KeeperDataStore::~KeeperDataStore()
 {
-    LOG_INFO("[KeeperDataStore] Destructor called. Initiating shutdown. Active StoryPipelines count={}"
-             , theMapOfStoryPipelines.size());
+    LOG_INFO("[KeeperDataStore] Destructor called. Initiating shutdown. Active StoryPipelines count={}",
+             theMapOfStoryPipelines.size());
     shutdownDataCollection();
-    LOG_INFO("[KeeperDataStore] Shutdown completed successfully. Active StoryPipelines count={}"
-             , theMapOfStoryPipelines.size());
+    LOG_INFO("[KeeperDataStore] Shutdown completed successfully. Active StoryPipelines count={}",
+             theMapOfStoryPipelines.size());
 }

--- a/ChronoKeeper/src/KeeperRegClient.cpp
+++ b/ChronoKeeper/src/KeeperRegClient.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <cstdlib>
+#include <string>
+#include <cstdint>
 #include <thallium.hpp>
 
 int main(int argc, char**argv)

--- a/ChronoKeeper/src/KeeperRegClient.cpp
+++ b/ChronoKeeper/src/KeeperRegClient.cpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <thallium.hpp>
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     if(argc != 3)
     {

--- a/ChronoKeeper/src/StoryChunkExtractor.cpp
+++ b/ChronoKeeper/src/StoryChunkExtractor.cpp
@@ -27,14 +27,14 @@ void chronolog::StoryChunkExtractorBase::startExtractionThreads(int stream_count
 
     for(int i = 0; i < stream_count; ++i)
     {
-        tl::managed <tl::xstream> es = tl::xstream::create();
+        tl::managed<tl::xstream> es = tl::xstream::create();
         extractionStreams.push_back(std::move(es));
     }
 
     for(int i = 0; i < stream_count; ++i)
     {
-        tl::managed <tl::thread> th = extractionStreams[i % extractionStreams.size()]->make_thread([p = this]()
-                                                                                                   { p->drainExtractionQueue(); });
+        tl::managed<tl::thread> th = extractionStreams[i % extractionStreams.size()]->make_thread(
+                [p = this]() { p->drainExtractionQueue(); });
         extractionThreads.push_back(std::move(th));
     }
 }
@@ -54,15 +54,9 @@ void chronolog::StoryChunkExtractorBase::shutdownExtractionThreads()
     LOG_DEBUG("[StoryChunkExtractionBase] Initiating shutdown. Queue size: {}", chunkExtractionQueue.size());
 
     // join threads & executionstreams while holding stateMutex
-    for(auto &eth: extractionThreads)
-    {
-        eth->join();
-    }
+    for(auto& eth: extractionThreads) { eth->join(); }
     LOG_DEBUG("[StoryChunkExtractionBase] Extraction threads successfully shut down.");
-    for(auto &es: extractionStreams)
-    {
-        es->join();
-    }
+    for(auto& es: extractionStreams) { es->join(); }
     LOG_DEBUG("[StoryChunkExtractionBase] Streams have been successfully closed.");
 }
 
@@ -86,14 +80,16 @@ void chronolog::StoryChunkExtractorBase::drainExtractionQueue()
     // and until the extractionQueue is drained in shutdown mode
     while((extractorState == RUNNING) || !chunkExtractionQueue.empty())
     {
-        LOG_DEBUG("[StoryChunkExtractionBase] Draining queue. ES Rank: {}, ULT ID: {}, Queue Size: {}", es.get_rank()
-                  , thallium::thread::self_id(), chunkExtractionQueue.size());
+        LOG_DEBUG("[StoryChunkExtractionBase] Draining queue. ES Rank: {}, ULT ID: {}, Queue Size: {}",
+                  es.get_rank(),
+                  thallium::thread::self_id(),
+                  chunkExtractionQueue.size());
 
         while(!chunkExtractionQueue.empty())
         {
-            StoryChunk*storyChunk = chunkExtractionQueue.ejectStoryChunk();
+            StoryChunk* storyChunk = chunkExtractionQueue.ejectStoryChunk();
             if(storyChunk == nullptr)
-                //the queue might have been drained by another thread before the current thread acquired extractionQueue mutex
+            //the queue might have been drained by another thread before the current thread acquired extractionQueue mutex
             {
                 LOG_WARNING("[StoryChunkExtractionBase] Failed to acquire a story chunk from the queue.");
                 break;
@@ -101,17 +97,22 @@ void chronolog::StoryChunkExtractorBase::drainExtractionQueue()
             int ret = processStoryChunk(storyChunk);
             if(ret == chronolog::CL_SUCCESS)
             {
-                LOG_DEBUG("[StoryChunkExtractionBase] Successfully processed a story chunk. ES Rank: {}, ULT ID: {}"
-                          , es.get_rank(), thallium::thread::self_id());
+                LOG_DEBUG("[StoryChunkExtractionBase] Successfully processed a story chunk. ES Rank: {}, ULT ID: {}",
+                          es.get_rank(),
+                          thallium::thread::self_id());
                 delete storyChunk;
             }
             else
             {
-                LOG_ERROR("[StoryChunkExtractionBase] Failed to process a story chunk, Error Code: {}. ES Rank: {}"
-                                  , ret, es.get_rank(), thallium::thread::self_id());
-                LOG_ERROR(
-                        "[StoryChunkExtractionBase] Stashing the story chunk for later processing... ES Rank: {}, ULT ID:"
-                        " {}", es.get_rank(), thallium::thread::self_id());
+                LOG_ERROR("[StoryChunkExtractionBase] Failed to process a story chunk, Error Code: {}. ES Rank: {}",
+                          ret,
+                          es.get_rank(),
+                          thallium::thread::self_id());
+                LOG_ERROR("[StoryChunkExtractionBase] Stashing the story chunk for later processing... ES Rank: {}, "
+                          "ULT ID:"
+                          " {}",
+                          es.get_rank(),
+                          thallium::thread::self_id());
                 chunkExtractionQueue.stashStoryChunk(storyChunk);
             }
         }

--- a/ChronoKeeper/src/StoryChunkExtractor.cpp
+++ b/ChronoKeeper/src/StoryChunkExtractor.cpp
@@ -1,4 +1,7 @@
 #include <unistd.h>
+#include <string>
+#include <cstdint>
+#include <memory>
 #include <thallium.hpp>
 
 #include <StoryChunkExtractor.h>

--- a/ChronoKeeper/src/StoryChunkExtractorRDMA.cpp
+++ b/ChronoKeeper/src/StoryChunkExtractorRDMA.cpp
@@ -12,10 +12,12 @@
 
 namespace tl = thallium;
 
-chronolog::StoryChunkExtractorRDMA::StoryChunkExtractorRDMA(tl::engine &extraction_engine
-                                                            , tl::remote_procedure &drain_to_grapher
-                                                            , tl::provider_handle &service_ph): extraction_engine(
-        extraction_engine), drain_to_grapher(drain_to_grapher), service_ph(service_ph)
+chronolog::StoryChunkExtractorRDMA::StoryChunkExtractorRDMA(tl::engine& extraction_engine,
+                                                            tl::remote_procedure& drain_to_grapher,
+                                                            tl::provider_handle& service_ph)
+    : extraction_engine(extraction_engine)
+    , drain_to_grapher(drain_to_grapher)
+    , service_ph(service_ph)
 {
     LOG_DEBUG("[StoryChunkExtractorRDMA] KeeperGrapherDrainService setup complete");
 }
@@ -26,13 +28,14 @@ chronolog::StoryChunkExtractorRDMA::~StoryChunkExtractorRDMA()
     drain_to_grapher.deregister();
 }
 
-int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk)
+int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk* story_chunk)
 {
     std::chrono::high_resolution_clock::time_point start, end;
     try
     {
-        LOG_DEBUG("[StoryChunkExtractorRDMA] Processing a story chunk, StoryID: {}, StartTime: {} ..."
-                  , story_chunk->getStoryId(), story_chunk->getStartTime());
+        LOG_DEBUG("[StoryChunkExtractorRDMA] Processing a story chunk, StoryID: {}, StartTime: {} ...",
+                  story_chunk->getStoryId(),
+                  story_chunk->getStartTime());
 #ifndef NDEBUG
         start = std::chrono::high_resolution_clock::now();
 #endif
@@ -46,11 +49,11 @@ int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk
 #ifndef NDEBUG
         end = std::chrono::high_resolution_clock::now();
         LOG_INFO("[StoryChunkExtractorRDMA] Serialization took {} us",
-                std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0);
+                 std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count() / 1000.0);
 #endif
         LOG_DEBUG("[StoryChunkExtractorRDMA] Serialized story chunk size: {}", serialized_story_chunk_size);
 
-        std::vector <std::pair <void*, std::size_t>> segments(1);
+        std::vector<std::pair<void*, std::size_t>> segments(1);
         segments[0].first = (void*)(serialized_story_chunk.data());
         segments[0].second = serialized_story_chunk_size;
         tl::bulk tl_bulk = extraction_engine.expose(segments, tl::bulk_mode::read_only);
@@ -62,36 +65,41 @@ int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk
 #ifndef NDEBUG
         end = std::chrono::high_resolution_clock::now();
         LOG_INFO("[StoryChunkExtractorRDMA] Draining to Grapher took {} us",
-                std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0);
+                 std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count() / 1000.0);
 #endif
         LOG_DEBUG("[StoryChunkExtractorRDMA] Draining to Grapher returned with result: {}", result);
 
         if(result == serialized_story_chunk_size)
         {
             LOG_INFO("[StoryChunkExtractorRDMA] Successfully drained a story chunk to Grapher, StoryID: {}, "
-                     "StartTime: {}", story_chunk->getStoryId(), story_chunk->getStartTime());
+                     "StartTime: {}",
+                     story_chunk->getStoryId(),
+                     story_chunk->getStartTime());
             return chronolog::CL_SUCCESS;
         }
         else
         {
             LOG_ERROR("[StoryChunkExtractorRDMA] Failed to drain a story chunk to Grapher, StoryID: {}, "
-                      "StartTime: {}, Error Code: {}", story_chunk->getStoryId(), story_chunk->getStartTime(), result);
+                      "StartTime: {}, Error Code: {}",
+                      story_chunk->getStoryId(),
+                      story_chunk->getStartTime(),
+                      result);
             return chronolog::CL_ERR_STORY_CHUNK_EXTRACTION;
         }
     }
-    catch(tl::exception const &ex)
+    catch(tl::exception const& ex)
     {
         LOG_ERROR("[StoryChunkExtractorRDMA] Thallium exception encountered draining story chunk to grapher.");
         LOG_ERROR("[StoryChunkExtractorRDMA] Exception: {}", ex.what());
         return (chronolog::CL_ERR_UNKNOWN);
     }
-    catch(cereal::Exception const &ex)
+    catch(cereal::Exception const& ex)
     {
         LOG_ERROR("[StoryChunkExtractorRDMA] Cereal exception encountered serializing story chunk.");
         LOG_ERROR("[StoryChunkExtractorRDMA] Exception: {}", ex.what());
         return chronolog::CL_ERR_UNKNOWN;
     }
-    catch(std::exception const &ex)
+    catch(std::exception const& ex)
     {
         LOG_ERROR("[StoryChunkExtractorRDMA] Standard exception encountered serializing story chunk.");
         LOG_ERROR("[StoryChunkExtractorRDMA] Exception: {}", ex.what());

--- a/ChronoKeeper/src/StoryChunkExtractorRDMA.cpp
+++ b/ChronoKeeper/src/StoryChunkExtractorRDMA.cpp
@@ -1,3 +1,10 @@
+#include <string>
+#include <sstream>
+#include <chrono>
+#include <cstdint>
+#include <vector>
+#include <utility>
+#include <stdexcept>
 #include <thallium/serialization/stl/vector.hpp>
 #include <cereal/archives/binary.hpp>
 

--- a/ChronoKeeper/src/StoryPipeline.cpp
+++ b/ChronoKeeper/src/StoryPipeline.cpp
@@ -1,6 +1,11 @@
 #include <deque>
 #include <map>
 #include <mutex>
+#include <string>
+#include <cstdint>
+#include <chrono>
+#include <ctime>
+#include <memory>
 
 #include <StoryChunk.h>
 #include <StoryPipeline.h>

--- a/ChronoKeeper/src/StoryPipeline.cpp
+++ b/ChronoKeeper/src/StoryPipeline.cpp
@@ -20,49 +20,64 @@ namespace chl = chronolog;
 
 ////////////////////////
 
-chronolog::StoryPipeline::StoryPipeline(StoryChunkExtractionQueue &extractionQueue, std::string const &chronicle_name
-                        , std::string const &story_name, chronolog::StoryId const &story_id
-                        , uint64_t story_start_time, uint32_t chunk_granularity
-                        , uint32_t acceptance_window)
-    : theExtractionQueue(extractionQueue), storyId(story_id)
-    , chronicleName(chronicle_name), storyName(story_name)
-    , chunkGranularity(chunk_granularity), acceptanceWindow(acceptance_window)
+chronolog::StoryPipeline::StoryPipeline(StoryChunkExtractionQueue& extractionQueue,
+                                        std::string const& chronicle_name,
+                                        std::string const& story_name,
+                                        chronolog::StoryId const& story_id,
+                                        uint64_t story_start_time,
+                                        uint32_t chunk_granularity,
+                                        uint32_t acceptance_window)
+    : theExtractionQueue(extractionQueue)
+    , storyId(story_id)
+    , chronicleName(chronicle_name)
+    , storyName(story_name)
+    , chunkGranularity(chunk_granularity)
+    , acceptanceWindow(acceptance_window)
     , activeIngestionHandle(nullptr)
 {
     activeIngestionHandle = new chl::StoryIngestionHandle(ingestionMutex, &eventQueue1, &eventQueue2);
 
-    //pre-initialize the pipeline map with the StoryChunks of chunkGranulary 
+    //pre-initialize the pipeline map with the StoryChunks of chunkGranulary
     // with the total timelength of at least 2 chunks (merging logic assumes at least 2 chunks in the active pipeline)
 
-    chunkGranularity *= 1000000000;    // seconds =>nanoseconds
-    acceptanceWindow *= 1000000000;    // seconds =>nanoseconds
+    chunkGranularity *= 1000000000; // seconds =>nanoseconds
+    acceptanceWindow *= 1000000000; // seconds =>nanoseconds
 
     //adjust the timeline start to the closest prior boundary of chunkGranularity
     story_start_time -= (story_start_time % chunkGranularity);
 
-    for(int i=0; i<3; ++i)
+    for(int i = 0; i < 3; ++i)
     {
-        StoryChunk * new_chunk = new chronolog::StoryChunk(chronicleName, storyName, storyId, (story_start_time + chunkGranularity*i), (story_start_time + chunkGranularity*(i+1)));
-        storyTimelineMap.insert( std::pair <uint64_t, chronolog::StoryChunk*>(new_chunk->getStartTime(), new_chunk));
+        StoryChunk* new_chunk = new chronolog::StoryChunk(chronicleName,
+                                                          storyName,
+                                                          storyId,
+                                                          (story_start_time + chunkGranularity * i),
+                                                          (story_start_time + chunkGranularity * (i + 1)));
+        storyTimelineMap.insert(std::pair<uint64_t, chronolog::StoryChunk*>(new_chunk->getStartTime(), new_chunk));
     }
 
-    auto timeline_start_point = std::chrono::time_point<std::chrono::system_clock,std::chrono::nanoseconds>{} // epoch_time_point{};
-        + std::chrono::nanoseconds(TimelineStart());
+    auto timeline_start_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>{}
+                                // epoch_time_point{};
+                                + std::chrono::nanoseconds(TimelineStart());
     std::time_t time_t_story_start = std::chrono::high_resolution_clock::to_time_t(timeline_start_point);
-    auto timeline_end_point = std::chrono::time_point<std::chrono::system_clock,std::chrono::nanoseconds>{}
-        + std::chrono::nanoseconds(TimelineEnd());
+    auto timeline_end_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>{} +
+                              std::chrono::nanoseconds(TimelineEnd());
     std::time_t time_t_story_end = std::chrono::high_resolution_clock::to_time_t(timeline_end_point);
     LOG_INFO("[StoryPipeline] Initialized StoryPipleine StoryID={}, {}-{} timeline {}-{} Start {} End {} "
-             "ChunkGranularity={} seconds, AcceptanceWindow={} seconds", storyId, chronicleName, storyName, TimelineStart(), TimelineEnd()
-            , std::ctime(&time_t_story_start), std::ctime(&time_t_story_end), chunkGranularity / 1000000000, acceptanceWindow / 1000000000);
-
+             "ChunkGranularity={} seconds, AcceptanceWindow={} seconds",
+             storyId,
+             chronicleName,
+             storyName,
+             TimelineStart(),
+             TimelineEnd(),
+             std::ctime(&time_t_story_start),
+             std::ctime(&time_t_story_end),
+             chunkGranularity / 1000000000,
+             acceptanceWindow / 1000000000);
 }
 ///////////////////////
 
-chl::StoryIngestionHandle*chl::StoryPipeline::getActiveIngestionHandle()
-{
-    return activeIngestionHandle;
-}
+chl::StoryIngestionHandle* chl::StoryPipeline::getActiveIngestionHandle() { return activeIngestionHandle; }
 
 ///////////////////////
 chronolog::StoryPipeline::~StoryPipeline()
@@ -74,7 +89,7 @@ chronolog::StoryPipeline::~StoryPipeline()
 
 void chronolog::StoryPipeline::finalize()
 {
-    //by this time activeIngestionHandle is disengaged from the IngestionQueue 
+    //by this time activeIngestionHandle is disengaged from the IngestionQueue
     // as part of KeeperDataStore::shutdown
     if(activeIngestionHandle != nullptr)
     {
@@ -93,19 +108,21 @@ void chronolog::StoryPipeline::finalize()
     //extract any remianing non-empty StoryChunks regardless of decay_time
     // an active pipeline is guaranteed to have at least 2 chunks at any moment...
     {
-        std::lock_guard <std::mutex> lock(sequencingMutex);
+        std::lock_guard<std::mutex> lock(sequencingMutex);
         while(!storyTimelineMap.empty())
         {
-            StoryChunk*extractedChunk = nullptr;
+            StoryChunk* extractedChunk = nullptr;
 
             extractedChunk = (*storyTimelineMap.begin()).second;
             storyTimelineMap.erase(storyTimelineMap.begin());
 
 #ifdef TRACE_CHUNK_EXTRACTION
-            LOG_TRACE("[StoryPipeline] Finalized chunk for StoryID={}. Is empty: {}", storyId, (extractedChunk->empty() ? "Yes" : "No"));
+            LOG_TRACE("[StoryPipeline] Finalized chunk for StoryID={}. Is empty: {}",
+                      storyId,
+                      (extractedChunk->empty() ? "Yes" : "No"));
 #endif
             if(extractedChunk->empty())
-            {  // no need to carry an empty chunk any further...
+            { // no need to carry an empty chunk any further...
                 delete extractedChunk;
             }
             else
@@ -119,21 +136,29 @@ void chronolog::StoryPipeline::finalize()
 
 /////////////////////
 
-std::map <uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::prependStoryChunk()
+std::map<uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::prependStoryChunk()
 {
     // prepend a storyChunk at the begining of  storyTimeline and return the iterator to the new node
 #ifdef TRACE_CHUNKING
-    std::chrono::time_point<std::chrono::system_clock,std::chrono::nanoseconds> epoch_time_point{};
-    auto chunk_start_point = epoch_time_point + std::chrono::nanoseconds(TimelineStart()-chunkGranularity);
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> epoch_time_point{};
+    auto chunk_start_point = epoch_time_point + std::chrono::nanoseconds(TimelineStart() - chunkGranularity);
     std::time_t time_t_chunk_start = std::chrono::high_resolution_clock::to_time_t(chunk_start_point);
     auto chunk_end_point = epoch_time_point + std::chrono::nanoseconds(TimelineStart());
     std::time_t time_t_chunk_end = std::chrono::high_resolution_clock::to_time_t(chunk_end_point);
     LOG_TRACE("[StoryPipeline] Prepending new chunk for StoryID={} timeline {}-{} prepend_chunk {}-{}",
-                               storyId, TimelineStart(), TimelineEnd(), std::ctime(&time_t_chunk_start), std::ctime(&time_t_chunk_end));
+              storyId,
+              TimelineStart(),
+              TimelineEnd(),
+              std::ctime(&time_t_chunk_start),
+              std::ctime(&time_t_chunk_end));
 #endif
     auto result = storyTimelineMap.insert(
-            std::pair <uint64_t, chronolog::StoryChunk*>(TimelineStart() - chunkGranularity, new chronolog::StoryChunk(
-                    chronicleName, storyName, storyId, TimelineStart() - chunkGranularity, TimelineStart())));
+            std::pair<uint64_t, chronolog::StoryChunk*>(TimelineStart() - chunkGranularity,
+                                                        new chronolog::StoryChunk(chronicleName,
+                                                                                  storyName,
+                                                                                  storyId,
+                                                                                  TimelineStart() - chunkGranularity,
+                                                                                  TimelineStart())));
     if(!result.second)
     {
         return storyTimelineMap.end();
@@ -145,22 +170,29 @@ std::map <uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::
 }
 /////////////////////////////
 
-std::map <uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::appendStoryChunk()
+std::map<uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::appendStoryChunk()
 {
     // append the next storyChunk at the end of storyTimeline and return the iterator to the new node
 #ifdef TRACE_CHUNKING
-    std::chrono::time_point<std::chrono::system_clock,std::chrono::nanoseconds> epoch_time_point{};
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> epoch_time_point{};
     auto chunk_start_point = epoch_time_point + std::chrono::nanoseconds(TimelineEnd());
     std::time_t time_t_chunk_start = std::chrono::high_resolution_clock::to_time_t(chunk_start_point);
-    auto chunk_end_point = epoch_time_point + std::chrono::nanoseconds(TimelineEnd()+chunkGranularity);
+    auto chunk_end_point = epoch_time_point + std::chrono::nanoseconds(TimelineEnd() + chunkGranularity);
     std::time_t time_t_chunk_end = std::chrono::high_resolution_clock::to_time_t(chunk_end_point);
     LOG_TRACE("[StoryPipeline] Appending new chunk for StoryID={} timeline {}-{} new_chunk {}-{}",
-                               storyId, TimelineStart(), TimelineEnd(), time_t_chunk_start,time_t_chunk_end);
+              storyId,
+              TimelineStart(),
+              TimelineEnd(),
+              time_t_chunk_start,
+              time_t_chunk_end);
 #endif
     auto result = storyTimelineMap.insert(
-            std::pair <uint64_t, chronolog::StoryChunk*>(TimelineEnd(), new chronolog::StoryChunk(chronicleName, storyName
-                                                                                                , storyId
-                                                                                                , TimelineEnd(), TimelineEnd() + chunkGranularity)));
+            std::pair<uint64_t, chronolog::StoryChunk*>(TimelineEnd(),
+                                                        new chronolog::StoryChunk(chronicleName,
+                                                                                  storyName,
+                                                                                  storyId,
+                                                                                  TimelineEnd(),
+                                                                                  TimelineEnd() + chunkGranularity)));
     if(!result.second)
     {
         return storyTimelineMap.end();
@@ -185,44 +217,51 @@ void chronolog::StoryPipeline::collectIngestedEvents()
 void chronolog::StoryPipeline::extractDecayedStoryChunks(uint64_t current_time)
 {
 #ifdef TRACE_CHUNK_EXTRACTION
-    auto current_point =
-            std::chrono::time_point <std::chrono::system_clock, std::chrono::nanoseconds>{} // epoch_time_point{};
-            + std::chrono::nanoseconds(current_time);
+    auto current_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>{}
+                         // epoch_time_point{};
+                         + std::chrono::nanoseconds(current_time);
     std::time_t time_t_current_time = std::chrono::high_resolution_clock::to_time_t(current_point);
     uint64_t head_chunk_end_time = (*storyTimelineMap.begin()).second->getEndTime();
-    auto decay_point =
-            std::chrono::time_point <std::chrono::system_clock, std::chrono::nanoseconds>{} // epoch_time_point{};
-            + std::chrono::nanoseconds(head_chunk_end_time + acceptanceWindow);
+    auto decay_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>{}
+                       // epoch_time_point{};
+                       + std::chrono::nanoseconds(head_chunk_end_time + acceptanceWindow);
     std::time_t time_t_decay = std::chrono::high_resolution_clock::to_time_t(decay_point);
-    LOG_TRACE("[StoryPipeline] StoryID: {} - Current time: {} - Timeline size: {} - Head chunk decay time: {}", storyId
-         , std::ctime(&time_t_current_time), storyTimelineMap.size(), std::ctime(&time_t_decay));
+    LOG_TRACE("[StoryPipeline] StoryID: {} - Current time: {} - Timeline size: {} - Head chunk decay time: {}",
+              storyId,
+              std::ctime(&time_t_current_time),
+              storyTimelineMap.size(),
+              std::ctime(&time_t_decay));
 #endif
 
     while(current_time >= acceptanceWindow + (*storyTimelineMap.begin()).second->getEndTime())
     {
-        StoryChunk*extractedChunk = nullptr;
+        StoryChunk* extractedChunk = nullptr;
 
         {
             // lock the TimelineMap & check that the decayed storychunk is still there
-            std::lock_guard <std::mutex> lock(sequencingMutex);
+            std::lock_guard<std::mutex> lock(sequencingMutex);
             if(current_time > acceptanceWindow + (*storyTimelineMap.begin()).second->getEndTime())
             {
                 extractedChunk = (*storyTimelineMap.begin()).second;
                 storyTimelineMap.erase(storyTimelineMap.begin());
                 if(storyTimelineMap.size() < 2)
-                    //keep at least 2 chunks in the map of active pipeline as merging relies on it ...
-                { appendStoryChunk(); }
+                //keep at least 2 chunks in the map of active pipeline as merging relies on it ...
+                {
+                    appendStoryChunk();
+                }
             }
         }
 
         if(extractedChunk != nullptr)
         {
 #ifdef TRACE_CHUNK_EXTRACTION
-            LOG_TRACE("[StoryPipeline] StoryID: {} - Extracted chunk with start time {} is empty: {}", storyId
-                 , extractedChunk->getStartTime(), (extractedChunk->empty() ? "Yes" : "No"));
+            LOG_TRACE("[StoryPipeline] StoryID: {} - Extracted chunk with start time {} is empty: {}",
+                      storyId,
+                      extractedChunk->getStartTime(),
+                      (extractedChunk->empty() ? "Yes" : "No"));
 #endif
             if(extractedChunk->empty())
-            {   // there's no need to carry an empty chunk any further...  
+            { // there's no need to carry an empty chunk any further...
                 delete extractedChunk;
             }
             else
@@ -232,29 +271,35 @@ void chronolog::StoryPipeline::extractDecayedStoryChunks(uint64_t current_time)
         }
     }
 #ifdef TRACE_CHUNK_EXTRACTION
-    LOG_TRACE("[StoryPipeline] Extracting decayed chunks for StoryID={}. Queue size: {}", storyId
-         , theExtractionQueue.size());
+    LOG_TRACE("[StoryPipeline] Extracting decayed chunks for StoryID={}. Queue size: {}",
+              storyId,
+              theExtractionQueue.size());
 #endif
 }
 
 ////////////////////
 
-void chronolog::StoryPipeline::mergeEvents(chronolog::EventDeque &event_deque)
+void chronolog::StoryPipeline::mergeEvents(chronolog::EventDeque& event_deque)
 {
     if(event_deque.empty())
-    { return; }
+    {
+        return;
+    }
 
-    std::lock_guard <std::mutex> lock(sequencingMutex);
+    std::lock_guard<std::mutex> lock(sequencingMutex);
     chl::LogEvent event;
     // the last chunk is most likely the one that would get the events, so we'd start with the last
     // chunk and do the lookup only if it's not the one
     // NOTE: we should never have less than 2 chunks in the active storyTimelineMap !!!
-    std::map <uint64_t, chronolog::StoryChunk*>::iterator chunk_to_merge_iter = --storyTimelineMap.end();
+    std::map<uint64_t, chronolog::StoryChunk*>::iterator chunk_to_merge_iter = --storyTimelineMap.end();
     while(!event_deque.empty())
     {
         event = event_deque.front();
-        LOG_DEBUG("[StoryPipeline] StoryID: {} [Start: {}, End: {}]: Merging event time: {}", storyId, TimelineStart()
-             , TimelineEnd(), event.time());
+        LOG_DEBUG("[StoryPipeline] StoryID: {} [Start: {}, End: {}]: Merging event time: {}",
+                  storyId,
+                  TimelineStart(),
+                  TimelineEnd(),
+                  event.time());
         if(TimelineStart() <= event.time() && event.time() < TimelineEnd())
         {
             // we expect the events in the deque to be mostly monotonous
@@ -264,55 +309,74 @@ void chronolog::StoryPipeline::mergeEvents(chronolog::EventDeque &event_deque)
             {
                 // find the new chunk_to_merge the event into : we are lookingt for
                 // the chunk preceeding the first chunk with the startTime > event.time()
-                chunk_to_merge_iter = storyTimelineMap.lower_bound(event.time());  
+                chunk_to_merge_iter = storyTimelineMap.lower_bound(event.time());
                 // in a rare case when the event.time() is exactly on the chunk.StartTime boundary merge into it right away,
                 //  otherwise merge into the preceeding chunk
-                if(chunk_to_merge_iter == storyTimelineMap.end() || (*chunk_to_merge_iter).second->getStartTime() > event.time())
-                { 
-                  chunk_to_merge_iter --;
+                if(chunk_to_merge_iter == storyTimelineMap.end() ||
+                   (*chunk_to_merge_iter).second->getStartTime() > event.time())
+                {
+                    chunk_to_merge_iter--;
                 }
-                
+
                 if(!(*chunk_to_merge_iter).second->insertEvent(event))
                 {
-                    LOG_ERROR("[StoryPipeline] StoryID: {} - Discarded event with timestamp: {}", storyId, event.time());
+                    LOG_ERROR("[StoryPipeline] StoryID: {} - Discarded event with timestamp: {}",
+                              storyId,
+                              event.time());
                 }
             }
         }
         else if(event.time() >= TimelineEnd())
-        {  //extend timeline forward
+        { //extend timeline forward
             while(event.time() >= TimelineEnd())
             {
                 chunk_to_merge_iter = appendStoryChunk();
                 if(chunk_to_merge_iter == storyTimelineMap.end())
-                { break; }
+                {
+                    break;
+                }
             }
             if(chunk_to_merge_iter != storyTimelineMap.end())
-            { (*chunk_to_merge_iter).second->insertEvent(event); }
+            {
+                (*chunk_to_merge_iter).second->insertEvent(event);
+            }
             else
             {
                 LOG_ERROR("[StoryPipeline] StoryID: {} - Discarding event with timestamp: {}", storyId, event.time());
             }
         }
         else
-        {  
+        {
             // a case of seriously delayed event that arrives at the ChronoKeeper after the StoryChunk it belongs to has already been extracted from the StoryPipeline
             // we need (1) to extend the pipeline into the past by prepending the story chunks and (2) to increase the acceptance window so that we don't have to keep prepending story chunks for the slow client - chrono_keeper connection case...
-             LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : delayed event {} - need to prepend chunks ", storyId, TimelineStart(), TimelineEnd(), event.time());
+            LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : delayed event {} - need to prepend chunks ",
+                      storyId,
+                      TimelineStart(),
+                      TimelineEnd(),
+                      event.time());
 
-            //we also increase the acceptance window for the slow story environment so that we do not have to keep prepending StoryChunks 
+            //we also increase the acceptance window for the slow story environment so that we do not have to keep prepending StoryChunks
             // and deal with auxiliary files if recording of this particular Story turns to be slow...
             acceptanceWindow = (TimelineStart() - event.time()) + 3000; //current delay + 3 microseconds buffer
 
-            LOG_INFO("[StoryPipeline] StoryId {} timeline {}-{} : increased acceptanceWindow to {} seconds", storyId, TimelineStart(), TimelineEnd(), acceptanceWindow/1000000000);
+            LOG_INFO("[StoryPipeline] StoryId {} timeline {}-{} : increased acceptanceWindow to {} seconds",
+                     storyId,
+                     TimelineStart(),
+                     TimelineEnd(),
+                     acceptanceWindow / 1000000000);
 
             while(event.time() < TimelineStart())
             {
                 chunk_to_merge_iter = chl::StoryPipeline::prependStoryChunk();
                 if(chunk_to_merge_iter == storyTimelineMap.end())
-                { break; }
+                {
+                    break;
+                }
             }
             if(chunk_to_merge_iter != storyTimelineMap.end())
-            { (*chunk_to_merge_iter).second->insertEvent(event); }
+            {
+                (*chunk_to_merge_iter).second->insertEvent(event);
+            }
             else
             {
                 LOG_ERROR("[StoryPipeline] StoryID: {} - Discarding event with timestamp: {}", storyId, event.time());

--- a/ChronoPlayer/include/ArchiveReadingAgent.h
+++ b/ChronoPlayer/include/ArchiveReadingAgent.h
@@ -15,23 +15,18 @@
 namespace chronolog
 {
 
-class DummyReadingAgent 
+class DummyReadingAgent
 {
 public:
-    DummyReadingAgent()
-    {}
-   
-    ~DummyReadingAgent()
-    {}
+    DummyReadingAgent() {}
 
-    int initialize()
-    { return 1; }
+    ~DummyReadingAgent() {}
 
-    int shutdown()
-    { return 1; }
+    int initialize() { return 1; }
 
-    int readArchivedStory( ChronicleName, StoryName, uint64_t, uint64_t, std::list<StoryChunk*>&)
-    { return 1; }
+    int shutdown() { return 1; }
+
+    int readArchivedStory(ChronicleName, StoryName, uint64_t, uint64_t, std::list<StoryChunk*>&) { return 1; }
 };
 
 class ArchiveReadingAgent
@@ -39,26 +34,24 @@ class ArchiveReadingAgent
 
     enum ReadingAgentState
     {
-        UNKNOWN = 0, 
-        RUNNING = 1,   
-        SHUTTING_DOWN = 2   
+        UNKNOWN = 0,
+        RUNNING = 1,
+        SHUTTING_DOWN = 2
     };
 
 
 public:
-    ArchiveReadingAgent( ArchiveReadingRequestQueue & request_queue, std::string const & archive_path)
+    ArchiveReadingAgent(ArchiveReadingRequestQueue& request_queue, std::string const& archive_path)
         : theReadingRequestQueue(request_queue)
         , agentState(UNKNOWN)
-        , theReadingAgent(archive_path, true)  // Default to polling mode
+        , theReadingAgent(archive_path, true) // Default to polling mode
     {}
 
     ~ArchiveReadingAgent();
 
-    bool is_running() const
-    { return (RUNNING == agentState); }
+    bool is_running() const { return (RUNNING == agentState); }
 
-    bool is_shutting_down() const
-    { return (SHUTTING_DOWN == agentState); }
+    bool is_shutting_down() const { return (SHUTTING_DOWN == agentState); }
 
     void startArchiveReading(int stream_count);
 
@@ -67,21 +60,20 @@ public:
     void archiveReadingTask();
 
 private:
-    ArchiveReadingAgent(ArchiveReadingAgent const &) = delete;
+    ArchiveReadingAgent(ArchiveReadingAgent const&) = delete;
 
-    ArchiveReadingAgent &operator=(ArchiveReadingAgent const &) = delete;
+    ArchiveReadingAgent& operator=(ArchiveReadingAgent const&) = delete;
 
-    ArchiveReadingRequestQueue & theReadingRequestQueue;
+    ArchiveReadingRequestQueue& theReadingRequestQueue;
 
     std::mutex agentStateMutex;
     ReadingAgentState agentState;
-    std::vector <thallium::managed <thallium::xstream>> archiveReadingStreams;
-    std::vector <thallium::managed <thallium::thread>> archiveReadingThreads;
+    std::vector<thallium::managed<thallium::xstream>> archiveReadingStreams;
+    std::vector<thallium::managed<thallium::thread>> archiveReadingThreads;
 
     //archiveSpecific readingAgent (template later on)
     HDF5ArchiveReadingAgent theReadingAgent;
-
 };
 
-}
+} // namespace chronolog
 #endif

--- a/ChronoPlayer/include/ArchiveReadingAgent.h
+++ b/ChronoPlayer/include/ArchiveReadingAgent.h
@@ -1,6 +1,8 @@
 #ifndef ARCHIVE_READING_AGENT_H
 #define ARCHIVE_READING_AGENT_H
 
+#include <string>
+#include <cstdint>
 #include <vector>
 #include <list>
 #include <map>

--- a/ChronoPlayer/include/ArchiveReadingRequestQueue.h
+++ b/ChronoPlayer/include/ArchiveReadingRequestQueue.h
@@ -1,6 +1,8 @@
 #ifndef ARCHIVE_READING_REQUEST_QUEUE_H
 #define ARCHIVE_READING_REQUEST_QUEUE_H
 
+#include <string>
+#include <cstdint>
 #include <mutex>
 #include <deque>
 

--- a/ChronoPlayer/include/ArchiveReadingRequestQueue.h
+++ b/ChronoPlayer/include/ArchiveReadingRequestQueue.h
@@ -15,54 +15,54 @@ class StoryChunkExtractionQueue;
 
 struct ArchiveReadingRequest
 {
-    StoryChunkExtractionQueue * storyChunkQueue;
+    StoryChunkExtractionQueue* storyChunkQueue;
     ChronicleName chronicleName;
-    StoryName     storyName;
-    chrono_time      startTime;
-    chrono_time      endTime;   
+    StoryName storyName;
+    chrono_time startTime;
+    chrono_time endTime;
 
-    ArchiveReadingRequest( StoryChunkExtractionQueue* queue = nullptr, 
-        ChronicleName const& chronicle=std::string(), StoryName const& story=std::string(), chrono_time const& start=0, chrono_time const& end=0)
-    : storyChunkQueue(queue)
-    , chronicleName(chronicle)
-    , storyName(story)
-    , startTime(start)
-    , endTime(end)
-    { } 
+    ArchiveReadingRequest(StoryChunkExtractionQueue* queue = nullptr,
+                          ChronicleName const& chronicle = std::string(),
+                          StoryName const& story = std::string(),
+                          chrono_time const& start = 0,
+                          chrono_time const& end = 0)
+        : storyChunkQueue(queue)
+        , chronicleName(chronicle)
+        , storyName(story)
+        , startTime(start)
+        , endTime(end)
+    {}
 };
 
 class ArchiveReadingRequestQueue
 {
 public:
-    ArchiveReadingRequestQueue()
-    {}
-    
-    ~ArchiveReadingRequestQueue()
-    {}
+    ArchiveReadingRequestQueue() {}
 
-    bool empty() const
-    {   return readingRequestQueue.empty(); }
+    ~ArchiveReadingRequestQueue() {}
+
+    bool empty() const { return readingRequestQueue.empty(); }
 
     void pushReadingRequest(ArchiveReadingRequest const& a_request)
     {
         std::lock_guard<std::mutex> lock(readingRequestQueueMutex);
         readingRequestQueue.push_back(a_request);
     }
-          
-    ArchiveReadingRequest & popReadingRequest( ArchiveReadingRequest & a_request)
+
+    ArchiveReadingRequest& popReadingRequest(ArchiveReadingRequest& a_request)
     {
         std::lock_guard<std::mutex> lock(readingRequestQueueMutex);
-        if( !readingRequestQueue.empty())
+        if(!readingRequestQueue.empty())
         {
             a_request = readingRequestQueue.front();
             readingRequestQueue.pop_front();
         }
-        else 
+        else
         {
-            a_request = ArchiveReadingRequest{nullptr,"","",0,0};
+            a_request = ArchiveReadingRequest{nullptr, "", "", 0, 0};
         }
 
-        return a_request;    
+        return a_request;
     }
 
     void clear()
@@ -71,17 +71,16 @@ public:
         readingRequestQueue.clear();
     }
 
-            
+
 private:
-    ArchiveReadingRequestQueue(ArchiveReadingRequestQueue const &) = delete;
+    ArchiveReadingRequestQueue(ArchiveReadingRequestQueue const&) = delete;
 
-    ArchiveReadingRequestQueue &operator=( ArchiveReadingRequestQueue const &) = delete;
+    ArchiveReadingRequestQueue& operator=(ArchiveReadingRequestQueue const&) = delete;
 
-    std::mutex  readingRequestQueueMutex;
+    std::mutex readingRequestQueueMutex;
     std::deque<ArchiveReadingRequest> readingRequestQueue;
-
 };
 
-}
+} // namespace chronolog
 
 #endif

--- a/ChronoPlayer/include/HDF5ArchiveReadingAgent.h
+++ b/ChronoPlayer/include/HDF5ArchiveReadingAgent.h
@@ -1,6 +1,10 @@
 #ifndef CHRONOLOG_HDF5ARCHIVEREADINGAGENT_H
 #define CHRONOLOG_HDF5ARCHIVEREADINGAGENT_H
 
+#include <cstdlib>
+#include <fstream>
+#include <algorithm>
+#include <cctype>
 #include <list>
 #include <string>
 #include <map>
@@ -8,6 +12,7 @@
 #include <thallium.hpp>
 #include <utility>
 
+#include <chrono_monitor.h>
 #include <StoryChunkIngestionQueue.h>
 
 namespace tl = thallium;

--- a/ChronoPlayer/include/HDF5ArchiveReadingAgent.h
+++ b/ChronoPlayer/include/HDF5ArchiveReadingAgent.h
@@ -28,16 +28,23 @@ namespace chronolog
 class HDF5ArchiveReadingAgent
 {
     // File system state tracking for polling
-    struct FileInfo 
+    struct FileInfo
     {
         std::string path;
         fs::file_time_type last_modified;
         std::uintmax_t file_size;
         bool is_directory;
-        
-        FileInfo() : file_size(0), is_directory(false) {}
+
+        FileInfo()
+            : file_size(0)
+            , is_directory(false)
+        {}
         FileInfo(const std::string& p, const fs::file_time_type& lm, std::uintmax_t fs, bool is_dir)
-            : path(p), last_modified(lm), file_size(fs), is_directory(is_dir) {}
+            : path(p)
+            , last_modified(lm)
+            , file_size(fs)
+            , is_directory(is_dir)
+        {}
     };
 
     // Directory caching for performance optimization
@@ -48,29 +55,35 @@ class HDF5ArchiveReadingAgent
         int64_t last_check_time_ns;
         bool has_changes;
 
-        DirectoryCache() : last_modified_ns(0), last_check_time_ns(0), has_changes(false) {}
-        DirectoryCache(const fs::path &p, int64_t lm_ns, int64_t lc_ns, bool changes)
-            : path(p), last_modified_ns(lm_ns), last_check_time_ns(lc_ns), has_changes(changes) {}
+        DirectoryCache()
+            : last_modified_ns(0)
+            , last_check_time_ns(0)
+            , has_changes(false)
+        {}
+        DirectoryCache(const fs::path& p, int64_t lm_ns, int64_t lc_ns, bool changes)
+            : path(p)
+            , last_modified_ns(lm_ns)
+            , last_check_time_ns(lc_ns)
+            , has_changes(changes)
+        {}
     };
 
 public:
-    explicit HDF5ArchiveReadingAgent(std::string const &archive_path, bool use_polling = true, 
-                                    std::chrono::milliseconds monitoring_interval = std::chrono::milliseconds(5000))
+    explicit HDF5ArchiveReadingAgent(std::string const& archive_path,
+                                     bool use_polling = true,
+                                     std::chrono::milliseconds monitoring_interval = std::chrono::milliseconds(5000))
         : archive_path_(fs::absolute(expandTilde(fs::path(archive_path))).make_preferred().string())
         , use_polling_(use_polling)
         , monitoring_interval_(monitoring_interval)
         , shutdown_requested_(false)
     {}
 
-    ~HDF5ArchiveReadingAgent()
-    {
-        shutdown();
-    }
+    ~HDF5ArchiveReadingAgent() { shutdown(); }
 
     int initialize()
     {
-        LOG_INFO("[HDF5ArchiveReadingAgent] Initializing, scanning archive path {} recursively to create the map ..."
-                 , archive_path_);
+        LOG_INFO("[HDF5ArchiveReadingAgent] Initializing, scanning archive path {} recursively to create the map ...",
+                 archive_path_);
         createStartTimeFileNameMap();
         return setUpFsMonitoring();
     }
@@ -88,13 +101,21 @@ public:
         return 0;
     }
 
-    int readStoryChunkFile(const ChronicleName&, const StoryName&, uint64_t, uint64_t, std::list<StoryChunk*>&
-                          , const std::string &);
+    int readStoryChunkFile(const ChronicleName&,
+                           const StoryName&,
+                           uint64_t,
+                           uint64_t,
+                           std::list<StoryChunk*>&,
+                           const std::string&);
 
-    int readArchivedStory(const ChronicleName&, const StoryName&, uint64_t, uint64_t, std::list<StoryChunk*>&
-                          , bool = false);
+    int readArchivedStory(const ChronicleName&,
+                          const StoryName&,
+                          uint64_t,
+                          uint64_t,
+                          std::list<StoryChunk*>&,
+                          bool = false);
 
-    static std::string getChronicleName(const std::string &file_name)
+    static std::string getChronicleName(const std::string& file_name)
     {
         // Example file name: /home/kfeng/chronolog/Debug/output/chronicle_0_0.story_0_0.1736806500.vlen.h5
         std::string base_name = fs::path(file_name).filename().string();
@@ -102,7 +123,7 @@ public:
         return chronicle_name;
     }
 
-    static std::string getStoryName(const std::string &file_name)
+    static std::string getStoryName(const std::string& file_name)
     {
         // Example file name: /home/kfeng/chronolog/Debug/output/chronicle_0_0.story_0_0.1736806500.vlen.h5
         std::string base_name = fs::path(file_name).filename().string();
@@ -112,26 +133,27 @@ public:
         return story_name;
     }
 
-    static uint64_t getStartTime(const std::string &file_name)
+    static uint64_t getStartTime(const std::string& file_name)
     {
         // Example file name: /home/kfeng/chronolog/Debug/output/chronicle_0_0.story_0_0.1736806500.vlen.h5
-//        LOG_DEBUG("[HDF5ArchiveReadingAgent] Extracting start time from file name: {}", file_name);
+        //        LOG_DEBUG("[HDF5ArchiveReadingAgent] Extracting start time from file name: {}", file_name);
         std::string base_name = fs::path(file_name).filename().string();
         size_t first_dot = base_name.find_first_of('.');
         size_t second_dot = base_name.find_first_of('.', first_dot + 1);
         size_t third_dot = base_name.find_first_of('.', second_dot + 1);
         std::string start_time_str = base_name.substr(second_dot + 1, third_dot - second_dot - 1);
-//        LOG_DEBUG("[HDF5ArchiveReadingAgent] Extracted start time: {}", start_time_str);
+        //        LOG_DEBUG("[HDF5ArchiveReadingAgent] Extracted start time: {}", start_time_str);
         uint64_t start_time_in_ns = 0;
         try
         {
             start_time_in_ns = std::stoull(start_time_str) * 1000000000;
             LOG_DEBUG("[HDF5ArchiveReadingAgent] Use start time={} for file map", start_time_in_ns);
         }
-        catch(const std::exception &e)
+        catch(const std::exception& e)
         {
-            LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to convert start time string '{}' to uint64_t: {}"
-                      , start_time_str, e.what());
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to convert start time string '{}' to uint64_t: {}",
+                      start_time_str,
+                      e.what());
         }
         return start_time_in_ns;
     }
@@ -141,52 +163,58 @@ private:
     {
         if(!path.empty() && path.string()[0] == '~')
         {
-            const char *home = getenv("HOME");
+            const char* home = getenv("HOME");
             if(home)
             {
                 fs::path expanded_path = fs::path(home) / path.string().substr(1);
-                LOG_DEBUG("[HDF5ArchiveReadingAgent] Expanding archive path from {} to {}"
-                          , path.string(), expanded_path.string());
+                LOG_DEBUG("[HDF5ArchiveReadingAgent] Expanding archive path from {} to {}",
+                          path.string(),
+                          expanded_path.string());
                 return expanded_path;
             }
             else
             {
-                LOG_ERROR("[HDF5ArchiveReadingAgent] HOME environment variable is not set. Cannot expand tilde in path: {}"
-                          , path.string());
+                LOG_ERROR("[HDF5ArchiveReadingAgent] HOME environment variable is not set. Cannot expand tilde in "
+                          "path: {}",
+                          path.string());
                 return path; // Return the original path if HOME is not set
             }
         }
         return path;
     }
 
-    bool isValidArchiveFile(const std::string &file_name)
+    bool isValidArchiveFile(const std::string& file_name)
     {
         fs::path expanded_full_path = fs::absolute(fs::path(file_name));
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] Checking if file {} is a valid archive file.", expanded_full_path.string());
-        
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] Checking if file {} is a valid archive file.",
+                  expanded_full_path.string());
+
         // Quick check: file extension first
         if(expanded_full_path.extension() != ".h5")
         {
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] File {} is not an HDF5 file. Skipping this file.", expanded_full_path.string());
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] File {} is not an HDF5 file. Skipping this file.",
+                      expanded_full_path.string());
             return false;
         }
-        
+
         // Check if file exists and is readable using access()
         if(access(expanded_full_path.c_str(), R_OK) != 0)
         {
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] File {} is not readable. Skipping this file.", expanded_full_path.string());
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] File {} is not readable. Skipping this file.",
+                      expanded_full_path.string());
             return false;
         }
-        
+
         // Verify it's a regular file using filesystem
         fs::directory_entry entry(expanded_full_path);
         std::error_code ec;
         if(!entry.is_regular_file(ec))
         {
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] File {} is not a regular file. Skipping this file.", expanded_full_path.string());
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] File {} is not a regular file. Skipping this file.",
+                      expanded_full_path.string());
             return false;
         }
-        
+
         return true;
     }
 
@@ -207,7 +235,8 @@ private:
     // Directory caching methods
     int64_t getDirectoryModificationTime(const fs::path& dir_path, std::error_code& ec);
     bool hasDirectoryChangedWithCache(const fs::path& dir_path, int64_t last_scan_ns, std::error_code& ec);
-    void updateDirectoryCache(const fs::path& dir_path, int64_t last_modified_ns, int64_t check_time_ns, bool has_changes);
+    void
+    updateDirectoryCache(const fs::path& dir_path, int64_t last_modified_ns, int64_t check_time_ns, bool has_changes);
     void clearDirectoryCache();
 
     int createStartTimeFileNameMap()
@@ -218,12 +247,13 @@ private:
         auto it = fs::recursive_directory_iterator(archive_path_, fs::directory_options::skip_permission_denied, ec);
         if(ec)
         {
-            LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to iterate recursively over archive directory '{}': {}"
-                      , archive_path_, ec.message());
+            LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to iterate recursively over archive directory '{}': {}",
+                      archive_path_,
+                      ec.message());
             return -1; // Return error code on failure
         }
         std::string file_name, chronicle_name, story_name;
-        for(const auto &entry: it)
+        for(const auto& entry: it)
         {
             if(ec)
             {
@@ -237,12 +267,12 @@ private:
             addFileToStartTimeFileNameMap(file_name);
         }
 
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] Created start_time_file_name_map_ with {} entries."
-                  , start_time_file_name_map_.size());
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] Created start_time_file_name_map_ with {} entries.",
+                  start_time_file_name_map_.size());
         return 0;
     }
 
-    int addFileToStartTimeFileNameMap(const std::string &file_name)
+    int addFileToStartTimeFileNameMap(const std::string& file_name)
     {
         std::lock_guard<std::mutex> lock(start_time_file_name_map_mutex_);
         if(!isValidArchiveFile(file_name))
@@ -255,26 +285,26 @@ private:
         uint64_t start_time = getStartTime(file_name);
         if(start_time == 0)
         {
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] Failed to extract start time from file: {}. Skipping this file."
-                      , file_name);
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] Failed to extract start time from file: {}. Skipping this file.",
+                      file_name);
             return -1; // Skip files with invalid start time
         }
         std::string file_name_number = fs::path(file_name).replace_extension("").extension().string().substr(1);
         if(std::all_of(file_name_number.begin(), file_name_number.end(), ::isdigit))
         {
             LOG_DEBUG("[HDF5ArchiveReadingAgent] {} is an auxiliary file. Skipping this file.", file_name);
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] start_time_file_name_map_ has {} entries."
-                      , start_time_file_name_map_.size());
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] start_time_file_name_map_ has {} entries.",
+                      start_time_file_name_map_.size());
             return -1; // Skip files that already exist in the map
         }
         start_time_file_name_map_[std::make_tuple(chronicle_name, story_name, start_time)] = file_name;
         LOG_DEBUG("[HDF5ArchiveReadingAgent] Added file {} to start_time_file_name_map_.", file_name);
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] start_time_file_name_map_ has {} entries."
-                  , start_time_file_name_map_.size());
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] start_time_file_name_map_ has {} entries.",
+                  start_time_file_name_map_.size());
         return 0;
     }
 
-    int removeFileFromStartTimeFileNameMap(const std::string &file_name)
+    int removeFileFromStartTimeFileNameMap(const std::string& file_name)
     {
         std::lock_guard<std::mutex> lock(start_time_file_name_map_mutex_);
         std::string chronicle_name = getChronicleName(file_name);
@@ -290,8 +320,8 @@ private:
         if(std::all_of(file_name_number.begin(), file_name_number.end(), ::isdigit))
         {
             LOG_DEBUG("[HDF5ArchiveReadingAgent] {} is an auxiliary file. Skipping this file.", file_name);
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] start_time_file_name_map_ has {} entries."
-                      , start_time_file_name_map_.size());
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] start_time_file_name_map_ has {} entries.",
+                      start_time_file_name_map_.size());
             return -1; // Skip files that already exist in the map
         }
         start_time_file_name_map_.erase(std::make_tuple(chronicle_name, story_name, start_time));
@@ -301,12 +331,13 @@ private:
         return 0;
     }
 
-    int renameFileInStartTimeFileNameMap(const std::string &old_file_name, const std::string &new_file_name)
+    int renameFileInStartTimeFileNameMap(const std::string& old_file_name, const std::string& new_file_name)
     {
         removeFileFromStartTimeFileNameMap(old_file_name);
         addFileToStartTimeFileNameMap(new_file_name);
         LOG_DEBUG("[HDF5ArchiveReadingAgent] Renamed file {} to {} in start_time_file_name_map_.",
-                  old_file_name, new_file_name);
+                  old_file_name,
+                  new_file_name);
         LOG_DEBUG("[HDF5ArchiveReadingAgent] start_time_file_name_map_ has {} entries.",
                   start_time_file_name_map_.size());
         return 0;
@@ -315,14 +346,14 @@ private:
     std::string archive_path_;
     std::map<std::tuple<std::string, std::string, uint64_t>, std::string> start_time_file_name_map_;
     std::mutex start_time_file_name_map_mutex_;
-    tl::managed <tl::xstream> archive_dir_monitoring_stream_;
-    tl::managed <tl::thread> archive_dir_monitoring_thread_;
+    tl::managed<tl::xstream> archive_dir_monitoring_stream_;
+    tl::managed<tl::thread> archive_dir_monitoring_thread_;
 
     // Feature flag and monitoring configuration
     bool use_polling_;
     std::chrono::milliseconds monitoring_interval_;
     std::chrono::system_clock::time_point last_scan_time_;
-    
+
     // File system state tracking for polling
     std::map<std::string, FileInfo> previous_file_state_;
     std::mutex file_state_mutex_;
@@ -330,11 +361,11 @@ private:
     // Directory caching for performance optimization
     std::map<fs::path, DirectoryCache> directory_cache_;
     std::mutex directory_cache_mutex_;
-    
+
     // Thread control
     std::atomic<bool> shutdown_requested_;
 };
 
-} // chronolog
+} // namespace chronolog
 
 #endif //CHRONOLOG_HDF5ARCHIVEREADINGAGENT_H

--- a/ChronoPlayer/include/PlaybackService.h
+++ b/ChronoPlayer/include/PlaybackService.h
@@ -18,40 +18,44 @@ namespace tl = thallium;
 namespace chronolog
 {
 
-class StoryChunkTransferAgent; 
+class StoryChunkTransferAgent;
 
-class PlaybackService: public tl::provider <PlaybackService>
+class PlaybackService: public tl::provider<PlaybackService>
 {
 public:
     // Service should be created on the heap not the stack thus the constructor is private...
-    static PlaybackService*
-    CreatePlaybackService(tl::engine &tl_engine, uint16_t service_provider_id, ArchiveReadingRequestQueue & archiveReadingQueue)
+    static PlaybackService* CreatePlaybackService(tl::engine& tl_engine,
+                                                  uint16_t service_provider_id,
+                                                  ArchiveReadingRequestQueue& archiveReadingQueue)
     {
         return new PlaybackService(tl_engine, service_provider_id, archiveReadingQueue);
     }
 
     ~PlaybackService();
 
-    void playback_service_available(tl::request const &request);
+    void playback_service_available(tl::request const& request);
 
-    void
-    story_playback_request(tl::request const &request, ServiceId const & requesting_service_id, uint32_t query_id
-            , ChronicleName const &chronicle_name, StoryName const &story_name, chrono_time const& start_time, chrono_time const& end_time);
+    void story_playback_request(tl::request const& request,
+                                ServiceId const& requesting_service_id,
+                                uint32_t query_id,
+                                ChronicleName const& chronicle_name,
+                                StoryName const& story_name,
+                                chrono_time const& start_time,
+                                chrono_time const& end_time);
 
 private:
-    PlaybackService(tl::engine &tl_engine, uint16_t service_provider_id
-        , ArchiveReadingRequestQueue & reading_queue);
+    PlaybackService(tl::engine& tl_engine, uint16_t service_provider_id, ArchiveReadingRequestQueue& reading_queue);
 
     PlaybackService() = delete;
-    PlaybackService(PlaybackService const &) = delete;
-    PlaybackService &operator=(PlaybackService const &) = delete;
+    PlaybackService(PlaybackService const&) = delete;
+    PlaybackService& operator=(PlaybackService const&) = delete;
 
-    tl::engine  playbackEngine;
-    ArchiveReadingRequestQueue & theArchiveReadingRequestQueue;
+    tl::engine playbackEngine;
+    ArchiveReadingRequestQueue& theArchiveReadingRequestQueue;
     std::mutex playbackServiceMutex;
     std::map<service_endpoint, StoryChunkTransferAgent*> chunkSenders;
 };
 
-}// namespace chronolog
+} // namespace chronolog
 
 #endif

--- a/ChronoPlayer/include/PlaybackService.h
+++ b/ChronoPlayer/include/PlaybackService.h
@@ -1,10 +1,13 @@
 #ifndef PLAYBACK_SERVICE_H
 #define PLAYBACK_SERVICE_H
 
+#include <string>
+#include <cstdint>
 #include <iostream>
 #include <mutex>
 #include <thallium.hpp>
 
+#include <chrono_monitor.h>
 #include <chronolog_types.h>
 #include <ServiceId.h>
 

--- a/ChronoPlayer/include/PlayerDataStore.h
+++ b/ChronoPlayer/include/PlayerDataStore.h
@@ -24,14 +24,14 @@ class PlayerDataStore
 
     enum DataStoreState
     {
-        UNKNOWN = 0, 
-        RUNNING = 1,    //  active stories
-        SHUTTING_DOWN = 2    // Shutting down services
+        UNKNOWN = 0,
+        RUNNING = 1,      //  active stories
+        SHUTTING_DOWN = 2 // Shutting down services
     };
 
 
 public:
-    PlayerDataStore(StoryChunkIngestionQueue &ingestion_queue, StoryChunkExtractionQueue &extraction_queue)
+    PlayerDataStore(StoryChunkIngestionQueue& ingestion_queue, StoryChunkExtractionQueue& extraction_queue)
         : state(UNKNOWN)
         , theIngestionQueue(ingestion_queue)
         , theExtractionQueue(extraction_queue)
@@ -39,12 +39,10 @@ public:
 
     ~PlayerDataStore();
 
-    bool is_running() const
-    { return (RUNNING == state); }
+    bool is_running() const { return (RUNNING == state); }
 
-    bool is_shutting_down() const
-    { return (SHUTTING_DOWN == state); }
-/*
+    bool is_shutting_down() const { return (SHUTTING_DOWN == state); }
+    /*
     int startStoryRecording(ChronicleName const &, StoryName const &, StoryId const &, uint64_t start_time
                             , uint32_t time_chunk_ranularity = 30, uint32_t access_window = 300);
 
@@ -63,22 +61,21 @@ public:
     void dataCollectionTask();
 
 private:
-    PlayerDataStore(PlayerDataStore const &) = delete;
+    PlayerDataStore(PlayerDataStore const&) = delete;
 
-    PlayerDataStore &operator=(PlayerDataStore const &) = delete;
+    PlayerDataStore& operator=(PlayerDataStore const&) = delete;
 
     DataStoreState state;
     std::mutex dataStoreStateMutex;
-    StoryChunkIngestionQueue &theIngestionQueue;
-    StoryChunkExtractionQueue &theExtractionQueue;
-    std::vector <thallium::managed <thallium::xstream>> dataStoreStreams;
-    std::vector <thallium::managed <thallium::thread>> dataStoreThreads;
+    StoryChunkIngestionQueue& theIngestionQueue;
+    StoryChunkExtractionQueue& theExtractionQueue;
+    std::vector<thallium::managed<thallium::xstream>> dataStoreStreams;
+    std::vector<thallium::managed<thallium::thread>> dataStoreThreads;
 
     std::mutex dataStoreMutex;
-    std::unordered_map <StoryId, StoryPipeline*> theMapOfStoryPipelines;
-    std::unordered_map <StoryId, std::pair <StoryPipeline*, uint64_t>> pipelinesWaitingForExit;
-
+    std::unordered_map<StoryId, StoryPipeline*> theMapOfStoryPipelines;
+    std::unordered_map<StoryId, std::pair<StoryPipeline*, uint64_t>> pipelinesWaitingForExit;
 };
 
-}
+} // namespace chronolog
 #endif

--- a/ChronoPlayer/include/PlayerDataStore.h
+++ b/ChronoPlayer/include/PlayerDataStore.h
@@ -1,9 +1,12 @@
 #ifndef PLAYER_DATA_STORE_H
 #define PLAYER_DATA_STORE_H
 
+#include <string>
+#include <cstdint>
 #include <vector>
 #include <list>
 #include <map>
+#include <unordered_map>
 #include <mutex>
 #include <thallium.hpp>
 

--- a/ChronoPlayer/include/PlayerRegClient.h
+++ b/ChronoPlayer/include/PlayerRegClient.h
@@ -1,15 +1,18 @@
 #ifndef PLAYER_REG_CLIENT_H
 #define PLAYER_REG_CLIENT_H
 
+#include <string>
+#include <cstdint>
+#include <sstream>
 #include <iostream>
 #include <thallium/serialization/stl/string.hpp>
 #include <thallium.hpp>
 
+#include <chrono_monitor.h>
 #include <PlayerIdCard.h>
 #include <PlayerRegistrationMsg.h>
 #include <PlayerStatsMsg.h>
 #include <chronolog_errcode.h>
-#include <chrono_monitor.h>
 
 
 namespace tl = thallium;

--- a/ChronoPlayer/include/PlayerRegClient.h
+++ b/ChronoPlayer/include/PlayerRegClient.h
@@ -26,21 +26,20 @@ class PlayerRegistryClient
 
 public:
     static PlayerRegistryClient*
-    CreateRegistryClient(tl::engine &tl_engine, std::string const &registry_service_addr
-                               , uint16_t registry_provider_id)
+    CreateRegistryClient(tl::engine& tl_engine, std::string const& registry_service_addr, uint16_t registry_provider_id)
     {
         try
         {
             return new PlayerRegistryClient(tl_engine, registry_service_addr, registry_provider_id);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[PlayerRegistryClient] Failed to create PlayerRegistryClient");
             return nullptr;
         }
     }
 
-    int send_register_msg(PlayerRegistrationMsg const & msg)
+    int send_register_msg(PlayerRegistrationMsg const& msg)
     {
         try
         {
@@ -49,14 +48,14 @@ public:
             LOG_DEBUG("[PlayerRegistryClient] Sending Registration Message: {}", ss.str());
             return register_player.on(reg_service_ph)(msg);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[PlayerRegistryClient] Failed Sending Registration Message.");
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
 
-    int send_unregister_msg(PlayerIdCard const &playerIdCard)
+    int send_unregister_msg(PlayerIdCard const& playerIdCard)
     {
         try
         {
@@ -65,14 +64,14 @@ public:
             LOG_DEBUG("[PlayerRegistryClient] Sending Unregister Message: {}", ss.str());
             return unregister_player.on(reg_service_ph)(playerIdCard);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[PlayerRegistryClient] Failed Sending Unregistered Message.");
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
 
-    void send_stats_msg(PlayerStatsMsg const & statsMsg)
+    void send_stats_msg(PlayerStatsMsg const& statsMsg)
     {
         try
         {
@@ -81,7 +80,7 @@ public:
             LOG_DEBUG("[PlayerRegistryClient] Sending Stats Message: {}", stats.str());
             handle_player_stats_msg.on(reg_service_ph)(statsMsg);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[PlayerRegisterClient] Failed Sending Stats Message.");
         }
@@ -96,25 +95,27 @@ public:
     }
 
 private:
-    std::string reg_service_addr;     // na address of Keeper Registry Service 
-    uint16_t reg_service_provider_id;          // KeeperRegistryService provider id
-    tl::provider_handle reg_service_ph;  //provider_handle for remote registry service
+    std::string reg_service_addr;       // na address of Keeper Registry Service
+    uint16_t reg_service_provider_id;   // KeeperRegistryService provider id
+    tl::provider_handle reg_service_ph; //provider_handle for remote registry service
     tl::remote_procedure register_player;
     tl::remote_procedure unregister_player;
     tl::remote_procedure handle_player_stats_msg;
 
     // constructor is private to make sure thalium rpc objects are created on the heap, not stack
-    PlayerRegistryClient(tl::engine &tl_engine, std::string const &registry_addr, uint16_t registry_provider_id)
-            : reg_service_addr(registry_addr), reg_service_provider_id(registry_provider_id), reg_service_ph(
-            tl_engine.lookup(registry_addr), registry_provider_id)
+    PlayerRegistryClient(tl::engine& tl_engine, std::string const& registry_addr, uint16_t registry_provider_id)
+        : reg_service_addr(registry_addr)
+        , reg_service_provider_id(registry_provider_id)
+        , reg_service_ph(tl_engine.lookup(registry_addr), registry_provider_id)
     {
-        LOG_DEBUG("[PlayerRegistryClient] Initialized for RegistryService at {} with ProviderID={}", registry_addr
-             , registry_provider_id);
+        LOG_DEBUG("[PlayerRegistryClient] Initialized for RegistryService at {} with ProviderID={}",
+                  registry_addr,
+                  registry_provider_id);
         register_player = tl_engine.define("register_player");
         unregister_player = tl_engine.define("unregister_player");
         handle_player_stats_msg = tl_engine.define("handle_player_stats_msg").disable_response();
     }
 };
-}
+} // namespace chronolog
 
 #endif

--- a/ChronoPlayer/include/PlayerStoreAdminService.h
+++ b/ChronoPlayer/include/PlayerStoreAdminService.h
@@ -18,12 +18,13 @@ namespace tl = thallium;
 namespace chronolog
 {
 
-class PlayerStoreAdminService: public tl::provider <PlayerStoreAdminService>
+class PlayerStoreAdminService: public tl::provider<PlayerStoreAdminService>
 {
 public:
     // Service should be created on the heap not the stack thus the constructor is private...
-    static PlayerStoreAdminService*
-    CreatePlayerStoreAdminService(tl::engine &tl_engine, uint16_t service_provider_id, PlayerDataStore &dataStoreInstance)
+    static PlayerStoreAdminService* CreatePlayerStoreAdminService(tl::engine& tl_engine,
+                                                                  uint16_t service_provider_id,
+                                                                  PlayerDataStore& dataStoreInstance)
     {
         return new PlayerStoreAdminService(tl_engine, service_provider_id, dataStoreInstance);
     }
@@ -35,18 +36,15 @@ public:
         get_engine().pop_finalize_callback(this);
     }
 
-    void collection_service_available(tl::request const &request)
-    {
-        request.respond(1);
-    }
+    void collection_service_available(tl::request const& request) { request.respond(1); }
 
-    void shutdown_data_collection(tl::request const &request)
+    void shutdown_data_collection(tl::request const& request)
     {
         int status = 1;
         theDataStore.shutdownDataCollection();
         request.respond(status);
     }
-/*
+    /*
     void
     StartStoryRecording(tl::request const &request, std::string const &chronicle_name, std::string const &story_name
                         , StoryId const &story_id, uint64_t start_time)
@@ -64,29 +62,29 @@ public:
     }
 */
 private:
-    PlayerStoreAdminService(tl::engine &tl_engine, uint16_t service_provider_id, PlayerDataStore &data_store_instance)
-            : tl::provider <PlayerStoreAdminService>(tl_engine, service_provider_id), theDataStore(data_store_instance)
+    PlayerStoreAdminService(tl::engine& tl_engine, uint16_t service_provider_id, PlayerDataStore& data_store_instance)
+        : tl::provider<PlayerStoreAdminService>(tl_engine, service_provider_id)
+        , theDataStore(data_store_instance)
     {
         define("collection_service_available", &PlayerStoreAdminService::collection_service_available);
         define("shutdown_data_collection", &PlayerStoreAdminService::shutdown_data_collection);
         //define("start_story_recording", &DataStoreAdminService::StartStoryRecording);
         //define("stop_story_recording", &DataStoreAdminService::StopStoryRecording);
         //set up callback for the case when the engine is being finalized while this provider is still alive
-        get_engine().push_finalize_callback(this, [p = this]()
-        { delete p; });
+        get_engine().push_finalize_callback(this, [p = this]() { delete p; });
 
         std::stringstream ss;
         ss << get_engine().self();
         LOG_INFO("[PlayerStoreAdminService] Constructed at {}. ProviderID={}", ss.str(), service_provider_id);
     }
 
-    PlayerStoreAdminService(PlayerStoreAdminService const &) = delete;
+    PlayerStoreAdminService(PlayerStoreAdminService const&) = delete;
 
-    PlayerStoreAdminService &operator=(PlayerStoreAdminService const &) = delete;
+    PlayerStoreAdminService& operator=(PlayerStoreAdminService const&) = delete;
 
-    PlayerDataStore &theDataStore;
+    PlayerDataStore& theDataStore;
 };
 
-}// namespace chronolog
+} // namespace chronolog
 
 #endif

--- a/ChronoPlayer/include/PlayerStoreAdminService.h
+++ b/ChronoPlayer/include/PlayerStoreAdminService.h
@@ -1,11 +1,14 @@
 #ifndef PlayerStoreAdmin_SERVICE_H
 #define PlayerStoreAdmin_SERVICE_H
 
+#include <string>
+#include <cstdint>
 #include <iostream>
 #include <margo.h>
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>
 
+#include <chrono_monitor.h>
 #include <chronolog_types.h>
 
 #include "PlayerDataStore.h"

--- a/ChronoPlayer/include/StoryChunkTransferAgent.h
+++ b/ChronoPlayer/include/StoryChunkTransferAgent.h
@@ -18,16 +18,15 @@ namespace chronolog
 class StoryChunkTransferAgent: public StoryChunkExtractorBase
 {
 public:
-
-    static StoryChunkTransferAgent *
-    CreateStoryChunkTransferAgent(tl::engine &tl_engine , ServiceId const & receiver_service_id)
+    static StoryChunkTransferAgent* CreateStoryChunkTransferAgent(tl::engine& tl_engine,
+                                                                  ServiceId const& receiver_service_id)
     {
-        StoryChunkTransferAgent * storyChunkTransferAgent = nullptr;
+        StoryChunkTransferAgent* storyChunkTransferAgent = nullptr;
         try
         {
             storyChunkTransferAgent = new StoryChunkTransferAgent(tl_engine, receiver_service_id);
         }
-        catch(tl::exception const &ex)
+        catch(tl::exception const& ex)
         {
             LOG_ERROR("[StoryChunkTransferAgent] Failed to create StoryChunkTransferAgent for service");
         }
@@ -35,24 +34,24 @@ public:
     }
 
 
-   virtual ~StoryChunkTransferAgent();
+    virtual ~StoryChunkTransferAgent();
 
-    int processStoryChunk(StoryChunk*story_chunk) override;
+    int processStoryChunk(StoryChunk* story_chunk) override;
     bool is_receiver_available() const;
 
 private:
-    tl::engine & service_engine;          // local tl::engine
-    ServiceId   receiver_service_id;              // remote receiver service ServiceId
-    tl::provider_handle receiver_service_handle;  // tl::provider_handle for remote receiver service
+    tl::engine& service_engine;                  // local tl::engine
+    ServiceId receiver_service_id;               // remote receiver service ServiceId
+    tl::provider_handle receiver_service_handle; // tl::provider_handle for remote receiver service
     tl::remote_procedure receiver_is_available;
     tl::remote_procedure receive_story_chunk;
 
     // constructor is private to make sure thalium rpc objects are created on the heap, not stack
-    StoryChunkTransferAgent(tl::engine &tl_engine, ServiceId const& receiver_service_id);
+    StoryChunkTransferAgent(tl::engine& tl_engine, ServiceId const& receiver_service_id);
 };
 
 
-}
+} // namespace chronolog
 
 
 #endif //CHRONOLOG_STORYCHUNK_SENDER_H

--- a/ChronoPlayer/include/StoryChunkTransferAgent.h
+++ b/ChronoPlayer/include/StoryChunkTransferAgent.h
@@ -1,6 +1,8 @@
 #ifndef CHRONOLOG_STORYCHUNK_TRANSFER_AGENT_H
 #define CHRONOLOG_STORYCHUNK_TRANSFER_AGENT_H
 
+#include <string>
+#include <cstdint>
 #include <thallium.hpp>
 
 #include <chrono_monitor.h>

--- a/ChronoPlayer/src/ChronoPlayer.cpp
+++ b/ChronoPlayer/src/ChronoPlayer.cpp
@@ -1,6 +1,12 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <signal.h>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <margo.h>
 
 #include <PlayerIdCard.h>
 #include <PlayerRegClient.h>

--- a/ChronoPlayer/src/ChronoPlayer.cpp
+++ b/ChronoPlayer/src/ChronoPlayer.cpp
@@ -34,7 +34,7 @@ void sigterm_handler(int)
 
 ///////////////////////////////////////////////
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     int exit_code = 0;
     signal(SIGTERM, sigterm_handler);
@@ -49,15 +49,15 @@ int main(int argc, char**argv)
     chronolog::ConfigurationManager confManager(conf_file_path);
     chronolog::PlayerConfiguration PLAYER_CONF = confManager.PLAYER_CONF;
 
-    std::cout << "ChronoPlayer Configuration "<< PLAYER_CONF.to_String()<<std::endl;
+    std::cout << "ChronoPlayer Configuration " << PLAYER_CONF.to_String() << std::endl;
 
-    int result = chronolog::chrono_monitor::initialize(PLAYER_CONF.LOG_CONF.LOGTYPE
-                                                       , PLAYER_CONF.LOG_CONF.LOGFILE
-                                                       , PLAYER_CONF.LOG_CONF.LOGLEVEL
-                                                       , PLAYER_CONF.LOG_CONF.LOGNAME
-                                                       , PLAYER_CONF.LOG_CONF.LOGFILESIZE
-                                                       , PLAYER_CONF.LOG_CONF.LOGFILENUM
-                                                       , PLAYER_CONF.LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize(PLAYER_CONF.LOG_CONF.LOGTYPE,
+                                                       PLAYER_CONF.LOG_CONF.LOGFILE,
+                                                       PLAYER_CONF.LOG_CONF.LOGLEVEL,
+                                                       PLAYER_CONF.LOG_CONF.LOGNAME,
+                                                       PLAYER_CONF.LOG_CONF.LOGFILESIZE,
+                                                       PLAYER_CONF.LOG_CONF.LOGFILENUM,
+                                                       PLAYER_CONF.LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
@@ -70,12 +70,12 @@ int main(int argc, char**argv)
 
     // validate ip address, instantiate DataAdminService and create ServiceId to be included in RegistrationMsg
 
-    chronolog::ServiceId playerAdminServiceId( PLAYER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF,
-        PLAYER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.IP,
-        PLAYER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.BASE_PORT,
-        PLAYER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.SERVICE_PROVIDER_ID);
+    chronolog::ServiceId playerAdminServiceId(PLAYER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.PROTO_CONF,
+                                              PLAYER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.IP,
+                                              PLAYER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.BASE_PORT,
+                                              PLAYER_CONF.DATA_STORE_ADMIN_SERVICE_CONF.SERVICE_PROVIDER_ID);
 
-    if( !playerAdminServiceId.is_valid())
+    if(!playerAdminServiceId.is_valid())
     {
         LOG_CRITICAL("[ChronoPlayer] Failed to start DataStoreAdminService. Invalid endpoint provided.");
         return (-1);
@@ -89,20 +89,20 @@ int main(int argc, char**argv)
 
     // validate ip address, instantiate Playback Service and create IdCard
 
-    chronolog::ServiceId playbackServiceId( PLAYER_CONF.PLAYBACK_SERVICE_CONF.PROTO_CONF,
-        PLAYER_CONF.PLAYBACK_SERVICE_CONF.IP,
-        PLAYER_CONF.PLAYBACK_SERVICE_CONF.BASE_PORT,
-        PLAYER_CONF.PLAYBACK_SERVICE_CONF.SERVICE_PROVIDER_ID);
+    chronolog::ServiceId playbackServiceId(PLAYER_CONF.PLAYBACK_SERVICE_CONF.PROTO_CONF,
+                                           PLAYER_CONF.PLAYBACK_SERVICE_CONF.IP,
+                                           PLAYER_CONF.PLAYBACK_SERVICE_CONF.BASE_PORT,
+                                           PLAYER_CONF.PLAYBACK_SERVICE_CONF.SERVICE_PROVIDER_ID);
 
-    if( !playbackServiceId.is_valid())
+    if(!playbackServiceId.is_valid())
     {
         LOG_CRITICAL("[ChronoPlayer] Failed to start PlayerAdminService. Invalid endpoint provided.");
         return (-1);
     }
 
 
-    tl::engine * playbackEngine = nullptr;
-    chronolog::PlaybackService * playbackService = nullptr;
+    tl::engine* playbackEngine = nullptr;
+    chronolog::PlaybackService* playbackService = nullptr;
     chronolog::ArchiveReadingRequestQueue readingRequestQueue;
 
     try
@@ -111,23 +111,28 @@ int main(int argc, char**argv)
 
         playbackServiceId.get_service_as_string(PLAYBACK_SERVICE_NA_STRING);
 
-        margo_instance_id playback_margo_id = margo_init(PLAYBACK_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1 , 1);
+        margo_instance_id playback_margo_id = margo_init(PLAYBACK_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1, 1);
 
         playbackEngine = new tl::engine(playback_margo_id);
 
         LOG_DEBUG("[ChronoPlayer] starting PlaybackService at {}", chl::to_string(playbackServiceId));
 
-        playbackService = chronolog::PlaybackService::CreatePlaybackService(*playbackEngine, playbackServiceId.getProviderId(),readingRequestQueue);
+        playbackService = chronolog::PlaybackService::CreatePlaybackService(*playbackEngine,
+                                                                            playbackServiceId.getProviderId(),
+                                                                            readingRequestQueue);
     }
-    catch(tl::exception const & ex)
+    catch(tl::exception const& ex)
     {
-        LOG_ERROR("[ChronoPlayer]  failed to create playbackService at {} exception:{}", chl::to_string(playbackServiceId), ex.what());
+        LOG_ERROR("[ChronoPlayer]  failed to create playbackService at {} exception:{}",
+                  chl::to_string(playbackServiceId),
+                  ex.what());
         playbackService = nullptr;
     }
 
     if(nullptr == playbackService)
     {
-        LOG_CRITICAL("[ChronoPlayer] failed to create Playback Service at {}; exiting", chl::to_string(playbackServiceId));
+        LOG_CRITICAL("[ChronoPlayer] failed to create Playback Service at {}; exiting",
+                     chl::to_string(playbackServiceId));
         return (-1);
     }
 
@@ -143,35 +148,39 @@ int main(int argc, char**argv)
 
     chronolog::PlayerDataStore theDataStore(ingestionQueue, extractionQueue);
 
-    tl::engine * dataAdminEngine = nullptr;
+    tl::engine* dataAdminEngine = nullptr;
 
-    chronolog::PlayerStoreAdminService * playerStoreAdminService = nullptr;
+    chronolog::PlayerStoreAdminService* playerStoreAdminService = nullptr;
 
     try
     {
         std::string DATASTORE_SERVICE_NA_STRING;
         playerAdminServiceId.get_service_as_string(DATASTORE_SERVICE_NA_STRING);
 
-        margo_instance_id collection_margo_id = margo_init(DATASTORE_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1
-                                                           , 1);
+        margo_instance_id collection_margo_id =
+                margo_init(DATASTORE_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1, 1);
 
         dataAdminEngine = new tl::engine(collection_margo_id);
 
         LOG_DEBUG("[ChronoPlayer] starting AdminService at {}", chl::to_string(playerAdminServiceId));
-        
-        playerStoreAdminService = chronolog::PlayerStoreAdminService::CreatePlayerStoreAdminService(*dataAdminEngine
-                                                                                                , playerAdminServiceId.getProviderId()
-                                                                                                , theDataStore);
+
+        playerStoreAdminService =
+                chronolog::PlayerStoreAdminService::CreatePlayerStoreAdminService(*dataAdminEngine,
+                                                                                  playerAdminServiceId.getProviderId(),
+                                                                                  theDataStore);
     }
-    catch(tl::exception const & ex)
+    catch(tl::exception const& ex)
     {
-        LOG_ERROR("[ChronoPlayer]  failed to create DataStoreAdminService at {} exception:{}", chl::to_string(playerAdminServiceId), ex.what());
+        LOG_ERROR("[ChronoPlayer]  failed to create DataStoreAdminService at {} exception:{}",
+                  chl::to_string(playerAdminServiceId),
+                  ex.what());
         playerStoreAdminService = nullptr;
     }
 
     if(nullptr == playerStoreAdminService)
     {
-        LOG_CRITICAL("[ChronoPlayer] failed to create DataStoreAdminService at {} , exiting", chl::to_string(playerAdminServiceId));
+        LOG_CRITICAL("[ChronoPlayer] failed to create DataStoreAdminService at {} , exiting",
+                     chl::to_string(playerAdminServiceId));
         delete playbackService;
         return (-1);
     }
@@ -183,13 +192,14 @@ int main(int argc, char**argv)
     // create RegistryClient and register the new Recording service with the Registry
     std::string REGISTRY_SERVICE_NA_STRING = PLAYER_CONF.VISOR_REGISTRY_SERVICE_CONF.PROTO_CONF + "://" +
                                              PLAYER_CONF.VISOR_REGISTRY_SERVICE_CONF.IP + ":" +
-                                             std::to_string(
-                                                     PLAYER_CONF.VISOR_REGISTRY_SERVICE_CONF.BASE_PORT);
+                                             std::to_string(PLAYER_CONF.VISOR_REGISTRY_SERVICE_CONF.BASE_PORT);
 
     uint16_t REGISTRY_SERVICE_PROVIDER_ID = PLAYER_CONF.VISOR_REGISTRY_SERVICE_CONF.SERVICE_PROVIDER_ID;
 
-    chronolog::PlayerRegistryClient * playerRegistryClient = chronolog::PlayerRegistryClient::CreateRegistryClient(
-            *dataAdminEngine, REGISTRY_SERVICE_NA_STRING, REGISTRY_SERVICE_PROVIDER_ID);
+    chronolog::PlayerRegistryClient* playerRegistryClient =
+            chronolog::PlayerRegistryClient::CreateRegistryClient(*dataAdminEngine,
+                                                                  REGISTRY_SERVICE_NA_STRING,
+                                                                  REGISTRY_SERVICE_PROVIDER_ID);
 
     if(nullptr == playerRegistryClient)
     {
@@ -199,7 +209,7 @@ int main(int argc, char**argv)
         return (-1);
     }
 
-    chronolog::ArchiveReadingAgent * archiveReadingAgent = nullptr;
+    chronolog::ArchiveReadingAgent* archiveReadingAgent = nullptr;
 
     std::string archive_path = PLAYER_CONF.READER_CONF.story_files_dir;
     archiveReadingAgent = new chronolog::ArchiveReadingAgent(readingRequestQueue, archive_path);
@@ -208,7 +218,7 @@ int main(int argc, char**argv)
     // try to register with chronoVisor a few times than log ERROR and exit...
     int registration_status = playerRegistryClient->send_register_msg(
             chronolog::PlayerRegistrationMsg(playerIdCard, playerAdminServiceId));
-    //if the first attemp failes retry 
+    //if the first attemp failes retry
     int retries = 5;
     while((chronolog::CL_SUCCESS != registration_status) && (retries > 0))
     {
@@ -233,11 +243,11 @@ int main(int argc, char**argv)
     // services are successfully created and keeper process had registered with ChronoVisor
     // start all dataCollection and Extraction threads...
     tl::abt scope;
-   // theDataStore.startDataCollection(3);
+    // theDataStore.startDataCollection(3);
     // start extraction streams & threads
     //storyExtractor.startExtractionThreads(2);
     int NUMBER_ARCHIVE_READING_STREAMS = 1;
-    archiveReadingAgent->startArchiveReading(NUMBER_ARCHIVE_READING_STREAMS); 
+    archiveReadingAgent->startArchiveReading(NUMBER_ARCHIVE_READING_STREAMS);
 
     /// Main loop for sending stats message until receiving SIGTERM ____________________________________________________
     // now we are ready to ingest records coming from the storyteller clients ....
@@ -257,8 +267,8 @@ int main(int argc, char**argv)
 
     /// Stop services and shut down ____________________________________________________________________________________
     LOG_INFO("[ChronoPlayer] Initiating shutdown procedures.");
-    
-    archiveReadingAgent->shutdownArchiveReading(); 
+
+    archiveReadingAgent->shutdownArchiveReading();
     delete archiveReadingAgent;
     delete playerStoreAdminService;
     delete playbackService;
@@ -270,7 +280,7 @@ int main(int argc, char**argv)
     // these are not probably needed as thallium handles the engine finalization...
     //  recordingEngine.finalize();
     //  collectionEngine.finalize();
-   // delete recordingEngine;
+    // delete recordingEngine;
     delete dataAdminEngine;
     delete playbackEngine;
     LOG_INFO("[ChronoPlayer] Shutdown completed. Exiting.");

--- a/ChronoPlayer/src/HDF5ArchiveReadingAgent.cpp
+++ b/ChronoPlayer/src/HDF5ArchiveReadingAgent.cpp
@@ -23,7 +23,8 @@ std::string formatWithCommas(uint64_t value)
 {
     std::string str = std::to_string(value);
     int pos = str.length() - 3;
-    while (pos > 0) {
+    while(pos > 0)
+    {
         str.insert(pos, ",");
         pos -= 3;
     }
@@ -46,21 +47,20 @@ int64_t convertFileTimeToSystemClockNs(const fs::file_time_type& file_time)
     auto offset = sys_duration - file_now_duration;
     auto sys_time = std::chrono::system_clock::time_point(file_duration + offset);
 
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(
-        sys_time.time_since_epoch()).count();
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(sys_time.time_since_epoch()).count();
 }
 
 namespace chronolog
 {
 struct ErrorReport
 {
-    std::vector <std::string> messages;
+    std::vector<std::string> messages;
 };
 
-herr_t error_walker(unsigned int n, const H5E_error2_t *err_desc, void *client_data)
+herr_t error_walker(unsigned int n, const H5E_error2_t* err_desc, void* client_data)
 {
     // Cast the client_data back to our ErrorReport struct
-    auto *report = static_cast<ErrorReport *>(client_data);
+    auto* report = static_cast<ErrorReport*>(client_data);
 
     // Get the major and minor error strings
     char maj[256], min[256];
@@ -68,10 +68,10 @@ herr_t error_walker(unsigned int n, const H5E_error2_t *err_desc, void *client_d
     H5Eget_msg(err_desc->min_num, nullptr, min, 256);
 
     // Format the detailed error message
-    std::string msg =
-            "HDF5 Error #" + std::to_string(n) + ":\n" + "  File: " + err_desc->file_name + "\n" + "  Line: " +
-            std::to_string(err_desc->line) + "\n" + "  Function: " + err_desc->func_name + "\n" + "  Major Error: " +
-            maj + "\n" + "  Minor Error: " + min + "\n" + "  Description: " + err_desc->desc;
+    std::string msg = "HDF5 Error #" + std::to_string(n) + ":\n" + "  File: " + err_desc->file_name + "\n" +
+                      "  Line: " + std::to_string(err_desc->line) + "\n" + "  Function: " + err_desc->func_name + "\n" +
+                      "  Major Error: " + maj + "\n" + "  Minor Error: " + min + "\n" +
+                      "  Description: " + err_desc->desc;
 
     // Add the formatted message to our report
     report->messages.push_back(msg);
@@ -80,20 +80,21 @@ herr_t error_walker(unsigned int n, const H5E_error2_t *err_desc, void *client_d
     return 0;
 }
 
-int chronolog::HDF5ArchiveReadingAgent::readStoryChunkFile(const ChronicleName& chronicleName
-                                                           , const StoryName& storyName
-                                                           , uint64_t startTime, uint64_t endTime
-                                                           , std::list<StoryChunk*>& listOfChunks
-                                                           , const std::string& file_name)
+int chronolog::HDF5ArchiveReadingAgent::readStoryChunkFile(const ChronicleName& chronicleName,
+                                                           const StoryName& storyName,
+                                                           uint64_t startTime,
+                                                           uint64_t endTime,
+                                                           std::list<StoryChunk*>& listOfChunks,
+                                                           const std::string& file_name)
 {
-    std::unique_ptr <H5::H5File> file;
-    StoryChunk *story_chunk = nullptr;
+    std::unique_ptr<H5::H5File> file;
+    StoryChunk* story_chunk = nullptr;
     try
     {
         H5::Exception::dontPrint();
 
         LOG_DEBUG("[HDF5ArchiveReadingAgent] Opening file {}", file_name);
-        file = std::make_unique <H5::H5File>(file_name, H5F_ACC_SWMR_READ);
+        file = std::make_unique<H5::H5File>(file_name, H5F_ACC_SWMR_READ);
 
         std::string dataset_name = "/story_chunks/data.vlen_bytes";
         LOG_DEBUG("[HDF5ArchiveReadingAgent] Opening dataset {}", dataset_name);
@@ -102,15 +103,17 @@ int chronolog::HDF5ArchiveReadingAgent::readStoryChunkFile(const ChronicleName& 
         H5::DataSpace dataspace = dataset.getSpace();
         hsize_t dims_out[2] = {0, 0};
         dataspace.getSimpleExtentDims(dims_out, nullptr);
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading dataset {} with {} events", dataset_name, formatWithCommas(dims_out[0]));
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading dataset {} with {} events",
+                  dataset_name,
+                  formatWithCommas(dims_out[0]));
 
         H5::CompType defined_comp_type = StoryChunkWriter::createEventCompoundType();
         H5::CompType probed_data_type = dataset.getCompType();
         if(probed_data_type.getNmembers() != defined_comp_type.getNmembers())
         {
             LOG_WARNING(
-                    "[HDF5ArchiveReadingAgent] Error reading dataset {} : Not a compound type with the same #members"
-                    , file_name);
+                    "[HDF5ArchiveReadingAgent] Error reading dataset {} : Not a compound type with the same #members",
+                    file_name);
             return CL_ERR_UNKNOWN;
         }
         if(probed_data_type != defined_comp_type)
@@ -120,95 +123,118 @@ int chronolog::HDF5ArchiveReadingAgent::readStoryChunkFile(const ChronicleName& 
         }
 
         LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading data from dataset {}", dataset_name);
-        std::vector <LogEventHVL> data;
+        std::vector<LogEventHVL> data;
         data.resize(dims_out[0]);
         dataset.read(data.data(), defined_comp_type);
 
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] Creating StoryChunk {}-{} range {}-{}...", chronicleName, storyName
-                  , formatWithCommas(startTime), formatWithCommas(endTime));
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] Creating StoryChunk {}-{} range {}-{}...",
+                  chronicleName,
+                  storyName,
+                  formatWithCommas(startTime),
+                  formatWithCommas(endTime));
         story_chunk = new StoryChunk(chronicleName, storyName, 0, startTime, endTime);
-        for(auto const &event_hvl: data)
+        for(auto const& event_hvl: data)
         {
             if(event_hvl.eventTime < startTime)
             {
-                LOG_DEBUG("[HDF5ArchiveReadingAgent] Skipping event with time {} outside range {}-{}"
-                          , formatWithCommas(event_hvl.eventTime), formatWithCommas(startTime), formatWithCommas(endTime));
+                LOG_DEBUG("[HDF5ArchiveReadingAgent] Skipping event with time {} outside range {}-{}",
+                          formatWithCommas(event_hvl.eventTime),
+                          formatWithCommas(startTime),
+                          formatWithCommas(endTime));
                 continue;
             }
             if(event_hvl.eventTime >= endTime)
             {
-                LOG_DEBUG("[HDF5ArchiveReadingAgent] Stopping reading events at time {} outside range {}-{}"
-                          , formatWithCommas(event_hvl.eventTime), formatWithCommas(startTime), formatWithCommas(endTime));
+                LOG_DEBUG("[HDF5ArchiveReadingAgent] Stopping reading events at time {} outside range {}-{}",
+                          formatWithCommas(event_hvl.eventTime),
+                          formatWithCommas(startTime),
+                          formatWithCommas(endTime));
                 break;
             }
 
-            LogEvent event(event_hvl.storyId, event_hvl.eventTime, event_hvl.clientId, event_hvl.eventIndex
-                           , std::string(static_cast<char *>(event_hvl.logRecord.p), event_hvl.logRecord.len));
+            LogEvent event(event_hvl.storyId,
+                           event_hvl.eventTime,
+                           event_hvl.clientId,
+                           event_hvl.eventIndex,
+                           std::string(static_cast<char*>(event_hvl.logRecord.p), event_hvl.logRecord.len));
             story_chunk->insertEvent(event);
         }
 
         if(story_chunk->getEventCount() > 0)
         {
             listOfChunks.emplace_back(story_chunk);
-            LOG_DEBUG("[HDF5ArchiveReadingAgent] Inserted a StoryChunk with {} events {}-{} range {}-{} into list"
-                      , formatWithCommas(story_chunk->getEventCount()), chronicleName, storyName, formatWithCommas(startTime), formatWithCommas(endTime));
+            LOG_DEBUG("[HDF5ArchiveReadingAgent] Inserted a StoryChunk with {} events {}-{} range {}-{} into list",
+                      formatWithCommas(story_chunk->getEventCount()),
+                      chronicleName,
+                      storyName,
+                      formatWithCommas(startTime),
+                      formatWithCommas(endTime));
         }
         else
         {
             LOG_DEBUG("[HDF5ArchiveReadingAgent] No events in {}-{} are in range {}-{}, "
-                      "no StoryChunk added to list", chronicleName, storyName, formatWithCommas(startTime), formatWithCommas(endTime));
+                      "no StoryChunk added to list",
+                      chronicleName,
+                      storyName,
+                      formatWithCommas(startTime),
+                      formatWithCommas(endTime));
             delete story_chunk;
         }
     }
-    catch(H5::FileIException &error)
+    catch(H5::FileIException& error)
     {
-        LOG_ERROR("[HDF5ArchiveReadingAgent] reading file {} : FileIException: {} in C Function: {}", file_name
-                  , error.getCDetailMsg(), error.getCFuncName());
+        LOG_ERROR("[HDF5ArchiveReadingAgent] reading file {} : FileIException: {} in C Function: {}",
+                  file_name,
+                  error.getCDetailMsg(),
+                  error.getCFuncName());
         ErrorReport report;
         H5::Exception::walkErrorStack(H5E_WALK_UPWARD, error_walker, &report);
-        for(const auto &msg: report.messages)
-        {
-            LOG_ERROR("[HDF5ArchiveReadingAgent] {}", msg);
-        }
+        for(const auto& msg: report.messages) { LOG_ERROR("[HDF5ArchiveReadingAgent] {}", msg); }
 
         delete story_chunk;
         return -1;
     }
-    catch(H5::Exception &error)
+    catch(H5::Exception& error)
     {
-        LOG_ERROR("[HDF5ArchiveReadingAgent] reading file {} : Exception: {} in C Function: {}", file_name
-                  , error.getCDetailMsg(), error.getCFuncName());
+        LOG_ERROR("[HDF5ArchiveReadingAgent] reading file {} : Exception: {} in C Function: {}",
+                  file_name,
+                  error.getCDetailMsg(),
+                  error.getCFuncName());
         ErrorReport report;
         H5::Exception::walkErrorStack(H5E_WALK_UPWARD, error_walker, &report);
-        for(const auto &msg: report.messages)
-        {
-            LOG_ERROR("[HDF5ArchiveReadingAgent] {}", msg);
-        }
+        for(const auto& msg: report.messages) { LOG_ERROR("[HDF5ArchiveReadingAgent] {}", msg); }
         delete story_chunk;
         return -1;
     }
     return 0;
 }
 
-int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName &chronicleName
-                                                          , const StoryName &storyName
-                                                          , uint64_t startTime, uint64_t endTime
-                                                          , std::list <StoryChunk *> &listOfChunks
-                                                          , bool readAuxFiles)
+int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName& chronicleName,
+                                                          const StoryName& storyName,
+                                                          uint64_t startTime,
+                                                          uint64_t endTime,
+                                                          std::list<StoryChunk*>& listOfChunks,
+                                                          bool readAuxFiles)
 {
     // find all HDF5 files in the archive directory the start time of which falls in the range [startTime, endTime)
     // for each file, read Events in the StoryChunk and add matched ones to the list of StoryChunks
     // return the list of StoryChunks
-    std::lock_guard <std::mutex> lock(start_time_file_name_map_mutex_);
+    std::lock_guard<std::mutex> lock(start_time_file_name_map_mutex_);
     if(!readAuxFiles)
     {
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading archived story {}-{} range {}-{}, main file only"
-              , chronicleName, storyName, formatWithCommas(startTime), formatWithCommas(endTime));
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading archived story {}-{} range {}-{}, main file only",
+                  chronicleName,
+                  storyName,
+                  formatWithCommas(startTime),
+                  formatWithCommas(endTime));
     }
     else
     {
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading archived story {}-{} range {}-{}, main and auxiliary files"
-              , chronicleName, storyName, formatWithCommas(startTime), formatWithCommas(endTime));
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] Reading archived story {}-{} range {}-{}, main and auxiliary files",
+                  chronicleName,
+                  storyName,
+                  formatWithCommas(startTime),
+                  formatWithCommas(endTime));
     }
     // Find the last file whose start time <= startTime for the SAME chronicle-story combination
     auto start_it = start_time_file_name_map_.upper_bound(std::make_tuple(chronicleName, storyName, startTime));
@@ -225,28 +251,41 @@ int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName &c
 
     // Find first file whose start time > endTime (this part you already have correct)
     auto end_it = start_time_file_name_map_.upper_bound(std::make_tuple(chronicleName, storyName, endTime));
-    LOG_DEBUG("[HDF5ArchiveReadingAgent] readArchiveStory {}-{} range {}-{}", chronicleName, storyName
-        , formatWithCommas(startTime), formatWithCommas(endTime));
+    LOG_DEBUG("[HDF5ArchiveReadingAgent] readArchiveStory {}-{} range {}-{}",
+              chronicleName,
+              storyName,
+              formatWithCommas(startTime),
+              formatWithCommas(endTime));
 
     if(start_it == end_it)
     {
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] No matching files found for story {}-{} in range {}-{}", chronicleName
-                  , storyName, formatWithCommas(startTime), formatWithCommas(endTime));
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] No matching files found for story {}-{} in range {}-{}",
+                  chronicleName,
+                  storyName,
+                  formatWithCommas(startTime),
+                  formatWithCommas(endTime));
         return CL_ERR_UNKNOWN;
     }
 
-    LOG_DEBUG("[HDF5ArchiveReadingAgent] Found matching files for story {}-{} in range {}-{}", chronicleName, storyName
-              , formatWithCommas(startTime), formatWithCommas(endTime));
-    LOG_DEBUG(
-            "[HDF5ArchiveReadingAgent] Start iterator: chronicle name: {}, story name: {}, start time: {}, file name: {}"
-            , std::get <0>(start_it->first), std::get <1>(start_it->first), formatWithCommas(std::get <2>(start_it->first))
-            , start_it->second);
+    LOG_DEBUG("[HDF5ArchiveReadingAgent] Found matching files for story {}-{} in range {}-{}",
+              chronicleName,
+              storyName,
+              formatWithCommas(startTime),
+              formatWithCommas(endTime));
+    LOG_DEBUG("[HDF5ArchiveReadingAgent] Start iterator: chronicle name: {}, story name: {}, start time: {}, file "
+              "name: {}",
+              std::get<0>(start_it->first),
+              std::get<1>(start_it->first),
+              formatWithCommas(std::get<2>(start_it->first)),
+              start_it->second);
     if(end_it != start_time_file_name_map_.end())
     {
-        LOG_DEBUG(
-            "[HDF5ArchiveReadingAgent] End iterator: chronicle name: {}, story name: {}, start time: {}, file name: {}"
-            , std::get <0>(end_it->first), std::get <1>(end_it->first), formatWithCommas(std::get <2>(end_it->first))
-            , end_it->second);
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] End iterator: chronicle name: {}, story name: {}, start time: {}, file "
+                  "name: {}",
+                  std::get<0>(end_it->first),
+                  std::get<1>(end_it->first),
+                  formatWithCommas(std::get<2>(end_it->first)),
+                  end_it->second);
     }
     else
     {
@@ -268,14 +307,14 @@ int chronolog::HDF5ArchiveReadingAgent::readArchivedStory(const ChronicleName &c
         {
             // next_file_name should be in the format of {chronicleName}.{storyName}.{startTime}.vlen.{number}.h5
             next_file_name = StoryChunkWriter::getStoryChunkFileName(archive_path_, file_full_path.filename().string());
-            next_file_number_str = fs::path(next_file_name).replace_extension("").extension().string().
-                                   substr(1);
+            next_file_number_str = fs::path(next_file_name).replace_extension("").extension().string().substr(1);
             if(next_file_number_str == "vlen")
             {
                 // should not happen, but just in case
                 LOG_ERROR("[HDF5ArchiveReadingAgent] getStoryChunkFileName returned a file name without a number: {},"
-                          " indicating main story chunk file {} does not exist. "
-                          , next_file_name, file_name);
+                          " indicating main story chunk file {} does not exist. ",
+                          next_file_name,
+                          file_name);
                 return -1;
             }
             else if(std::all_of(next_file_number_str.begin(), next_file_number_str.end(), ::isdigit))
@@ -312,29 +351,31 @@ int chronolog::HDF5ArchiveReadingAgent::setUpFsMonitoring()
 {
     if(use_polling_)
     {
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] Setting up polling-based file system monitoring for archive directory: '{}'"
-                  , archive_path_);
+        LOG_DEBUG(
+                "[HDF5ArchiveReadingAgent] Setting up polling-based file system monitoring for archive directory: '{}'",
+                archive_path_);
     }
     else
     {
-        LOG_DEBUG("[HDF5ArchiveReadingAgent] Setting up inotify-based file system monitoring for archive directory: '{}' recursively."
-                  , archive_path_);
+        LOG_DEBUG("[HDF5ArchiveReadingAgent] Setting up inotify-based file system monitoring for archive directory: "
+                  "'{}' recursively.",
+                  archive_path_);
     }
 
-    tl::managed <tl::xstream> es = tl::xstream::create();
+    tl::managed<tl::xstream> es = tl::xstream::create();
     archive_dir_monitoring_stream_ = std::move(es);
 
     if(use_polling_)
     {
-        tl::managed <tl::thread> th = archive_dir_monitoring_stream_->make_thread([p = this]()
-                                                                                  { p->pollingMonitoringThreadFunc(); });
+        tl::managed<tl::thread> th =
+                archive_dir_monitoring_stream_->make_thread([p = this]() { p->pollingMonitoringThreadFunc(); });
         archive_dir_monitoring_thread_ = std::move(th);
         LOG_DEBUG("[HDF5ArchiveReadingAgent] Started polling-based archive directory monitoring thread.");
     }
     else
     {
-        tl::managed <tl::thread> th = archive_dir_monitoring_stream_->make_thread([p = this]()
-                                                                                  { p->inotifyMonitoringThreadFunc(); });
+        tl::managed<tl::thread> th =
+                archive_dir_monitoring_stream_->make_thread([p = this]() { p->inotifyMonitoringThreadFunc(); });
         archive_dir_monitoring_thread_ = std::move(th);
         LOG_DEBUG("[HDF5ArchiveReadingAgent] Started inotify-based archive directory monitoring thread.");
     }
@@ -342,10 +383,11 @@ int chronolog::HDF5ArchiveReadingAgent::setUpFsMonitoring()
     return 0;
 }
 
-void chronolog::HDF5ArchiveReadingAgent::addRecursiveWatch(int inotify_fd, const std::string &path
-                                                           , std::map <int, std::string> &wd_to_path)
+void chronolog::HDF5ArchiveReadingAgent::addRecursiveWatch(int inotify_fd,
+                                                           const std::string& path,
+                                                           std::map<int, std::string>& wd_to_path)
 {
-    int wd = inotify_add_watch(inotify_fd, path.c_str(), IN_CREATE|IN_DELETE|IN_MOVED_FROM|IN_MOVED_TO);
+    int wd = inotify_add_watch(inotify_fd, path.c_str(), IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
     if(wd < 0)
     {
         LOG_ERROR("[HDF5ArchiveReadingAgent] Failed to add inotify watch on {}: {}", path, strerror(errno));
@@ -353,7 +395,7 @@ void chronolog::HDF5ArchiveReadingAgent::addRecursiveWatch(int inotify_fd, const
     }
     wd_to_path[wd] = fs::absolute(path).string();
 
-    for(const auto &entry: fs::directory_iterator(path))
+    for(const auto& entry: fs::directory_iterator(path))
     {
         if(fs::is_directory(entry.status()))
         {
@@ -386,7 +428,7 @@ int chronolog::HDF5ArchiveReadingAgent::inotifyMonitoringThreadFunc()
         return -1;
     }
 
-    std::map <int, std::string> wd_to_path;
+    std::map<int, std::string> wd_to_path;
     addRecursiveWatch(inotifyFd, archive_path_, wd_to_path);
 
     const size_t eventSize = sizeof(struct inotify_event);
@@ -416,22 +458,21 @@ int chronolog::HDF5ArchiveReadingAgent::inotifyMonitoringThreadFunc()
         }
 
         std::string old_file_name;
-        for(ssize_t i = 0; i < length; i += (ssize_t)eventSize + ((struct inotify_event *)&buffer[i])->len)
+        for(ssize_t i = 0; i < length; i += (ssize_t)eventSize + ((struct inotify_event*)&buffer[i])->len)
         {
-            auto *event = (struct inotify_event *)&buffer[i];
+            auto* event = (struct inotify_event*)&buffer[i];
             std::string path;
             if(event->len)
             {
                 path = (fs::path(wd_to_path[event->wd]) / event->name).string();
             }
 
-            if(event->mask&(IN_CREATE))
+            if(event->mask & (IN_CREATE))
             {
-                if(event->mask&IN_ISDIR)
+                if(event->mask & IN_ISDIR)
                 {
                     // If a directory is created, we need to add a watch for it recursively
-                    LOG_DEBUG("[HDF5ArchiveReadingAgent] Directory {} created, updating inotify watch ..."
-                              , path);
+                    LOG_DEBUG("[HDF5ArchiveReadingAgent] Directory {} created, updating inotify watch ...", path);
                     addRecursiveWatch(inotifyFd, fs::absolute(path), wd_to_path);
                 }
                 else
@@ -440,12 +481,11 @@ int chronolog::HDF5ArchiveReadingAgent::inotifyMonitoringThreadFunc()
                     addFileToStartTimeFileNameMap(path);
                 }
             }
-            else if(event->mask&(IN_DELETE))
+            else if(event->mask & (IN_DELETE))
             {
-                if(event->mask&IN_ISDIR)
+                if(event->mask & IN_ISDIR)
                 {
-                    LOG_DEBUG("[HDF5ArchiveReadingAgent] Directory {} deleted, removing inotify watch ..."
-                              , path);
+                    LOG_DEBUG("[HDF5ArchiveReadingAgent] Directory {} deleted, removing inotify watch ...", path);
                     // Remove the watch for the deleted directory
                     wd_to_path.erase(event->wd);
                 }
@@ -455,12 +495,12 @@ int chronolog::HDF5ArchiveReadingAgent::inotifyMonitoringThreadFunc()
                     removeFileFromStartTimeFileNameMap(path);
                 }
             }
-            else if(event->mask&(IN_MOVED_FROM))
+            else if(event->mask & (IN_MOVED_FROM))
             {
                 LOG_DEBUG("[HDF5ArchiveReadingAgent] File is renamed from {}", path);
                 old_file_name = path;
             }
-            else if(event->mask&(IN_MOVED_TO))
+            else if(event->mask & (IN_MOVED_TO))
             {
                 if(old_file_name.empty())
                 {
@@ -478,7 +518,7 @@ int chronolog::HDF5ArchiveReadingAgent::inotifyMonitoringThreadFunc()
         }
     }
 
-    for(const auto &entry: wd_to_path)
+    for(const auto& entry: wd_to_path)
     {
         LOG_DEBUG("[HDF5ArchiveReadingAgent] Removing inotify watch for {} with wd {}", entry.second, entry.first);
         inotify_rm_watch(inotifyFd, entry.first);
@@ -490,8 +530,8 @@ int chronolog::HDF5ArchiveReadingAgent::inotifyMonitoringThreadFunc()
 
 int chronolog::HDF5ArchiveReadingAgent::pollingMonitoringThreadFunc()
 {
-    LOG_DEBUG("[HDF5ArchiveReadingAgent] Starting polling-based file system monitoring for archive directory: '{}'"
-              , archive_path_);
+    LOG_DEBUG("[HDF5ArchiveReadingAgent] Starting polling-based file system monitoring for archive directory: '{}'",
+              archive_path_);
 
     // Set the initial scan time BEFORE the initial scan
     last_scan_time_ = std::chrono::system_clock::now();
@@ -534,7 +574,7 @@ void chronolog::HDF5ArchiveReadingAgent::scanFileSystem()
     std::vector<std::pair<std::string, FileInfo>> missing_files;
 
     // Compare with previous state and update file map
-    for(const auto& file_info : current_state)
+    for(const auto& file_info: current_state)
     {
         auto it = previous_file_state_.find(file_info.path);
         if(it == previous_file_state_.end())
@@ -551,10 +591,10 @@ void chronolog::HDF5ArchiveReadingAgent::scanFileSystem()
     }
 
     // Check for deleted/missing files
-    for(const auto& prev_file : previous_file_state_)
+    for(const auto& prev_file: previous_file_state_)
     {
         bool still_exists = false;
-        for(const auto& curr_file : current_state)
+        for(const auto& curr_file: current_state)
         {
             if(curr_file.path == prev_file.first)
             {
@@ -581,13 +621,11 @@ void chronolog::HDF5ArchiveReadingAgent::scanFileSystem()
             const auto& new_file = *new_it;
 
             // Match files by size, modification time, and ensure both are regular files
-            if(!missing_file.is_directory && !new_file.is_directory &&
-               missing_file.file_size == new_file.file_size &&
+            if(!missing_file.is_directory && !new_file.is_directory && missing_file.file_size == new_file.file_size &&
                missing_file.last_modified == new_file.last_modified)
             {
                 // This looks like a rename!
-                LOG_DEBUG("[HDF5ArchiveReadingAgent] File renamed from {} to {}",
-                         missing_it->first, new_file.path);
+                LOG_DEBUG("[HDF5ArchiveReadingAgent] File renamed from {} to {}", missing_it->first, new_file.path);
                 renameFileInStartTimeFileNameMap(missing_it->first, new_file.path);
 
                 // Remove from both lists since we handled the rename
@@ -605,14 +643,14 @@ void chronolog::HDF5ArchiveReadingAgent::scanFileSystem()
     }
 
     // Handle remaining new files (actual creations)
-    for(const auto& file_info : new_files)
+    for(const auto& file_info: new_files)
     {
         LOG_DEBUG("[HDF5ArchiveReadingAgent] New file detected: {}", file_info.path);
         addFileToStartTimeFileNameMap(file_info.path);
     }
 
     // Handle remaining missing files (actual deletions)
-    for(const auto& missing_file : missing_files)
+    for(const auto& missing_file: missing_files)
     {
         LOG_DEBUG("[HDF5ArchiveReadingAgent] File deleted: {}", missing_file.first);
         removeFileFromStartTimeFileNameMap(missing_file.first);
@@ -620,29 +658,26 @@ void chronolog::HDF5ArchiveReadingAgent::scanFileSystem()
 
     // Update previous state
     previous_file_state_.clear();
-    for(const auto& file_info : current_state)
-    {
-        previous_file_state_[file_info.path] = file_info;
-    }
+    for(const auto& file_info: current_state) { previous_file_state_[file_info.path] = file_info; }
 }
 
 bool chronolog::HDF5ArchiveReadingAgent::hasFileSystemChanged()
 {
     std::error_code ec;
     // Use system_clock for consistent time comparison
-    auto last_scan_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        last_scan_time_.time_since_epoch()).count();
+    auto last_scan_ns =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(last_scan_time_.time_since_epoch()).count();
 
-    LOG_DEBUG("[HDF5ArchiveReadingAgent] Checking file system changes, last_scan_ns: {}"
-        , formatWithCommas(last_scan_ns));
+    LOG_DEBUG("[HDF5ArchiveReadingAgent] Checking file system changes, last_scan_ns: {}",
+              formatWithCommas(last_scan_ns));
 
     // Use cached directory checking for better performance
     return hasDirectoryChangedWithCache(archive_path_, last_scan_ns, ec);
 }
 
-bool chronolog::HDF5ArchiveReadingAgent::hasDirectoryChangedOptimizedRecursive(const fs::path& dir_path
-                                                                     , int64_t last_scan_ns
-                                                                     , std::error_code& ec)
+bool chronolog::HDF5ArchiveReadingAgent::hasDirectoryChangedOptimizedRecursive(const fs::path& dir_path,
+                                                                               int64_t last_scan_ns,
+                                                                               std::error_code& ec)
 {
     // Check if this directory has been modified
     auto dir_last_write = fs::last_write_time(dir_path, ec);
@@ -659,13 +694,13 @@ bool chronolog::HDF5ArchiveReadingAgent::hasDirectoryChangedOptimizedRecursive(c
     else
     {
         LOG_WARNING("[HDF5ArchiveReadingAgent] Error getting directory modification time for {}: {}",
-                   dir_path.string(), ec.message());
+                    dir_path.string(),
+                    ec.message());
         ec.clear();
     }
 
     // Directory was modified, check its contents
-    for(const auto& entry : fs::directory_iterator(dir_path,
-                                                   fs::directory_options::skip_permission_denied, ec))
+    for(const auto& entry: fs::directory_iterator(dir_path, fs::directory_options::skip_permission_denied, ec))
     {
         if(ec)
         {
@@ -701,7 +736,8 @@ bool chronolog::HDF5ArchiveReadingAgent::hasDirectoryChangedOptimizedRecursive(c
                 else
                 {
                     LOG_WARNING("[HDF5ArchiveReadingAgent] Error getting file modification time for {}: {}",
-                               entry.path().string(), ec.message());
+                                entry.path().string(),
+                                ec.message());
                     ec.clear();
                 }
             }
@@ -712,16 +748,17 @@ bool chronolog::HDF5ArchiveReadingAgent::hasDirectoryChangedOptimizedRecursive(c
 }
 
 // Directory caching implementation
-bool chronolog::HDF5ArchiveReadingAgent::hasDirectoryChangedWithCache(const fs::path& dir_path
-                                                                     , int64_t last_scan_ns
-                                                                     , std::error_code& ec)
+bool chronolog::HDF5ArchiveReadingAgent::hasDirectoryChangedWithCache(const fs::path& dir_path,
+                                                                      int64_t last_scan_ns,
+                                                                      std::error_code& ec)
 {
     // Get current directory modification time
     int64_t current_mod_time = getDirectoryModificationTime(dir_path, ec);
     if(ec)
     {
         LOG_WARNING("[HDF5ArchiveReadingAgent] Error getting directory modification time for {}: {}",
-                   dir_path.string(), ec.message());
+                    dir_path.string(),
+                    ec.message());
         ec.clear();
         // Continue with actual check if we can't get modification time
     }
@@ -735,11 +772,10 @@ bool chronolog::HDF5ArchiveReadingAgent::hasDirectoryChangedWithCache(const fs::
             // Only use cached "no changes" result if:
             // 1. Directory hasn't been modified since last check, AND
             // 2. We checked it after the last scan time
-            if(current_mod_time <= it->second.last_modified_ns &&
-               it->second.last_check_time_ns > last_scan_ns)
+            if(current_mod_time <= it->second.last_modified_ns && it->second.last_check_time_ns > last_scan_ns)
             {
                 LOG_DEBUG("[HDF5ArchiveReadingAgent] Using cached result for directory {}: no changes detected",
-                         dir_path.string());
+                          dir_path.string());
                 return it->second.has_changes;
             }
         }
@@ -754,16 +790,19 @@ bool chronolog::HDF5ArchiveReadingAgent::hasDirectoryChangedWithCache(const fs::
     return has_changes;
 }
 
-void chronolog::HDF5ArchiveReadingAgent::updateDirectoryCache(const fs::path& dir_path
-                                                             , int64_t last_modified_ns
-                                                             , int64_t check_time_ns
-                                                             , bool has_changes)
+void chronolog::HDF5ArchiveReadingAgent::updateDirectoryCache(const fs::path& dir_path,
+                                                              int64_t last_modified_ns,
+                                                              int64_t check_time_ns,
+                                                              bool has_changes)
 {
     std::lock_guard<std::mutex> lock(directory_cache_mutex_);
     directory_cache_[dir_path] = DirectoryCache(dir_path, last_modified_ns, check_time_ns, has_changes);
 
     LOG_DEBUG("[HDF5ArchiveReadingAgent] Updated directory cache for {}: modified_ns={}, check_ns={}, has_changes={}",
-             dir_path.string(), formatWithCommas(last_modified_ns), formatWithCommas(check_time_ns), has_changes);
+              dir_path.string(),
+              formatWithCommas(last_modified_ns),
+              formatWithCommas(check_time_ns),
+              has_changes);
 }
 
 void chronolog::HDF5ArchiveReadingAgent::clearDirectoryCache()
@@ -781,23 +820,21 @@ int64_t chronolog::HDF5ArchiveReadingAgent::getDirectoryModificationTime(const f
         return convertFileTimeToSystemClockNs(dir_last_write);
     }
     LOG_WARNING("[HDF5ArchiveReadingAgent] Error getting directory modification time for {}: {}",
-               dir_path.string(), ec.message());
+                dir_path.string(),
+                ec.message());
     ec.clear();
     return 0;
 }
 
-void chronolog::HDF5ArchiveReadingAgent::updateFileState()
-{
-    last_scan_time_ = std::chrono::system_clock::now();
-}
+void chronolog::HDF5ArchiveReadingAgent::updateFileState() { last_scan_time_ = std::chrono::system_clock::now(); }
 
 std::vector<chronolog::HDF5ArchiveReadingAgent::FileInfo> chronolog::HDF5ArchiveReadingAgent::getCurrentFileState()
 {
     std::vector<FileInfo> current_state;
     std::error_code ec;
 
-    for(const auto& entry : fs::recursive_directory_iterator(archive_path_,
-                                                             fs::directory_options::skip_permission_denied, ec))
+    for(const auto& entry:
+        fs::recursive_directory_iterator(archive_path_, fs::directory_options::skip_permission_denied, ec))
     {
         if(ec)
         {
@@ -828,7 +865,9 @@ std::vector<chronolog::HDF5ArchiveReadingAgent::FileInfo> chronolog::HDF5Archive
                 auto last_write = fs::last_write_time(entry.path(), ec);
                 if(ec)
                 {
-                    LOG_WARNING("[HDF5ArchiveReadingAgent] Error getting last write time for {}: {}", path, ec.message());
+                    LOG_WARNING("[HDF5ArchiveReadingAgent] Error getting last write time for {}: {}",
+                                path,
+                                ec.message());
                     ec.clear();
                     continue;
                 }
@@ -844,7 +883,7 @@ std::vector<chronolog::HDF5ArchiveReadingAgent::FileInfo> chronolog::HDF5Archive
                 current_state.emplace_back(path, last_write, file_size, false);
             }
         }
-        catch (const std::exception& e)
+        catch(const std::exception& e)
         {
             LOG_WARNING("[HDF5ArchiveReadingAgent] Exception during file state scan: {}", e.what());
             continue;
@@ -854,4 +893,4 @@ std::vector<chronolog::HDF5ArchiveReadingAgent::FileInfo> chronolog::HDF5Archive
     return current_state;
 }
 
-} // chronolog
+} // namespace chronolog

--- a/ChronoPlayer/src/HDF5ArchiveReadingAgent.cpp
+++ b/ChronoPlayer/src/HDF5ArchiveReadingAgent.cpp
@@ -1,4 +1,11 @@
 #include <sys/inotify.h>
+#include <unistd.h>
+#include <cstring>
+#include <cerrno>
+#include <memory>
+#include <vector>
+#include <string>
+#include <algorithm>
 #include <H5Cpp.h>
 #include <filesystem>
 

--- a/ChronoPlayer/src/HDF5ArchiveReadingAgentTest.cpp
+++ b/ChronoPlayer/src/HDF5ArchiveReadingAgentTest.cpp
@@ -2,6 +2,13 @@
 // Created by kfeng on 1/14/25.
 //
 #include <csignal>
+#include <iostream>
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <list>
+#include <atomic>
 #include <HDF5ArchiveReadingAgent.h>
 #include <ConfigurationManager.h>
 #include <cmd_arg_parse.h>

--- a/ChronoPlayer/src/HDF5ArchiveReadingAgentTest.cpp
+++ b/ChronoPlayer/src/HDF5ArchiveReadingAgentTest.cpp
@@ -23,12 +23,9 @@ void signalHandler(int signum)
 {
     std::cout << "Interrupt signal (" << signum << ") received.\n";
 
-    for(auto &chunk: list_of_chunks)
-    {
-        delete chunk;
-    }
+    for(auto& chunk: list_of_chunks) { delete chunk; }
 
-    if (agent_ptr)
+    if(agent_ptr)
     {
         agent_ptr->shutdown();
     }
@@ -38,9 +35,9 @@ void signalHandler(int signum)
     std::exit(signum);
 }
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
-//    uint64_t current_timestamp = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    //    uint64_t current_timestamp = std::chrono::high_resolution_clock::now().time_since_epoch().count();
     std::string chronicle_name = "chronicle_0_0";
     std::string story_name = "story_0_0";
     uint64_t start_time = 1736800000000000000;
@@ -56,13 +53,13 @@ int main(int argc, char**argv)
         std::exit(EXIT_FAILURE);
     }
     chronolog::ConfigurationManager confManager(conf_file_path);
-    int result = chronolog::chrono_monitor::initialize(confManager.PLAYER_CONF.LOG_CONF.LOGTYPE
-                                                       , confManager.PLAYER_CONF.LOG_CONF.LOGFILE
-                                                       , confManager.PLAYER_CONF.LOG_CONF.LOGLEVEL
-                                                       , confManager.PLAYER_CONF.LOG_CONF.LOGNAME
-                                                       , confManager.PLAYER_CONF.LOG_CONF.LOGFILESIZE
-                                                       , confManager.PLAYER_CONF.LOG_CONF.LOGFILENUM
-                                                       , confManager.PLAYER_CONF.LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize(confManager.PLAYER_CONF.LOG_CONF.LOGTYPE,
+                                                       confManager.PLAYER_CONF.LOG_CONF.LOGFILE,
+                                                       confManager.PLAYER_CONF.LOG_CONF.LOGLEVEL,
+                                                       confManager.PLAYER_CONF.LOG_CONF.LOGNAME,
+                                                       confManager.PLAYER_CONF.LOG_CONF.LOGFILESIZE,
+                                                       confManager.PLAYER_CONF.LOG_CONF.LOGFILENUM,
+                                                       confManager.PLAYER_CONF.LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
@@ -71,19 +68,19 @@ int main(int argc, char**argv)
     tl::abt scope;
 
     std::string archive_path = confManager.GRAPHER_CONF.EXTRACTOR_CONF.story_files_dir;
-    agent_ptr = new chronolog::HDF5ArchiveReadingAgent(archive_path, true);  // Default to polling mode
+    agent_ptr = new chronolog::HDF5ArchiveReadingAgent(archive_path, true); // Default to polling mode
 
     agent_ptr->initialize();
 
-//    std::list<chronolog::StoryChunk*> list_of_chunks;
+    //    std::list<chronolog::StoryChunk*> list_of_chunks;
     std::cout << "Reading events in range [" << start_time << ", " << end_time << "]" << std::endl;
     agent_ptr->readArchivedStory(chronicle_name, story_name, start_time, end_time, list_of_chunks);
     std::cout << list_of_chunks.size() << " chunks is returned." << std::endl;
 
     bool all_events_within_time_range = true;
-    for(auto &chunk: list_of_chunks)
+    for(auto& chunk: list_of_chunks)
     {
-        for(auto &event: *chunk)
+        for(auto& event: *chunk)
         {
             if(event.second.eventTime < start_time || event.second.eventTime > end_time)
             {
@@ -99,10 +96,7 @@ int main(int argc, char**argv)
         std::cout << "All events in all chunks are within the time range." << std::endl;
     }
 
-    while(running)
-    {
-        std::this_thread::sleep_for(std::chrono::seconds(10));
-    }
+    while(running) { std::this_thread::sleep_for(std::chrono::seconds(10)); }
 
     return 0;
 }

--- a/ChronoPlayer/src/PlaybackService.cpp
+++ b/ChronoPlayer/src/PlaybackService.cpp
@@ -1,4 +1,7 @@
 #include <map>
+#include <mutex>
+#include <sstream>
+#include <utility>
 #include <thallium.hpp>
 
 #include <chrono_monitor.h>

--- a/ChronoPlayer/src/PlaybackService.cpp
+++ b/ChronoPlayer/src/PlaybackService.cpp
@@ -11,51 +11,55 @@
 namespace tl = thallium;
 namespace chl = chronolog;
 
-chronolog::PlaybackService::PlaybackService(tl::engine &tl_engine, uint16_t service_provider_id
-    , chronolog::ArchiveReadingRequestQueue & archive_reading_queue
-    )
-            : tl::provider <PlaybackService>(tl_engine, service_provider_id)
-            , playbackEngine(tl_engine)
-            , theArchiveReadingRequestQueue(archive_reading_queue)
+chronolog::PlaybackService::PlaybackService(tl::engine& tl_engine,
+                                            uint16_t service_provider_id,
+                                            chronolog::ArchiveReadingRequestQueue& archive_reading_queue)
+    : tl::provider<PlaybackService>(tl_engine, service_provider_id)
+    , playbackEngine(tl_engine)
+    , theArchiveReadingRequestQueue(archive_reading_queue)
 {
-        define("playback_service_available", &PlaybackService::playback_service_available);
-        define("story_playback_request", &PlaybackService::story_playback_request);
+    define("playback_service_available", &PlaybackService::playback_service_available);
+    define("story_playback_request", &PlaybackService::story_playback_request);
 
-        //set up callback for the case when the engine is being finalized while this provider is still alive
-        playbackEngine.push_finalize_callback(this, [p = this]()
-        { delete p; });
+    //set up callback for the case when the engine is being finalized while this provider is still alive
+    playbackEngine.push_finalize_callback(this, [p = this]() { delete p; });
 
-        std::stringstream ss;
-        ss << get_engine().self();
-        LOG_INFO("[PlaybackService] Constructed at {}. ProviderID={}", ss.str(), service_provider_id);
+    std::stringstream ss;
+    ss << get_engine().self();
+    LOG_INFO("[PlaybackService] Constructed at {}. ProviderID={}", ss.str(), service_provider_id);
 }
-   
+
 ////////////////////
 
 chronolog::PlaybackService::~PlaybackService()
 {
-        LOG_DEBUG("[PlaybackService] Destructor called. Cleaning up...");
-        //remove provider finalization callback from the engine's list
-        playbackEngine.pop_finalize_callback(this);
+    LOG_DEBUG("[PlaybackService] Destructor called. Cleaning up...");
+    //remove provider finalization callback from the engine's list
+    playbackEngine.pop_finalize_callback(this);
 }
 
 //////////////////
 
-void chronolog::PlaybackService::playback_service_available(tl::request const &request)
-{
-        request.respond(1);
-}
+void chronolog::PlaybackService::playback_service_available(tl::request const& request) { request.respond(1); }
 
-void chronolog::PlaybackService::story_playback_request(tl::request const &request,chl::ServiceId const & receiver_service_id, uint32_t query_id
-    ,chl::ChronicleName const &chronicle_name, chl::StoryName const &story_name, chl::chrono_time const& start_time, chl::chrono_time const& end_time)
+void chronolog::PlaybackService::story_playback_request(tl::request const& request,
+                                                        chl::ServiceId const& receiver_service_id,
+                                                        uint32_t query_id,
+                                                        chl::ChronicleName const& chronicle_name,
+                                                        chl::StoryName const& story_name,
+                                                        chl::chrono_time const& start_time,
+                                                        chl::chrono_time const& end_time)
 {
-        LOG_INFO("[PlaybackService] story_playback_request for receiver_service {} Story {}-{}", chl::to_string(receiver_service_id), chronicle_name, story_name);
+    LOG_INFO("[PlaybackService] story_playback_request for receiver_service {} Story {}-{}",
+             chl::to_string(receiver_service_id),
+             chronicle_name,
+             story_name);
 
-   //ChronoPlayer is running and able to respond 
-   // generate unique RequestId (service_provider_id + atomic query index)
-   uint32_t requestId = 1;
-       
-    chl::StoryChunkTransferAgent * storyChunkSender = nullptr;
+    //ChronoPlayer is running and able to respond
+    // generate unique RequestId (service_provider_id + atomic query index)
+    uint32_t requestId = 1;
+
+    chl::StoryChunkTransferAgent* storyChunkSender = nullptr;
     // if we already have StoryChunkTransferAgent & ExtractionQueue for this receiver,
     // use it or add one otherwise
     {
@@ -68,21 +72,27 @@ void chronolog::PlaybackService::story_playback_request(tl::request const &reque
         }
         else
         {
-        //create RDMA client of the requesting service 
-        // using the service tl_engine and service_id provided in the request
-        storyChunkSender = chl::StoryChunkTransferAgent::CreateStoryChunkTransferAgent(playbackEngine, receiver_service_id);
-        chunkSenders.insert(std::pair<chl::service_endpoint, chl::StoryChunkTransferAgent*>(receiver_service_id.get_service_endpoint(),storyChunkSender));
-        storyChunkSender->startExtractionThreads(1);
+            //create RDMA client of the requesting service
+            // using the service tl_engine and service_id provided in the request
+            storyChunkSender =
+                    chl::StoryChunkTransferAgent::CreateStoryChunkTransferAgent(playbackEngine, receiver_service_id);
+            chunkSenders.insert(std::pair<chl::service_endpoint, chl::StoryChunkTransferAgent*>(
+                    receiver_service_id.get_service_endpoint(),
+                    storyChunkSender));
+            storyChunkSender->startExtractionThreads(1);
         }
     }
 
-    // put new archiveRequest tied to the Sender's extractionQueue on 
+    // put new archiveRequest tied to the Sender's extractionQueue on
     // onto the ArchiveReadingRequestQueue
 
     theArchiveReadingRequestQueue.pushReadingRequest(
-            chl::ArchiveReadingRequest( &(storyChunkSender->getExtractionQueue()),chronicle_name, story_name, start_time, end_time)
-        );
-    
-    // return requestId 
+            chl::ArchiveReadingRequest(&(storyChunkSender->getExtractionQueue()),
+                                       chronicle_name,
+                                       story_name,
+                                       start_time,
+                                       end_time));
+
+    // return requestId
     request.respond(requestId);
 }

--- a/ChronoPlayer/src/PlaybackServiceTest.cpp
+++ b/ChronoPlayer/src/PlaybackServiceTest.cpp
@@ -18,7 +18,7 @@ namespace chl = chronolog;
 bool keep_running = true;
 void sigterm_handler(int)
 {
-    std::cout<< "Received SIGTERM signal. Initiating shutdown procedure."<<std::endl;
+    std::cout << "Received SIGTERM signal. Initiating shutdown procedure." << std::endl;
     keep_running = false;
     return;
 }
@@ -28,25 +28,32 @@ int main()
 
     signal(SIGTERM, sigterm_handler);
 
-    int result = chronolog::chrono_monitor::initialize( "file" //confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGTYPE
-                                                    ,"/tmp/TransferAgent.log"  //, confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILE
-                                                    , spdlog::level::debug// confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
-                                                    , "CronoPlayer"//confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
-                                                    , 10000//confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                                    , 2//confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
-                                                    , spdlog::level::debug//confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
-                                                    );
+    int result = chronolog::chrono_monitor::initialize(
+            "file" //confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGTYPE
+            ,
+            "/tmp/TransferAgent.log" //, confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILE
+            ,
+            spdlog::level::debug // confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
+            ,
+            "CronoPlayer" //confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
+            ,
+            10000 //confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
+            ,
+            2 //confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+            ,
+            spdlog::level::debug //confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
+    );
 
 
-    chl::ServiceId localServiceId("ofi+sockets", "127.0.0.1",5555,55);
+    chl::ServiceId localServiceId("ofi+sockets", "127.0.0.1", 5555, 55);
 
     std::string LOCAL_SERVICE_NA_STRING;
     localServiceId.get_service_as_string(LOCAL_SERVICE_NA_STRING);
 
-    tl::engine * localEngine = nullptr;
-    chl::PlaybackService * playbackService = nullptr;
+    tl::engine* localEngine = nullptr;
+    chl::PlaybackService* playbackService = nullptr;
 
-    chl::ServiceId queryServiceId("ofi+sockets", "127.0.0.1",5557,57);
+    chl::ServiceId queryServiceId("ofi+sockets", "127.0.0.1", 5557, 57);
 
     chl::ArchiveReadingRequestQueue readingRequestQueue;
 
@@ -55,24 +62,27 @@ int main()
         margo_instance_id margo_id = margo_init(LOCAL_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1, 1);
         localEngine = new tl::engine(margo_id);
 
-        std::cout <<"started localEngine at "<< localEngine->self()<<std::endl;
+        std::cout << "started localEngine at " << localEngine->self() << std::endl;
 
 
-        chl::PlaybackService * playbackService = chl::PlaybackService::CreatePlaybackService( *localEngine, localServiceId.getProviderId(),readingRequestQueue);
+        chl::PlaybackService* playbackService =
+                chl::PlaybackService::CreatePlaybackService(*localEngine,
+                                                            localServiceId.getProviderId(),
+                                                            readingRequestQueue);
     }
-    catch(tl::exception const &)
+    catch(tl::exception const&)
     {
         playbackService = nullptr;
     }
 
     if(nullptr == playbackService)
     {
-        return(-1);
+        return (-1);
     }
 
- while( true ==  keep_running)
+    while(true == keep_running)
     {
-/*
+        /*
         std::cout<<"TransferAgent is running"<<std::endl;
         transferAgent->is_receiver_available();
         
@@ -87,12 +97,13 @@ int main()
         std::cout<<"TransferAgent is sending storyChunk for story "<<storyChunk.getChronicleName()<<"-"<< storyChunk.getStoryName()<<"-"<<storyChunk.getStartTime()<<"-"<<storyChunk.getEndTime()<<" eventCount:"<<storyChunk.getEventCount()<<std::endl;
         transferAgent->processStoryChunk(&storyChunk);
 
-  */      sleep(3);
+  */
+        sleep(3);
     }
 
-    std::cout << "Shutting down  TransferAgent for "<<chl::to_string(queryServiceId)<<std::endl;
+    std::cout << "Shutting down  TransferAgent for " << chl::to_string(queryServiceId) << std::endl;
 
     delete playbackService;
     delete localEngine;
-return 1;
+    return 1;
 }

--- a/ChronoPlayer/src/PlaybackServiceTest.cpp
+++ b/ChronoPlayer/src/PlaybackServiceTest.cpp
@@ -1,6 +1,9 @@
 #include <chrono>
 #include <iostream>
+#include <string>
+#include <thread>
 #include <signal.h>
+#include <margo.h>
 
 #include <chrono_monitor.h>
 #include <ServiceId.h>

--- a/ChronoPlayer/src/PlayerDataStore.cpp
+++ b/ChronoPlayer/src/PlayerDataStore.cpp
@@ -18,13 +18,16 @@ namespace tl = thallium;
 void chronolog::PlayerDataStore::collectIngestedEvents()
 {
     LOG_DEBUG("[PlayerDataStore] Initiating collection of ingested story chunks. Current state={}, Active "
-              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-              , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
     theIngestionQueue.drainOrphanChunks();
 
     std::lock_guard storeLock(dataStoreMutex);
-    for(auto pipeline_iter = theMapOfStoryPipelines.begin();
-        pipeline_iter != theMapOfStoryPipelines.end(); ++pipeline_iter)
+    for(auto pipeline_iter = theMapOfStoryPipelines.begin(); pipeline_iter != theMapOfStoryPipelines.end();
+        ++pipeline_iter)
     {
         //INNA: this can be delegated to different threads handling individual storylines...
         (*pipeline_iter).second->collectIngestedEvents();
@@ -34,14 +37,18 @@ void chronolog::PlayerDataStore::collectIngestedEvents()
 ////////////////////////
 void chronolog::PlayerDataStore::extractDecayedStoryChunks()
 {
-    LOG_DEBUG("[PlayerDataStore] Initiating extraction of decayed story chunks. Current state={}, Active StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-              , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+    LOG_DEBUG("[PlayerDataStore] Initiating extraction of decayed story chunks. Current state={}, Active "
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
 
     uint64_t current_time = std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
     std::lock_guard storeLock(dataStoreMutex);
-    for(auto pipeline_iter = theMapOfStoryPipelines.begin();
-        pipeline_iter != theMapOfStoryPipelines.end(); ++pipeline_iter)
+    for(auto pipeline_iter = theMapOfStoryPipelines.begin(); pipeline_iter != theMapOfStoryPipelines.end();
+        ++pipeline_iter)
     {
         (*pipeline_iter).second->extractDecayedStoryChunks(current_time);
     }
@@ -50,8 +57,12 @@ void chronolog::PlayerDataStore::extractDecayedStoryChunks()
 
 void chronolog::PlayerDataStore::retireDecayedPipelines()
 {
-    LOG_TRACE("[PlayerDataStore] Initiating retirement of decayed pipelines. Current state={}, Active StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-              , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+    LOG_TRACE("[PlayerDataStore] Initiating retirement of decayed pipelines. Current state={}, Active "
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
 
     if(!theMapOfStoryPipelines.empty())
     {
@@ -63,22 +74,32 @@ void chronolog::PlayerDataStore::retireDecayedPipelines()
             if(current_time >= (*pipeline_iter).second.second)
             {
                 //current_time >= pipeline exit_time
-                StoryPipeline * pipeline = (*pipeline_iter).second.first;
-                LOG_DEBUG("[PlayerDataStore] retiring pipeline StoryId {} timeline {}-{} acceptanceWindow {} retirementTime {}",
-                        pipeline->getStoryId(), pipeline->TimelineStart(), pipeline->TimelineEnd(), pipeline->getAcceptanceWindow(), (*pipeline_iter).second.second);
+                StoryPipeline* pipeline = (*pipeline_iter).second.first;
+                LOG_DEBUG("[PlayerDataStore] retiring pipeline StoryId {} timeline {}-{} acceptanceWindow {} "
+                          "retirementTime {}",
+                          pipeline->getStoryId(),
+                          pipeline->TimelineStart(),
+                          pipeline->TimelineEnd(),
+                          pipeline->getAcceptanceWindow(),
+                          (*pipeline_iter).second.second);
                 theMapOfStoryPipelines.erase(pipeline->getStoryId());
                 theIngestionQueue.removeStoryIngestionHandle(pipeline->getStoryId());
                 pipeline_iter = pipelinesWaitingForExit.erase(pipeline_iter);
                 delete pipeline;
             }
             else
-            { pipeline_iter++; }
-
+            {
+                pipeline_iter++;
+            }
         }
     }
 
-    LOG_TRACE("[PlayerDataStore] Completed retirement of decayed pipelines. Current state={}, Active StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}"
-              , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size(), tl::thread::self_id());
+    LOG_TRACE("[PlayerDataStore] Completed retirement of decayed pipelines. Current state={}, Active "
+              "StoryPipelines={}, PipelinesWaitingForExit={}, ThreadID={}",
+              state,
+              theMapOfStoryPipelines.size(),
+              pipelinesWaitingForExit.size(),
+              tl::thread::self_id());
 }
 
 void chronolog::PlayerDataStore::dataCollectionTask()
@@ -87,13 +108,15 @@ void chronolog::PlayerDataStore::dataCollectionTask()
     // or there're still events left to collect and
     // storyPipelines left to retire...
     tl::xstream es = tl::xstream::self();
-    LOG_DEBUG("[PlayerDataStore] Initiating DataCollectionTask. ESrank={}, ThreadID={}", es.get_rank()
-              , tl::thread::self_id());
+    LOG_DEBUG("[PlayerDataStore] Initiating DataCollectionTask. ESrank={}, ThreadID={}",
+              es.get_rank(),
+              tl::thread::self_id());
 
     while(!is_shutting_down() || !theIngestionQueue.is_empty() || !theMapOfStoryPipelines.empty())
     {
-        LOG_DEBUG("[PlayerDataStore] Running DataCollection iteration. ESrank={}, ThreadID={}", es.get_rank()
-                  , tl::thread::self_id());
+        LOG_DEBUG("[PlayerDataStore] Running DataCollection iteration. ESrank={}, ThreadID={}",
+                  es.get_rank(),
+                  tl::thread::self_id());
         for(int i = 0; i < 6; ++i)
         {
             collectIngestedEvents();
@@ -115,31 +138,36 @@ void chronolog::PlayerDataStore::startDataCollection(int stream_count)
         return;
     }
 
-    LOG_INFO("[PlayerDataStore] Starting data collection. StreamCount={}, ThreadID={}", stream_count
-             , tl::thread::self_id());
+    LOG_INFO("[PlayerDataStore] Starting data collection. StreamCount={}, ThreadID={}",
+             stream_count,
+             tl::thread::self_id());
     state = RUNNING;
 
     for(int i = 0; i < stream_count; ++i)
     {
-        tl::managed <tl::xstream> es = tl::xstream::create();
+        tl::managed<tl::xstream> es = tl::xstream::create();
         dataStoreStreams.push_back(std::move(es));
     }
 
     for(int i = 0; i < 2 * stream_count; ++i)
     {
-        tl::managed <tl::thread> th = dataStoreStreams[i % (dataStoreStreams.size())]->make_thread([p = this]()
-                                                                                                   { p->dataCollectionTask(); });
+        tl::managed<tl::thread> th =
+                dataStoreStreams[i % (dataStoreStreams.size())]->make_thread([p = this]() { p->dataCollectionTask(); });
         dataStoreThreads.push_back(std::move(th));
     }
-    LOG_INFO("[PlayerDataStore] Data collection started successfully. Stream count={}, ThreadID={}", stream_count
-             , tl::thread::self_id());
+    LOG_INFO("[PlayerDataStore] Data collection started successfully. Stream count={}, ThreadID={}",
+             stream_count,
+             tl::thread::self_id());
 }
 //////////////////////////////
 
 void chronolog::PlayerDataStore::shutdownDataCollection()
 {
-    LOG_INFO("[PlayerDataStore] Initiating shutdown of DataCollection. CurrentState={}, Active StoryPipelines={}, PipelinesWaitingForExit={}"
-             , state, theMapOfStoryPipelines.size(), pipelinesWaitingForExit.size());
+    LOG_INFO("[PlayerDataStore] Initiating shutdown of DataCollection. CurrentState={}, Active StoryPipelines={}, "
+             "PipelinesWaitingForExit={}",
+             state,
+             theMapOfStoryPipelines.size(),
+             pipelinesWaitingForExit.size());
 
     // switch the state to shuttingDown
     std::lock_guard storeLock(dataStoreStateMutex);
@@ -156,14 +184,14 @@ void chronolog::PlayerDataStore::shutdownDataCollection()
         std::lock_guard storeLock(dataStoreMutex);
         uint64_t current_time = std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
-        for(auto pipeline_iter = theMapOfStoryPipelines.begin();
-            pipeline_iter != theMapOfStoryPipelines.end(); ++pipeline_iter)
+        for(auto pipeline_iter = theMapOfStoryPipelines.begin(); pipeline_iter != theMapOfStoryPipelines.end();
+            ++pipeline_iter)
         {
             if(pipelinesWaitingForExit.find((*pipeline_iter).first) == pipelinesWaitingForExit.end())
             {
                 uint64_t exit_time = current_time + (*pipeline_iter).second->getAcceptanceWindow();
-                pipelinesWaitingForExit[(*pipeline_iter).first] = (std::pair <chl::StoryPipeline*, uint64_t>(
-                        (*pipeline_iter).second, exit_time));
+                pipelinesWaitingForExit[(*pipeline_iter).first] =
+                        (std::pair<chl::StoryPipeline*, uint64_t>((*pipeline_iter).second, exit_time));
             }
         }
     }
@@ -171,16 +199,10 @@ void chronolog::PlayerDataStore::shutdownDataCollection()
     // Join threads & execution streams while holding stateMutex
     // and just wait until all the events are collected and
     // all the storyPipelines decay and retire
-    for(auto &th: dataStoreThreads)
-    {
-        th->join();
-    }
+    for(auto& th: dataStoreThreads) { th->join(); }
     LOG_INFO("[PlayerDataStore] All data collection threads have been joined.");
 
-    for(auto &es: dataStoreStreams)
-    {
-        es->join();
-    }
+    for(auto& es: dataStoreStreams) { es->join(); }
     LOG_INFO("[PlayerDataStore] All data collection streams have been joined.");
     LOG_INFO("[PlayerDataStore] DataCollection shutdown completed.");
 }
@@ -190,9 +212,9 @@ void chronolog::PlayerDataStore::shutdownDataCollection()
 //
 chronolog::PlayerDataStore::~PlayerDataStore()
 {
-    LOG_INFO("[PlayerDataStore] Destructor called. Initiating shutdown. Active StoryPipelines count={}"
-             , theMapOfStoryPipelines.size());
+    LOG_INFO("[PlayerDataStore] Destructor called. Initiating shutdown. Active StoryPipelines count={}",
+             theMapOfStoryPipelines.size());
     shutdownDataCollection();
-    LOG_INFO("[PlayerDataStore] Shutdown completed successfully. Active StoryPipelines count={}"
-             , theMapOfStoryPipelines.size());
+    LOG_INFO("[PlayerDataStore] Shutdown completed successfully. Active StoryPipelines count={}",
+             theMapOfStoryPipelines.size());
 }

--- a/ChronoPlayer/src/PlayerDataStore.cpp
+++ b/ChronoPlayer/src/PlayerDataStore.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <mutex>
 #include <chrono>
+#include <utility>
 #include <thallium.hpp>
 
 #include <chronolog_errcode.h>

--- a/ChronoPlayer/src/StoryChunkTransferAgent.cpp
+++ b/ChronoPlayer/src/StoryChunkTransferAgent.cpp
@@ -14,15 +14,19 @@
 namespace tl = thallium;
 namespace chl = chronolog;
 
-chronolog::StoryChunkTransferAgent::StoryChunkTransferAgent(tl::engine &tl_engine, chronolog::ServiceId const& service_id)
-        : service_engine(tl_engine) 
-        , receiver_service_id(service_id)
+chronolog::StoryChunkTransferAgent::StoryChunkTransferAgent(tl::engine& tl_engine,
+                                                            chronolog::ServiceId const& service_id)
+    : service_engine(tl_engine)
+    , receiver_service_id(service_id)
 {
     std::string service_addr_string;
     receiver_service_id.get_service_as_string(service_addr_string);
-    
-    LOG_DEBUG("[StoryChunkTransferAgent] Constructor for receiver service {} , service_string {}", chl::to_string(receiver_service_id), service_addr_string);
-    receiver_service_handle = tl::provider_handle(service_engine.lookup(service_addr_string), receiver_service_id.getProviderId());
+
+    LOG_DEBUG("[StoryChunkTransferAgent] Constructor for receiver service {} , service_string {}",
+              chl::to_string(receiver_service_id),
+              service_addr_string);
+    receiver_service_handle =
+            tl::provider_handle(service_engine.lookup(service_addr_string), receiver_service_id.getProviderId());
 
     receiver_is_available = service_engine.define("receiver_is_available");
     receive_story_chunk = service_engine.define("receive_story_chunk");
@@ -34,22 +38,28 @@ chronolog::StoryChunkTransferAgent::~StoryChunkTransferAgent()
 {
     receiver_is_available.deregister();
     receive_story_chunk.deregister();
-    LOG_DEBUG("[StoryChunkTransferAgent] Destroying agent for receiver service {}", chl::to_string(receiver_service_id));
+    LOG_DEBUG("[StoryChunkTransferAgent] Destroying agent for receiver service {}",
+              chl::to_string(receiver_service_id));
 }
 
 bool chronolog::StoryChunkTransferAgent::is_receiver_available() const
 {
-    bool ret_value = receiver_is_available.on(receiver_service_handle)( );
+    bool ret_value = receiver_is_available.on(receiver_service_handle)();
 
-    LOG_DEBUG("[StoryChunkTransferAgent] receiver_service {} is available {}", chl::to_string(receiver_service_id), ret_value);
-return ret_value;    
+    LOG_DEBUG("[StoryChunkTransferAgent] receiver_service {} is available {}",
+              chl::to_string(receiver_service_id),
+              ret_value);
+    return ret_value;
 }
-int chronolog::StoryChunkTransferAgent::processStoryChunk(chronolog::StoryChunk*story_chunk)
+int chronolog::StoryChunkTransferAgent::processStoryChunk(chronolog::StoryChunk* story_chunk)
 {
     try
     {
-        LOG_DEBUG("[StoryChunkTransferAgent] agent for receiver {} processing a story chunk, StoryID: {}, StartTime: {}", chl::to_string(receiver_service_id)
-                  , story_chunk->getStoryId(), story_chunk->getStartTime());
+        LOG_DEBUG(
+                "[StoryChunkTransferAgent] agent for receiver {} processing a story chunk, StoryID: {}, StartTime: {}",
+                chl::to_string(receiver_service_id),
+                story_chunk->getStoryId(),
+                story_chunk->getStartTime());
 #ifdef LOGTIME
         std::chrono::high_resolution_clock::time_point start, end;
         start = std::chrono::high_resolution_clock::now();
@@ -64,11 +74,11 @@ int chronolog::StoryChunkTransferAgent::processStoryChunk(chronolog::StoryChunk*
 #ifdef LOGTIME
         end = std::chrono::high_resolution_clock::now();
         LOG_INFO("[StoryChunkTransferAgent] StoryChunk serialization took {} us",
-                std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0);
+                 std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count() / 1000.0);
 #endif
         LOG_DEBUG("[StoryChunkTransferAgent] Serialized StoryChunk size: {}", serialized_story_chunk_size);
 
-        std::vector <std::pair <void*, std::size_t>> segments(1);
+        std::vector<std::pair<void*, std::size_t>> segments(1);
         segments[0].first = (void*)(serialized_story_chunk.data());
         segments[0].second = serialized_story_chunk_size;
         tl::bulk tl_bulk = service_engine.expose(segments, tl::bulk_mode::read_only);
@@ -76,31 +86,33 @@ int chronolog::StoryChunkTransferAgent::processStoryChunk(chronolog::StoryChunk*
 
         size_t bytes_transfered = receive_story_chunk.on(receiver_service_handle)(tl_bulk);
 
-#ifdef LOGTIME 
+#ifdef LOGTIME
         start = end;
         end = std::chrono::high_resolution_clock::now();
         LOG_INFO("[StoryChunkTransferAgent] StoryChunk transfer took {} us",
-                std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0);
+                 std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count() / 1000.0);
 #endif
         LOG_DEBUG("[StoryChunkTransferAgent] StoryChunk transfer returned with result: {}", bytes_transfered);
 
         if(bytes_transfered == serialized_story_chunk_size)
         {
-            LOG_INFO("[StoryChunkTransferAgent] Successfully transfered StoryChunk, StoryId:{}, StartTime:{}", story_chunk->getStoryId(), story_chunk->getStartTime());
+            LOG_INFO("[StoryChunkTransferAgent] Successfully transfered StoryChunk, StoryId:{}, StartTime:{}",
+                     story_chunk->getStoryId(),
+                     story_chunk->getStartTime());
             return chronolog::CL_SUCCESS;
         }
     }
-    catch(tl::exception const &ex)
+    catch(tl::exception const& ex)
     {
         LOG_ERROR("[StoryChunkTransferAgent] Thallium exception while transferring StoryChunk: {}", ex.what());
         return (chronolog::CL_ERR_UNKNOWN);
     }
-    catch(cereal::Exception const &ex)
+    catch(cereal::Exception const& ex)
     {
         LOG_ERROR("[StoryChunkTransferAgent] Cereal exception while serializing StoryChunk: {}", ex.what());
         return chronolog::CL_ERR_UNKNOWN;
     }
-    catch(std::exception const &ex)
+    catch(std::exception const& ex)
     {
         LOG_ERROR("[StoryChunkTransferAgent] Standard exception while serializing StoryChunk: {}", ex.what());
         return chronolog::CL_ERR_UNKNOWN;
@@ -111,6 +123,8 @@ int chronolog::StoryChunkTransferAgent::processStoryChunk(chronolog::StoryChunk*
         return chronolog::CL_ERR_UNKNOWN;
     }
 
-    LOG_ERROR("[StoryChunkTransferAgent] Failed to transfer StoryShunk, StoryId:{},StartTime:{}", story_chunk->getStoryId(), story_chunk->getStartTime());
+    LOG_ERROR("[StoryChunkTransferAgent] Failed to transfer StoryShunk, StoryId:{},StartTime:{}",
+              story_chunk->getStoryId(),
+              story_chunk->getStartTime());
     return chronolog::CL_ERR_STORY_CHUNK_EXTRACTION;
 }

--- a/ChronoPlayer/src/StoryChunkTransferAgent.cpp
+++ b/ChronoPlayer/src/StoryChunkTransferAgent.cpp
@@ -1,3 +1,9 @@
+#include <sstream>
+#include <string>
+#include <vector>
+#include <utility>
+#include <ios>
+#include <cstddef>
 #include <thallium/serialization/stl/vector.hpp>
 #include <cereal/archives/binary.hpp>
 

--- a/ChronoPlayer/src/TransferAgentTest.cpp
+++ b/ChronoPlayer/src/TransferAgentTest.cpp
@@ -1,6 +1,9 @@
 #include <chrono>
 #include <iostream>
+#include <string>
+#include <thread>
 #include <signal.h>
+#include <margo.h>
 
 #include <chrono_monitor.h>
 #include <ServiceId.h>

--- a/ChronoPlayer/src/TransferAgentTest.cpp
+++ b/ChronoPlayer/src/TransferAgentTest.cpp
@@ -16,7 +16,7 @@ namespace chl = chronolog;
 bool keep_running = true;
 void sigterm_handler(int)
 {
-    std::cout<< "Received SIGTERM signal. Initiating shutdown procedure."<<std::endl;
+    std::cout << "Received SIGTERM signal. Initiating shutdown procedure." << std::endl;
     keep_running = false;
     return;
 }
@@ -26,68 +26,79 @@ int main()
 
     signal(SIGTERM, sigterm_handler);
 
-    int result = chronolog::chrono_monitor::initialize( "file" //confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGTYPE
-                                                    ,"/tmp/TransferAgent.log"  //, confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILE
-                                                    , spdlog::level::debug// confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
-                                                    , "CronoPlayer"//confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
-                                                    , 10000//confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                                    , 2//confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
-                                                    , spdlog::level::debug//confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
-                                                    );
+    int result = chronolog::chrono_monitor::initialize(
+            "file" //confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGTYPE
+            ,
+            "/tmp/TransferAgent.log" //, confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILE
+            ,
+            spdlog::level::debug // confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
+            ,
+            "CronoPlayer" //confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
+            ,
+            10000 //confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
+            ,
+            2 //confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+            ,
+            spdlog::level::debug //confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
+    );
 
 
-    chl::ServiceId localServiceId("ofi+sockets", "127.0.0.1",2225,25);
+    chl::ServiceId localServiceId("ofi+sockets", "127.0.0.1", 2225, 25);
 
     std::string LOCAL_SERVICE_NA_STRING;
     localServiceId.get_service_as_string(LOCAL_SERVICE_NA_STRING);
 
-    tl::engine * localEngine = nullptr;
-    chronolog::StoryChunkTransferAgent * transferAgent = nullptr;
+    tl::engine* localEngine = nullptr;
+    chronolog::StoryChunkTransferAgent* transferAgent = nullptr;
 
-    chl::ServiceId queryServiceId("ofi+sockets", "127.0.0.1",5557,57);
+    chl::ServiceId queryServiceId("ofi+sockets", "127.0.0.1", 5557, 57);
     try
     {
         margo_instance_id margo_id = margo_init(LOCAL_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1, 1);
         localEngine = new tl::engine(margo_id);
 
-        std::cout <<"started localEngine at "<< localEngine->self()<<std::endl;
+        std::cout << "started localEngine at " << localEngine->self() << std::endl;
 
 
-        transferAgent = chronolog::StoryChunkTransferAgent::CreateStoryChunkTransferAgent(*localEngine , queryServiceId);
-
+        transferAgent = chronolog::StoryChunkTransferAgent::CreateStoryChunkTransferAgent(*localEngine, queryServiceId);
     }
-    catch(tl::exception const &)
+    catch(tl::exception const&)
     {
         transferAgent = nullptr;
     }
 
     if(nullptr == transferAgent)
     {
-        return(-1);
+        return (-1);
     }
 
- while( true ==  keep_running)
+    while(true == keep_running)
     {
-        std::cout<<"TransferAgent is running"<<std::endl;
+        std::cout << "TransferAgent is running" << std::endl;
         transferAgent->is_receiver_available();
-        
-        chl::StoryChunk storyChunk("Chronicle","Story", 1, std::chrono::high_resolution_clock::now().time_since_epoch().count()
-                  ,  std::chrono::high_resolution_clock::now().time_since_epoch().count()+5000);
-   
-        for(int i =0; i< 5; ++i) 
-        { 
-            storyChunk.insertEvent(chl::LogEvent{ 1, storyChunk.getStartTime()+i, 2968,1,
-                             "line "+std::to_string(i)});
+
+        chl::StoryChunk storyChunk("Chronicle",
+                                   "Story",
+                                   1,
+                                   std::chrono::high_resolution_clock::now().time_since_epoch().count(),
+                                   std::chrono::high_resolution_clock::now().time_since_epoch().count() + 5000);
+
+        for(int i = 0; i < 5; ++i)
+        {
+            storyChunk.insertEvent(
+                    chl::LogEvent{1, storyChunk.getStartTime() + i, 2968, 1, "line " + std::to_string(i)});
         }
-        std::cout<<"TransferAgent is sending storyChunk for story "<<storyChunk.getChronicleName()<<"-"<< storyChunk.getStoryName()<<"-"<<storyChunk.getStartTime()<<"-"<<storyChunk.getEndTime()<<" eventCount:"<<storyChunk.getEventCount()<<std::endl;
+        std::cout << "TransferAgent is sending storyChunk for story " << storyChunk.getChronicleName() << "-"
+                  << storyChunk.getStoryName() << "-" << storyChunk.getStartTime() << "-" << storyChunk.getEndTime()
+                  << " eventCount:" << storyChunk.getEventCount() << std::endl;
         transferAgent->processStoryChunk(&storyChunk);
 
         sleep(3);
     }
 
-    std::cout << "Shutting down  TransferAgent for "<<chl::to_string(queryServiceId)<<std::endl;
+    std::cout << "Shutting down  TransferAgent for " << chl::to_string(queryServiceId) << std::endl;
 
     delete transferAgent;
     delete localEngine;
-return 1;
+    return 1;
 }

--- a/ChronoStore/include/StoryReader.h
+++ b/ChronoStore/include/StoryReader.h
@@ -1,7 +1,9 @@
 #ifndef READ_H
 #define READ_H
 
-#include <iostream>
+#include <cstdint>
+#include <string>
+#include <vector>
 #include <map>
 #include <json-c/json.h>
 #include <StoryChunk.h>

--- a/ChronoStore/include/StoryReader.h
+++ b/ChronoStore/include/StoryReader.h
@@ -6,12 +6,13 @@
 #include <vector>
 #include <map>
 #include <json-c/json.h>
+#include <hdf5.h>
+
 #include <StoryChunk.h>
 #include <event.h>
 #include <datasetreader.h>
 #include <datasetminmax.h>
 #include <chrono_monitor.h>
-#include <hdf5.h>
 
 class StoryReader
 {

--- a/ChronoStore/include/StoryReader.h
+++ b/ChronoStore/include/StoryReader.h
@@ -19,51 +19,57 @@ private:
     std::string chronicle_root_dir;
 
     // Deserialize StoryChunk from JSON string
-    chronolog::StoryChunk
-    deserializeStoryChunk(char*story_chunk_json_str, std::string chronicle_name, std::string story_name
-                          , uint64_t story_id, uint64_t start_time, uint64_t end_time);
+    chronolog::StoryChunk deserializeStoryChunk(char* story_chunk_json_str,
+                                                std::string chronicle_name,
+                                                std::string story_name,
+                                                uint64_t story_id,
+                                                uint64_t start_time,
+                                                uint64_t end_time);
 
     // Find all Story Chunks that overlap with the given time range of a Story
-    std::vector <std::string>
-    findContiguousStoryChunks(const hid_t &story_file, uint64_t start_time, uint64_t end_time);
+    std::vector<std::string> findContiguousStoryChunks(const hid_t& story_file, uint64_t start_time, uint64_t end_time);
 
     // Check if a Story Chunk overlaps with the given time range
-    static bool isStoryChunkOverlapping(const std::string &story_chunk_name, uint64_t start_time, uint64_t end_time);
+    static bool isStoryChunkOverlapping(const std::string& story_chunk_name, uint64_t start_time, uint64_t end_time);
 
     // Get all Story Chunks in a Story file
-    std::vector <std::string> getAllStoryChunks(const hid_t &story_file);
+    std::vector<std::string> getAllStoryChunks(const hid_t& story_file);
 
 public:
     StoryReader() = default;
 
-    explicit StoryReader(std::string &chronicle_root_dir): chronicle_root_dir(chronicle_root_dir)
+    explicit StoryReader(std::string& chronicle_root_dir)
+        : chronicle_root_dir(chronicle_root_dir)
     {}
 
     ~StoryReader() = default;
 
     // Read Events within a time range from a Story file
-    int
-    readStoryRange(const std::string &chronicle_name, const uint64_t &story_id, uint64_t start_time, uint64_t end_time
-                   , std::map <uint64_t, chronolog::StoryChunk> &story_chunk_map);
+    int readStoryRange(const std::string& chronicle_name,
+                       const uint64_t& story_id,
+                       uint64_t start_time,
+                       uint64_t end_time,
+                       std::map<uint64_t, chronolog::StoryChunk>& story_chunk_map);
 
     // Read from all Story files in a Chronicle directory
-    std::map <uint64_t, chronolog::StoryChunk> readAllStories(const std::string &chronicle_name);
+    std::map<uint64_t, chronolog::StoryChunk> readAllStories(const std::string& chronicle_name);
 
     // Read from one Story file
-    int readStory(const std::string &chronicle_name, const std::string &story_file_name
-                  , std::map <uint64_t, chronolog::StoryChunk> &story_chunk_map);
+    int readStory(const std::string& chronicle_name,
+                  const std::string& story_file_name,
+                  std::map<uint64_t, chronolog::StoryChunk>& story_chunk_map);
 
     // Read all Story Chunks in a Story file
-    int readAllStoryChunks(hid_t &story_file, std::map <uint64_t, chronolog::StoryChunk> &story_chunk_map);
+    int readAllStoryChunks(hid_t& story_file, std::map<uint64_t, chronolog::StoryChunk>& story_chunk_map);
 
     // Read a Story Chunk from a Story file
-    chronolog::StoryChunk readOneStoryChunk(hid_t &story_file, const std::string &story_chunk_name);
+    chronolog::StoryChunk readOneStoryChunk(hid_t& story_file, const std::string& story_chunk_name);
 
     // Read string attribute from a Story Chunk dataset
-    std::string readStringAttribute(hid_t &story_chunk_dset, const std::string &attribute_name);
+    std::string readStringAttribute(hid_t& story_chunk_dset, const std::string& attribute_name);
 
     // Read uint64_t attribute from a Story Chunk dataset
-    uint64_t readUint64Attribute(hid_t &story_chunk_dset, const std::string &attribute_name);
+    uint64_t readUint64Attribute(hid_t& story_chunk_dset, const std::string& attribute_name);
 };
 
 #endif

--- a/ChronoStore/include/StoryWriter.h
+++ b/ChronoStore/include/StoryWriter.h
@@ -1,9 +1,12 @@
 #ifndef STORY_WRITER_H
 #define STORY_WRITER_H
 
-#include <iostream>
+#include <cstdint>
+#include <string>
 #include <vector>
 #include <map>
+#include <tuple>
+#include <utility>
 #include <event.h>
 #include <json-c/json.h>
 #include <StoryChunk.h>

--- a/ChronoStore/include/StoryWriter.h
+++ b/ChronoStore/include/StoryWriter.h
@@ -7,10 +7,11 @@
 #include <map>
 #include <tuple>
 #include <utility>
-#include <event.h>
 #include <json-c/json.h>
-#include <StoryChunk.h>
 #include <hdf5.h>
+
+#include <StoryChunk.h>
+#include <event.h>
 
 class StoryWriter
 {

--- a/ChronoStore/include/StoryWriter.h
+++ b/ChronoStore/include/StoryWriter.h
@@ -18,35 +18,36 @@ private:
     std::string chronicle_root_dir;
 
     template <typename T>
-    json_object*convertToJsonObject(const T &value);
+    json_object* convertToJsonObject(const T& value);
 
     template <typename... Args, size_t... Is>
-    json_object*serializeTupleToJsonObject(const std::tuple <Args...> &tuple, std::index_sequence <Is...>);
+    json_object* serializeTupleToJsonObject(const std::tuple<Args...>& tuple, std::index_sequence<Is...>);
 
     template <typename... Args>
-    json_object*serializeTupleToJsonObject(const std::tuple <Args...> &tuple);
+    json_object* serializeTupleToJsonObject(const std::tuple<Args...>& tuple);
 
     hid_t
-    writeStringAttribute(hid_t story_chunk_dset, const std::string &attribute_name, const std::string &attribute_value);
+    writeStringAttribute(hid_t story_chunk_dset, const std::string& attribute_name, const std::string& attribute_value);
 
     hid_t
-    writeUint64Attribute(hid_t story_chunk_dset, const std::string &attribute_name, const uint64_t &attribute_value);
+    writeUint64Attribute(hid_t story_chunk_dset, const std::string& attribute_name, const uint64_t& attribute_value);
 
 public:
     StoryWriter() = default;
 
-    explicit StoryWriter(std::string &chronicle_root_dir): chronicle_root_dir(chronicle_root_dir)
-    {};
+    explicit StoryWriter(std::string& chronicle_root_dir)
+        : chronicle_root_dir(chronicle_root_dir){};
 
     ~StoryWriter() = default;
 
-    int writeStoryChunks(const std::map <uint64_t, chronolog::StoryChunk> &story_chunk_map
-                         , const std::string &chronicle_name, const std::string &story_name);
+    int writeStoryChunks(const std::map<uint64_t, chronolog::StoryChunk>& story_chunk_map,
+                         const std::string& chronicle_name,
+                         const std::string& story_name);
 
-    static void serializeStoryChunk(json_object*obj, chronolog::StoryChunk &story_chunk);
+    static void serializeStoryChunk(json_object* obj, chronolog::StoryChunk& story_chunk);
 
-    static std::vector <std::string>
-    serializeStoryChunkMap(std::map <std::uint64_t, chronolog::StoryChunk> &story_chunk_map);
+    static std::vector<std::string>
+    serializeStoryChunkMap(std::map<std::uint64_t, chronolog::StoryChunk>& story_chunk_map);
 };
 
 #endif

--- a/ChronoStore/include/StoryWriter.h
+++ b/ChronoStore/include/StoryWriter.h
@@ -36,7 +36,7 @@ public:
     StoryWriter() = default;
 
     explicit StoryWriter(std::string& chronicle_root_dir)
-        : chronicle_root_dir(chronicle_root_dir){};
+        : chronicle_root_dir(chronicle_root_dir) {};
 
     ~StoryWriter() = default;
 

--- a/ChronoStore/include/chunkattr.h
+++ b/ChronoStore/include/chunkattr.h
@@ -1,4 +1,4 @@
-#include<iostream>
+#include <cstdint>
 
 #ifndef CHUNK_ATTR_H
 #define CHUNK_ATTR_H

--- a/ChronoStore/include/datasetminmax.h
+++ b/ChronoStore/include/datasetminmax.h
@@ -1,5 +1,5 @@
-#include<iostream>
-#include<vector>
+#include <cstdint>
+#include <utility>
 
 #ifndef DATASET_MIN_MAX_H
 #define DATASET_MIN_MAX_H

--- a/ChronoStore/include/datasetminmax.h
+++ b/ChronoStore/include/datasetminmax.h
@@ -8,9 +8,9 @@
 typedef struct DatasetMinMax
 {
     int status;
-    std::pair <uint64_t, uint64_t> MinMax;
+    std::pair<uint64_t, uint64_t> MinMax;
 
-    DatasetMinMax(int initialStatus, const std::pair <uint64_t, uint64_t> &initialMinMax)
+    DatasetMinMax(int initialStatus, const std::pair<uint64_t, uint64_t>& initialMinMax)
     {
         status = initialStatus;
         MinMax = initialMinMax;

--- a/ChronoStore/include/datasetreader.h
+++ b/ChronoStore/include/datasetreader.h
@@ -8,9 +8,9 @@
 typedef struct DatasetReader
 {
     int status;
-    std::vector <Event> eventData;
+    std::vector<Event> eventData;
 
-    DatasetReader(int initialStatus, const std::vector <Event> &initialMinMax)
+    DatasetReader(int initialStatus, const std::vector<Event>& initialMinMax)
     {
         status = initialStatus;
         eventData = initialMinMax;

--- a/ChronoStore/include/datasetreader.h
+++ b/ChronoStore/include/datasetreader.h
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <vector>
 #include <event.h>
 

--- a/ChronoStore/include/event.h
+++ b/ChronoStore/include/event.h
@@ -1,4 +1,4 @@
-#include<iostream>
+#include <cstdint>
 
 #ifndef EVENT_H
 #define EVENT_H

--- a/ChronoStore/include/storyreader.h
+++ b/ChronoStore/include/storyreader.h
@@ -1,4 +1,5 @@
-#include <iostream>
+#include <cstdint>
+#include <utility>
 #include <event.h>
 #include <datasetreader.h>
 #include <datasetminmax.h>

--- a/ChronoStore/include/storyreader.h
+++ b/ChronoStore/include/storyreader.h
@@ -17,11 +17,10 @@ public:
     ~storyreader();
 
     // Read data from H5 dataset
-    DatasetReader readFromDataset(std::pair <uint64_t, uint64_t> range, const char*STORY, const char*CHRONICLE);
+    DatasetReader readFromDataset(std::pair<uint64_t, uint64_t> range, const char* STORY, const char* CHRONICLE);
 
     // Read dataset data range i.e Min and Max
-    DatasetMinMax readDatasetRange(const char*STORY, const char*CHRONICLE);
-
+    DatasetMinMax readDatasetRange(const char* STORY, const char* CHRONICLE);
 };
 
 #endif

--- a/ChronoStore/include/storywriter.h
+++ b/ChronoStore/include/storywriter.h
@@ -1,6 +1,5 @@
-#include<iostream>
-#include<vector>
-#include<event.h>
+#include <vector>
+#include <event.h>
 
 #ifndef WRITE_H
 #define WRITE_H

--- a/ChronoStore/include/storywriter.h
+++ b/ChronoStore/include/storywriter.h
@@ -14,7 +14,7 @@ public:
 
     ~storywriter();
 
-    int writeStoryChunk(std::vector <Event>*storyChunk, const char*DATASET_NAME, const char*H5FILE_NAME);
+    int writeStoryChunk(std::vector<Event>* storyChunk, const char* DATASET_NAME, const char* H5FILE_NAME);
 };
 
 #endif

--- a/ChronoStore/src/StoryReader.cpp
+++ b/ChronoStore/src/StoryReader.cpp
@@ -25,11 +25,11 @@
  * @param chronicle_name Chronicle name to read
  * @return a map of StoryChunk objects sorted by its start_time
  */
-std::map <uint64_t, chronolog::StoryChunk> StoryReader::readAllStories(const std::string &chronicle_name)
+std::map<uint64_t, chronolog::StoryChunk> StoryReader::readAllStories(const std::string& chronicle_name)
 {
-    std::map <uint64_t, chronolog::StoryChunk> story_chunk_map;
+    std::map<uint64_t, chronolog::StoryChunk> story_chunk_map;
     std::string chronicle_dir = std::string(chronicle_root_dir) + chronicle_name;
-    for(const auto &entry: std::filesystem::directory_iterator(chronicle_dir))
+    for(const auto& entry: std::filesystem::directory_iterator(chronicle_dir))
     {
         // Skip directories and non-HDF5 files
         if(entry.is_directory() || !H5Fis_hdf5(entry.path().c_str()))
@@ -51,8 +51,9 @@ std::map <uint64_t, chronolog::StoryChunk> StoryReader::readAllStories(const std
  * @param story_chunk_map the map to store StoryChunk objects
  * @return chronolog::CL_SUCCESS if successful, else error code
  */
-int StoryReader::readStory(const std::string &chronicle_name, const std::string &story_file_name
-                           , std::map <uint64_t, chronolog::StoryChunk> &story_chunk_map)
+int StoryReader::readStory(const std::string& chronicle_name,
+                           const std::string& story_file_name,
+                           std::map<uint64_t, chronolog::StoryChunk>& story_chunk_map)
 {
     // Open Story file
     hid_t story_file = H5Fopen(story_file_name.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
@@ -77,7 +78,7 @@ int StoryReader::readStory(const std::string &chronicle_name, const std::string 
  * @param story_chunk_map the map to store StoryChunk objects
  * @return chronolog::CL_SUCCESS if successful, else error code
  */
-int StoryReader::readAllStoryChunks(hid_t &story_file, std::map <uint64_t, chronolog::StoryChunk> &story_chunk_map)
+int StoryReader::readAllStoryChunks(hid_t& story_file, std::map<uint64_t, chronolog::StoryChunk>& story_chunk_map)
 {
     hid_t status;
     hsize_t num_story_chunks;
@@ -90,11 +91,17 @@ int StoryReader::readAllStoryChunks(hid_t &story_file, std::map <uint64_t, chron
         // Get story_chunk_dset name length first
         ssize_t story_chunk_dset_name_len =
                 H5Lget_name_by_idx(story_file, ".", H5_INDEX_NAME, H5_ITER_INC, i, nullptr, 0, H5P_DEFAULT) + 1;
-        char*story_chunk_dset_name = new char[story_chunk_dset_name_len];
+        char* story_chunk_dset_name = new char[story_chunk_dset_name_len];
 
         // Then read story_chunk_dset name
-        H5Lget_name_by_idx(story_file, ".", H5_INDEX_NAME, H5_ITER_INC, i, story_chunk_dset_name
-                           , story_chunk_dset_name_len, H5P_DEFAULT);
+        H5Lget_name_by_idx(story_file,
+                           ".",
+                           H5_INDEX_NAME,
+                           H5_ITER_INC,
+                           i,
+                           story_chunk_dset_name,
+                           story_chunk_dset_name_len,
+                           H5P_DEFAULT);
         // Open story_chunk_dset
         chronolog::StoryChunk story_chunk = readOneStoryChunk(story_file, std::string(story_chunk_dset_name));
 
@@ -111,7 +118,7 @@ int StoryReader::readAllStoryChunks(hid_t &story_file, std::map <uint64_t, chron
  * @param story_chunk_name Story Chunk name to read
  * @return a StoryChunk object
  */
-chronolog::StoryChunk StoryReader::readOneStoryChunk(hid_t &story_file, const std::string &story_chunk_name)
+chronolog::StoryChunk StoryReader::readOneStoryChunk(hid_t& story_file, const std::string& story_chunk_name)
 {
     hid_t status;
     // Open story_chunk_dset
@@ -124,11 +131,11 @@ chronolog::StoryChunk StoryReader::readOneStoryChunk(hid_t &story_file, const st
 
     hid_t story_chunk_dspace = H5Dget_space(story_chunk_dset);
     int story_chunk_dset_rank = H5Sget_simple_extent_ndims(story_chunk_dspace);
-    auto*story_chunk_dset_dims = new hsize_t[story_chunk_dset_rank];
+    auto* story_chunk_dset_dims = new hsize_t[story_chunk_dset_rank];
     H5Sget_simple_extent_dims(story_chunk_dspace, story_chunk_dset_dims, nullptr);
 
     // Read the dataset
-    char*story_chunk_dset_buf = new char[story_chunk_dset_dims[0]];
+    char* story_chunk_dset_buf = new char[story_chunk_dset_dims[0]];
     memset(story_chunk_dset_buf, 0, story_chunk_dset_dims[0]);
     status = H5Dread(story_chunk_dset, H5T_NATIVE_B8, H5S_ALL, H5S_ALL, H5P_DEFAULT, story_chunk_dset_buf);
     if(status < 0)
@@ -154,8 +161,8 @@ chronolog::StoryChunk StoryReader::readOneStoryChunk(hid_t &story_file, const st
     uint64_t end_time = readUint64Attribute(story_chunk_dset, "end_time");
 
     // Convert Story Chunk bytes to map of Story Chunks
-    chronolog::StoryChunk story_chunk = deserializeStoryChunk(story_chunk_dset_buf, chronicle_name, story_name
-                                                              , story_id, start_time, end_time);
+    chronolog::StoryChunk story_chunk =
+            deserializeStoryChunk(story_chunk_dset_buf, chronicle_name, story_name, story_id, start_time, end_time);
 
     free(story_chunk_dset_buf);
     free(story_chunk_dset_dims);
@@ -172,7 +179,7 @@ chronolog::StoryChunk StoryReader::readOneStoryChunk(hid_t &story_file, const st
  * @param attribute_name attribute name to read
  * @return attribute value
  */
-std::string StoryReader::readStringAttribute(hid_t &story_chunk_dset, const std::string &attribute_name) // NOLINT
+std::string StoryReader::readStringAttribute(hid_t& story_chunk_dset, const std::string& attribute_name) // NOLINT
 // (*-convert-member-functions-to-static)
 {
     hid_t attribute_id = H5Aopen(story_chunk_dset, attribute_name.c_str(), H5P_DEFAULT);
@@ -195,8 +202,9 @@ std::string StoryReader::readStringAttribute(hid_t &story_chunk_dset, const std:
  * @param attribute_name attribute name to read
  * @return attribute value
  */
-uint64_t StoryReader::readUint64Attribute(hid_t &story_chunk_dset
-                                          , const std::string &attribute_name) // NOLINT(*-convert-member-functions-to-static)
+uint64_t
+StoryReader::readUint64Attribute(hid_t& story_chunk_dset,
+                                 const std::string& attribute_name) // NOLINT(*-convert-member-functions-to-static)
 {
     hid_t attribute_id = H5Aopen(story_chunk_dset, attribute_name.c_str(), H5P_DEFAULT);
     if(attribute_id < 0)
@@ -220,11 +228,14 @@ uint64_t StoryReader::readUint64Attribute(hid_t &story_chunk_dset
  * @param end_time end time of the Story Chunk
  * @return a Story Chunk
  */
-chronolog::StoryChunk
-StoryReader::deserializeStoryChunk(char*story_chunk_json_str, std::string chronicle_name, std::string story_name
-                                   , uint64_t story_id, uint64_t start_time, uint64_t end_time)
+chronolog::StoryChunk StoryReader::deserializeStoryChunk(char* story_chunk_json_str,
+                                                         std::string chronicle_name,
+                                                         std::string story_name,
+                                                         uint64_t story_id,
+                                                         uint64_t start_time,
+                                                         uint64_t end_time)
 {
-    struct json_object*obj = json_tokener_parse(story_chunk_json_str);
+    struct json_object* obj = json_tokener_parse(story_chunk_json_str);
     chronolog::StoryChunk story_chunk(chronicle_name, story_name, story_id, start_time, end_time);
     enum json_type type = json_object_get_type(obj);
     if(type == json_type_object)
@@ -266,8 +277,11 @@ StoryReader::deserializeStoryChunk(char*story_chunk_json_str, std::string chroni
  * @param story_chunk_map map of Story Chunks to be populated
  * @return chronolog::CL_SUCCESS on success, else error code
  */
-int StoryReader::readStoryRange(const std::string &chronicle_name, const uint64_t &story_id, uint64_t start_time
-                                , uint64_t end_time, std::map <uint64_t, chronolog::StoryChunk> &story_chunk_map)
+int StoryReader::readStoryRange(const std::string& chronicle_name,
+                                const uint64_t& story_id,
+                                uint64_t start_time,
+                                uint64_t end_time,
+                                std::map<uint64_t, chronolog::StoryChunk>& story_chunk_map)
 {
     std::string story_file_name = chronicle_root_dir + "/" + chronicle_name + "/" + std::to_string(story_id);
     // Open Story file
@@ -278,9 +292,9 @@ int StoryReader::readStoryRange(const std::string &chronicle_name, const uint64_
         return chronolog::CL_ERR_UNKNOWN;
     }
     // Get all overlapped Story Chunk names
-    std::vector <std::string> story_chunk_names_overlap = findContiguousStoryChunks(story_file, start_time, end_time);
+    std::vector<std::string> story_chunk_names_overlap = findContiguousStoryChunks(story_file, start_time, end_time);
     // Read Story Chunks
-    for(const auto &story_chunk_name: story_chunk_names_overlap)
+    for(const auto& story_chunk_name: story_chunk_names_overlap)
     {
         chronolog::StoryChunk story_chunk = readOneStoryChunk(story_file, story_chunk_name);
         story_chunk_map.emplace(story_chunk.getStartTime(), story_chunk);
@@ -296,14 +310,14 @@ int StoryReader::readStoryRange(const std::string &chronicle_name, const uint64_
  * @param end_time end time
  * @return a vector of Story Chunk names that overlap with the time range
  */
-std::vector <std::string>
-StoryReader::findContiguousStoryChunks(const hid_t &story_file, uint64_t start_time, uint64_t end_time)
+std::vector<std::string>
+StoryReader::findContiguousStoryChunks(const hid_t& story_file, uint64_t start_time, uint64_t end_time)
 {
-    std::vector <std::string> story_chunk_names_cont_overlap;
+    std::vector<std::string> story_chunk_names_cont_overlap;
     // Get all Story Chunk names
-    std::vector <std::string> story_chunk_names_all = getAllStoryChunks(story_file);
+    std::vector<std::string> story_chunk_names_all = getAllStoryChunks(story_file);
     // Find Story Chunks that overlap with the time range
-    for(const auto &story_chunk_name: story_chunk_names_all)
+    for(const auto& story_chunk_name: story_chunk_names_all)
     {
         if(isStoryChunkOverlapping(story_chunk_name, start_time, end_time))
         {
@@ -320,12 +334,12 @@ StoryReader::findContiguousStoryChunks(const hid_t &story_file, uint64_t start_t
  * @param end_time end time
  * @return true if the Story Chunk overlaps with the time range, else false
  */
-bool StoryReader::isStoryChunkOverlapping(const std::string &story_chunk_name, uint64_t start_time, uint64_t end_time)
+bool StoryReader::isStoryChunkOverlapping(const std::string& story_chunk_name, uint64_t start_time, uint64_t end_time)
 {
-    uint64_t story_chunk_start_time = std::strtoll(
-            story_chunk_name.substr(0, story_chunk_name.find_last_of('_')).c_str(), nullptr, 10);
-    uint64_t story_chunk_end_time = std::strtoll(story_chunk_name.substr(story_chunk_name.find_last_of('_') + 1).c_str()
-                                                 , nullptr, 10);
+    uint64_t story_chunk_start_time =
+            std::strtoll(story_chunk_name.substr(0, story_chunk_name.find_last_of('_')).c_str(), nullptr, 10);
+    uint64_t story_chunk_end_time =
+            std::strtoll(story_chunk_name.substr(story_chunk_name.find_last_of('_') + 1).c_str(), nullptr, 10);
     return (story_chunk_start_time >= start_time || story_chunk_end_time < end_time);
 }
 
@@ -334,10 +348,10 @@ bool StoryReader::isStoryChunkOverlapping(const std::string &story_chunk_name, u
  * @param story_file Story file to read
  * @return a vector of Story Chunk names
  */
-std::vector <std::string>
-StoryReader::getAllStoryChunks(const hid_t &story_file) // NOLINT(*-convert-member-functions-to-static)
+std::vector<std::string>
+StoryReader::getAllStoryChunks(const hid_t& story_file) // NOLINT(*-convert-member-functions-to-static)
 {
-    std::vector <std::string> story_chunk_names;
+    std::vector<std::string> story_chunk_names;
     // Get all Story Chunk dataset names
     H5G_info_t group_info;
     H5Gget_info(story_file, &group_info);

--- a/ChronoStore/src/StoryReader.cpp
+++ b/ChronoStore/src/StoryReader.cpp
@@ -10,6 +10,7 @@
 #include <map>
 #include <string>
 #include <vector>
+
 #include <StoryReader.h>
 #include <event.h>
 #include <chunkattr.h>

--- a/ChronoStore/src/StoryReader.cpp
+++ b/ChronoStore/src/StoryReader.cpp
@@ -2,11 +2,14 @@
 
 #define H5_SIZEOF_SSIZE_T H5_SIZEOF_LONG_LONG
 
-
+#include <hdf5.h>
+#include <json-c/json.h>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <map>
 #include <string>
 #include <vector>
-#include <filesystem>
-#include <json-c/json.h>
 #include <StoryReader.h>
 #include <event.h>
 #include <chunkattr.h>

--- a/ChronoStore/src/StoryWriter.cpp
+++ b/ChronoStore/src/StoryWriter.cpp
@@ -32,7 +32,7 @@
 #define ATTRIBUTE_DATASET_MAX "Max"
 #define ATTRIBUTE_TOTAL_DATASET_STORY_EVENTS "TotalStoryEvents"
 #define ATTRIBUTE_CHUNKMETADATA_RANK 1
-#define DEBUG 0 // Set to 1 to print H5 error messages to console
+#define DEBUG 0          // Set to 1 to print H5 error messages to console
 #define CHUNK_SIZE 40000 // Number of events equal to page size of 4MB
 
 /**
@@ -42,14 +42,15 @@
  * @param attribute_value: attribute value
  * @return: 0 if successful, else errcode, if failed.
  */
-hid_t StoryWriter::writeStringAttribute(hid_t story_chunk_dset, const std::string &attribute_name
-                                        , const std::string &attribute_value)
+hid_t StoryWriter::writeStringAttribute(hid_t story_chunk_dset,
+                                        const std::string& attribute_name,
+                                        const std::string& attribute_value)
 {
     hsize_t attribute_dims[1] = {attribute_value.size()};
     hid_t attr_id = H5Screate(H5S_SIMPLE);
     hid_t status = H5Sset_extent_simple(attr_id, 1, attribute_dims, nullptr);
-    hid_t attr = H5Acreate2(story_chunk_dset, attribute_name.c_str(), H5T_NATIVE_CHAR, attr_id, H5P_DEFAULT
-                            , H5P_DEFAULT);
+    hid_t attr =
+            H5Acreate2(story_chunk_dset, attribute_name.c_str(), H5T_NATIVE_CHAR, attr_id, H5P_DEFAULT, H5P_DEFAULT);
     status += H5Awrite(attr, H5T_NATIVE_CHAR, attribute_value.c_str());
     status += H5Aclose(attr);
     status += H5Sclose(attr_id);
@@ -63,14 +64,15 @@ hid_t StoryWriter::writeStringAttribute(hid_t story_chunk_dset, const std::strin
  * @param attribute_value: attribute value
  * @return: 0 if successful, else errcode, if failed.
  */
-hid_t StoryWriter::writeUint64Attribute(hid_t story_chunk_dset, const std::string &attribute_name
-                                        , const uint64_t &attribute_value)
+hid_t StoryWriter::writeUint64Attribute(hid_t story_chunk_dset,
+                                        const std::string& attribute_name,
+                                        const uint64_t& attribute_value)
 {
     hsize_t attribute_dims[1] = {1};
     hid_t attr_id = H5Screate(H5S_SIMPLE);
     hid_t status = H5Sset_extent_simple(attr_id, 1, attribute_dims, nullptr);
-    hid_t attr = H5Acreate2(story_chunk_dset, attribute_name.c_str(), H5T_NATIVE_UINT64, attr_id, H5P_DEFAULT
-                            , H5P_DEFAULT);
+    hid_t attr =
+            H5Acreate2(story_chunk_dset, attribute_name.c_str(), H5T_NATIVE_UINT64, attr_id, H5P_DEFAULT, H5P_DEFAULT);
     status += H5Awrite(attr, H5T_NATIVE_UINT64, &attribute_value);
     status += H5Aclose(attr);
     status += H5Sclose(attr_id);
@@ -84,8 +86,9 @@ hid_t StoryWriter::writeUint64Attribute(hid_t story_chunk_dset, const std::strin
  * @param story_name: story name
  * @return: 0 if successful, else errcode, if failed.
  */
-int StoryWriter::writeStoryChunks(const std::map <uint64_t, chronolog::StoryChunk> &story_chunk_map
-                                  , const std::string &chronicle_name, const std::string &story_name)
+int StoryWriter::writeStoryChunks(const std::map<uint64_t, chronolog::StoryChunk>& story_chunk_map,
+                                  const std::string& chronicle_name,
+                                  const std::string& story_name)
 {
     // Disable automatic printing of HDF5 error stack to console
     if(!DEBUG)
@@ -99,19 +102,19 @@ int StoryWriter::writeStoryChunks(const std::map <uint64_t, chronolog::StoryChun
     hsize_t num_chunks = story_chunk_map.size();
     hsize_t total_num_events = 0;
     hsize_t total_chunk_size = 0;
-    std::vector <hsize_t> num_events;
-    std::vector <hsize_t> chunk_sizes;
-    std::vector <std::string> story_chunk_JSON_strs;
-    for(auto const &story_chunk_it: story_chunk_map)
+    std::vector<hsize_t> num_events;
+    std::vector<hsize_t> chunk_sizes;
+    std::vector<std::string> story_chunk_JSON_strs;
+    for(auto const& story_chunk_it: story_chunk_map)
     {
         hsize_t num_events_per_chunk = 0;
         hsize_t chunk_size = 0;
-        json_object*story_chunk_JSON_obj = json_object_new_object();
-        for(auto const &it: story_chunk_it.second)
+        json_object* story_chunk_JSON_obj = json_object_new_object();
+        for(auto const& it: story_chunk_it.second)
         {
             num_events_per_chunk++;
-            json_object*logRecordJSONObj = json_object_new_string(it.second.logRecord.c_str());
-            json_object*sequenceTuple = serializeTupleToJsonObject(it.first);
+            json_object* logRecordJSONObj = json_object_new_string(it.second.logRecord.c_str());
+            json_object* sequenceTuple = serializeTupleToJsonObject(it.first);
             LOG_DEBUG("sequenceTuple: {}", json_object_to_json_string(sequenceTuple));
             LOG_DEBUG("logRecordJSONObj: {}", json_object_to_json_string(logRecordJSONObj));
             json_object_object_add(story_chunk_JSON_obj, json_object_get_string(sequenceTuple), logRecordJSONObj);
@@ -126,7 +129,9 @@ int StoryWriter::writeStoryChunks(const std::map <uint64_t, chronolog::StoryChun
     }
 
     // Check if the directory for the Chronicle already exists
-    struct stat st{};
+    struct stat st
+    {
+    };
     std::string chronicle_dir = chronicle_root_dir + chronicle_name;
     if(stat(chronicle_dir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode))
     {
@@ -143,9 +148,9 @@ int StoryWriter::writeStoryChunks(const std::map <uint64_t, chronolog::StoryChun
     auto num_event_it = num_events.begin();
     auto story_chunk_size_it = chunk_sizes.begin();
     auto story_chunk_json_str_it = story_chunk_JSON_strs.begin();
-    std::unordered_map <uint64_t, hid_t> story_chunk_fd_map;
-    for(; story_chunk_map_it !=
-          story_chunk_map.end(); story_chunk_map_it++, num_event_it++, story_chunk_size_it++, story_chunk_json_str_it++)
+    std::unordered_map<uint64_t, hid_t> story_chunk_fd_map;
+    for(; story_chunk_map_it != story_chunk_map.end();
+        story_chunk_map_it++, num_event_it++, story_chunk_size_it++, story_chunk_json_str_it++)
     {
         // Check if the Story file has been opened/created already
         hid_t story_file;
@@ -156,7 +161,7 @@ int StoryWriter::writeStoryChunks(const std::map <uint64_t, chronolog::StoryChun
             story_file = story_chunk_fd_map.find(story_id)->second;
             LOG_DEBUG("Story file already opened: {}", story_file_name.c_str());
         }
-            // Story file does not exist, create the Story file if it does not exist
+        // Story file does not exist, create the Story file if it does not exist
         else if(stat(story_file_name.c_str(), &st) != 0)
         {
             story_file = H5Fcreate(story_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
@@ -200,8 +205,13 @@ int StoryWriter::writeStoryChunks(const std::map <uint64_t, chronolog::StoryChun
         }
 
         // Create the dataset for the Story Chunk
-        story_chunk_dset = H5Dcreate2(story_file, story_chunk_dset_name.c_str(), H5T_NATIVE_B8, story_chunk_dspace
-                                      , H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        story_chunk_dset = H5Dcreate2(story_file,
+                                      story_chunk_dset_name.c_str(),
+                                      H5T_NATIVE_B8,
+                                      story_chunk_dspace,
+                                      H5P_DEFAULT,
+                                      H5P_DEFAULT,
+                                      H5P_DEFAULT);
         if(story_chunk_dset < 0)
         {
             LOG_ERROR("Failed to create dataset for story chunk: {}", story_chunk_dset_name.c_str());
@@ -209,26 +219,33 @@ int StoryWriter::writeStoryChunks(const std::map <uint64_t, chronolog::StoryChun
             H5Eprint(H5E_DEFAULT, stderr);
 
             // Get the error stack and retrieve the error message
-            H5Ewalk2(H5E_DEFAULT, H5E_WALK_DOWNWARD
-                     , [](unsigned n, const H5E_error2_t*err_desc, void*client_data) -> herr_t
+            H5Ewalk2(
+                    H5E_DEFAULT,
+                    H5E_WALK_DOWNWARD,
+                    [](unsigned n, const H5E_error2_t* err_desc, void* client_data) -> herr_t
                     {
                         printf("Error #%u: %s\n", n, err_desc->desc);
                         return 0;
-                    }, nullptr);
+                    },
+                    nullptr);
             return chronolog::CL_ERR_UNKNOWN;
         }
 
         // Open the dataset for the Story Chunk
-//        story_chunk_dset = H5Dopen2(story_file, story_chunk_dset_name.c_str(), H5P_DEFAULT);
-//        if (story_chunk_dset < 0)
-//        {
-//            LOG_ERROR("Failed to open dataset for story chunk: {}", story_chunk_dset_name.c_str());
-//            return chronolog::CL_ERR_UNKNOWN;
-//        }
+        //        story_chunk_dset = H5Dopen2(story_file, story_chunk_dset_name.c_str(), H5P_DEFAULT);
+        //        if (story_chunk_dset < 0)
+        //        {
+        //            LOG_ERROR("Failed to open dataset for story chunk: {}", story_chunk_dset_name.c_str());
+        //            return chronolog::CL_ERR_UNKNOWN;
+        //        }
 
         // Write the Story Chunk to the dataset
-        status = H5Dwrite(story_chunk_dset, H5T_NATIVE_B8, H5S_ALL, H5S_ALL, H5P_DEFAULT
-                          , story_chunk_json_str_it->c_str());
+        status = H5Dwrite(story_chunk_dset,
+                          H5T_NATIVE_B8,
+                          H5S_ALL,
+                          H5S_ALL,
+                          H5P_DEFAULT,
+                          story_chunk_json_str_it->c_str());
         if(status < 0)
         {
             LOG_ERROR("Failed to write story chunk to dataset: {}", story_chunk_dset_name.c_str());
@@ -258,18 +275,19 @@ int StoryWriter::writeStoryChunks(const std::map <uint64_t, chronolog::StoryChun
         status += H5Sclose(story_chunk_dspace);
         if(status < 0)
         {
-            LOG_ERROR("Failed to close dataset or dataspace or file for story chunk: {}", story_chunk_dset_name.c_str());
+            LOG_ERROR("Failed to close dataset or dataspace or file for story chunk: {}",
+                      story_chunk_dset_name.c_str());
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
 
     // Close all files at the end
-    for(auto &story_chunk_fd_map_it: story_chunk_fd_map)
+    for(auto& story_chunk_fd_map_it: story_chunk_fd_map)
     {
         status = H5Fclose(story_chunk_fd_map_it.second);
         if(status < 0)
         {
-            char*file_name = new char[128];
+            char* file_name = new char[128];
             size_t file_name_len = 0;
             H5Fget_name(story_chunk_fd_map_it.second, file_name, file_name_len);
             LOG_ERROR("Failed to close file for story chunk: {}", file_name);
@@ -286,18 +304,17 @@ int StoryWriter::writeStoryChunks(const std::map <uint64_t, chronolog::StoryChun
  * @param obj: json_object to attach the Story Chunk to
  * @param story_chunk: Story Chunk to serialize
  */
-void StoryWriter::serializeStoryChunk(json_object*obj, chronolog::StoryChunk &story_chunk)
+void StoryWriter::serializeStoryChunk(json_object* obj, chronolog::StoryChunk& story_chunk)
 {
     std::string story_chunk_name =
             std::to_string(story_chunk.getStartTime()) + "_" + std::to_string(story_chunk.getEndTime());
     std::stringstream ss;
-    ss << "StoryChunk:{" << story_chunk.getStoryId() << ":"
-    << story_chunk.getStartTime() << ":" << story_chunk.getEndTime() << "} has "
-    << std::distance(story_chunk.begin(), story_chunk.end()) << " events: ";
-    for(const auto & iter : story_chunk)
+    ss << "StoryChunk:{" << story_chunk.getStoryId() << ":" << story_chunk.getStartTime() << ":"
+       << story_chunk.getEndTime() << "} has " << std::distance(story_chunk.begin(), story_chunk.end()) << " events: ";
+    for(const auto& iter: story_chunk)
     {
-        ss << "<" << std::get <0>(iter.first) << ", " << std::get <1>(iter.first) << ", "
-           << std::get <2>(iter.first) << ">: " << iter.second.toString();
+        ss << "<" << std::get<0>(iter.first) << ", " << std::get<1>(iter.first) << ", " << std::get<2>(iter.first)
+           << ">: " << iter.second.toString();
     }
     json_object_object_add(obj, story_chunk_name.c_str(), json_object_new_string(ss.str().c_str()));
 }
@@ -307,15 +324,15 @@ void StoryWriter::serializeStoryChunk(json_object*obj, chronolog::StoryChunk &st
  * @param story_chunk_map: map of <start_time, StoryChunk> to serialize
  * @return a vector of JSON strings, each of which is a serialized JSON string of a Story Chunk
  */
-std::vector <std::string>
-StoryWriter::serializeStoryChunkMap(std::map <std::uint64_t, chronolog::StoryChunk> &story_chunk_map)
+std::vector<std::string>
+StoryWriter::serializeStoryChunkMap(std::map<std::uint64_t, chronolog::StoryChunk>& story_chunk_map)
 {
-    std::vector <std::string> strings;
-    for(auto &map: story_chunk_map)
+    std::vector<std::string> strings;
+    for(auto& map: story_chunk_map)
     {
-        json_object*obj = json_object_new_object();
+        json_object* obj = json_object_new_object();
         serializeStoryChunk(obj, map.second);
-        const char*json = json_object_to_json_string(obj);
+        const char* json = json_object_to_json_string(obj);
         strings.emplace_back(json);
     }
     return strings;
@@ -323,27 +340,27 @@ StoryWriter::serializeStoryChunkMap(std::map <std::uint64_t, chronolog::StoryChu
 
 // Convert a single element to a json_object
 template <typename T>
-json_object*StoryWriter::convertToJsonObject(const T &value)
+json_object* StoryWriter::convertToJsonObject(const T& value)
 {
-    json_object*obj = nullptr;
+    json_object* obj = nullptr;
 
-    if constexpr(std::is_same_v <T, int>)
+    if constexpr(std::is_same_v<T, int>)
     {
         obj = json_object_new_int(value);
     }
-    else if constexpr(std::is_same_v <T, double>)
+    else if constexpr(std::is_same_v<T, double>)
     {
         obj = json_object_new_double(value);
     }
-    else if constexpr(std::is_same_v <T, std::string>)
+    else if constexpr(std::is_same_v<T, std::string>)
     {
         obj = json_object_new_string(value.c_str());
     }
-    else if constexpr(std::is_same_v <T, uint64_t>)
+    else if constexpr(std::is_same_v<T, uint64_t>)
     {
         obj = json_object_new_uint64(value);
     }
-    else if constexpr(std::is_same_v <T, uint32_t>)
+    else if constexpr(std::is_same_v<T, uint32_t>)
     {
         // TODO: make sure this is correct
         obj = json_object_new_uint64(value);
@@ -354,19 +371,19 @@ json_object*StoryWriter::convertToJsonObject(const T &value)
 
 // Serialize the std::tuple to a json_object
 template <typename... Args, size_t... Is>
-json_object*StoryWriter::serializeTupleToJsonObject(const std::tuple <Args...> &tuple, std::index_sequence <Is...>)
+json_object* StoryWriter::serializeTupleToJsonObject(const std::tuple<Args...>& tuple, std::index_sequence<Is...>)
 {
-    json_object*obj = json_object_new_array();
+    json_object* obj = json_object_new_array();
 
     // Convert each element of the std::tuple to a json_object and add it to the array
-    (json_object_array_add(obj, convertToJsonObject(std::get <Is>(tuple))), ...);
+    (json_object_array_add(obj, convertToJsonObject(std::get<Is>(tuple))), ...);
 
     return obj;
 }
 
 // Helper function to serialize the std::tuple to a json_object
 template <typename... Args>
-json_object*StoryWriter::serializeTupleToJsonObject(const std::tuple <Args...> &tuple)
+json_object* StoryWriter::serializeTupleToJsonObject(const std::tuple<Args...>& tuple)
 {
-    return serializeTupleToJsonObject(tuple, std::make_index_sequence <sizeof...(Args)>{});
+    return serializeTupleToJsonObject(tuple, std::make_index_sequence<sizeof...(Args)>{});
 }

--- a/ChronoStore/src/StoryWriter.cpp
+++ b/ChronoStore/src/StoryWriter.cpp
@@ -2,13 +2,22 @@
 
 //#define H5_SIZEOF_SSIZE_T H5_SIZEOF_LONG_LONG
 
-#include <fstream>
-#include <string>
+#include <hdf5.h>
+#include <json-c/json.h>
+#include <cerrno>
+#include <cstdlib>
 #include <cstring>
-#include <vector>
-#include <map>
-#include <unordered_map>
 #include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <event.h>

--- a/ChronoStore/src/StoryWriter.cpp
+++ b/ChronoStore/src/StoryWriter.cpp
@@ -13,13 +13,14 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <sys/stat.h>
-#include <sys/types.h>
+
 #include <event.h>
 #include <chunkattr.h>
 #include <StoryWriter.h>

--- a/ChronoStore/src/storyreader.cpp
+++ b/ChronoStore/src/storyreader.cpp
@@ -3,7 +3,10 @@
 #define H5_SIZEOF_SSIZE_T H5_SIZEOF_LONG_LONG
 
 #include <hdf5.h>
+#include <climits>
+#include <new>
 #include <string>
+#include <utility>
 #include <vector>
 #include <storyreader.h>
 #include <event.h>

--- a/ChronoStore/src/storyreader.cpp
+++ b/ChronoStore/src/storyreader.cpp
@@ -23,20 +23,21 @@
 
 
 // Constructor storyreader
-storyreader::storyreader()
-{}
+storyreader::storyreader() {}
 
 // Destructor storyreader
-storyreader::~storyreader()
-{}
+storyreader::~storyreader() {}
 
 // Search first chunk to retrieve
-int64_t searchFirstChunk(std::vector <ChunkAttr>*chunkAttributeData, uint64_t timestampToSearch, int64_t chunkEnd
-                         , int64_t chunkStart)
+int64_t searchFirstChunk(std::vector<ChunkAttr>* chunkAttributeData,
+                         uint64_t timestampToSearch,
+                         int64_t chunkEnd,
+                         int64_t chunkStart)
 {
     int64_t currentChunk = INT_MIN;
     int64_t ansChunk = -1;
-    if(chunkEnd == 0) return currentChunk;
+    if(chunkEnd == 0)
+        return currentChunk;
 
     while(chunkStart <= chunkEnd)
     {
@@ -59,11 +60,14 @@ int64_t searchFirstChunk(std::vector <ChunkAttr>*chunkAttributeData, uint64_t ti
 }
 
 // Search last chunk to retrieve
-int64_t searchLastChunk(std::vector <ChunkAttr>*chunkAttributeData, uint64_t timestampToSearch, int64_t chunkEnd
-                        , int64_t chunkStart)
+int64_t searchLastChunk(std::vector<ChunkAttr>* chunkAttributeData,
+                        uint64_t timestampToSearch,
+                        int64_t chunkEnd,
+                        int64_t chunkStart)
 {
     int64_t currentChunk = INT_MIN;
-    if(chunkEnd == 0) return currentChunk;
+    if(chunkEnd == 0)
+        return currentChunk;
 
     while(chunkStart <= chunkEnd)
     {
@@ -92,22 +96,25 @@ int64_t searchLastChunk(std::vector <ChunkAttr>*chunkAttributeData, uint64_t tim
  * @return: struct DatasetReader ->{0,EventData} (EventData consist of the read values) if successful, else \n
  *          return {-1,EventData}   (Empty EventData) if failed.
  */
-DatasetReader storyreader::readFromDataset(std::pair <uint64_t, uint64_t> range, const char*STORY, const char*CHRONICLE)
+DatasetReader
+storyreader::readFromDataset(std::pair<uint64_t, uint64_t> range, const char* STORY, const char* CHRONICLE)
 {
     // Disable automatic printing of HDF5 error stack
     if(!DEBUG)
     {
         H5Eset_auto(H5E_DEFAULT, NULL, NULL);
     }
-    std::vector <Event> resultVector;
+    std::vector<Event> resultVector;
     DatasetReader dr(-1, resultVector);
-    hid_t chronicle = -1, story = -1, storyDatasetSpace = -1, eventType = -1, attributeId = -1, attributeType = -1, attributeDataSpace = -1, hyperslabMemorySpace = -1;
-    herr_t status = -1, readChunkAttributeErr = -1, timeStampError = -1, dataError = -1, memSpaceErr = -1, datasetSpaceError = -1;
+    hid_t chronicle = -1, story = -1, storyDatasetSpace = -1, eventType = -1, attributeId = -1, attributeType = -1,
+          attributeDataSpace = -1, hyperslabMemorySpace = -1;
+    herr_t status = -1, readChunkAttributeErr = -1, timeStampError = -1, dataError = -1, memSpaceErr = -1,
+           datasetSpaceError = -1;
     DatasetMinMax dmm(-1, std::make_pair(0, 0));
-    std::pair <int64_t, int64_t> chunksToRead = {INT_MIN, INT_MIN};
+    std::pair<int64_t, int64_t> chunksToRead = {INT_MIN, INT_MIN};
     hsize_t datasetHyperslabStart[1] = {0}, storyChunkDims[1] = {0}, chunkOffset[1] = {0}, attributeDims = 0;
-    std::vector <Event>*eventBuffer;
-    std::vector <ChunkAttr>*attributeDataBuffer;
+    std::vector<Event>* eventBuffer;
+    std::vector<ChunkAttr>* attributeDataBuffer;
 
     /**
      * Read data from the story
@@ -135,7 +142,7 @@ DatasetReader storyreader::readFromDataset(std::pair <uint64_t, uint64_t> range,
 
     attributeDims = H5Sget_simple_extent_npoints(attributeDataSpace);
 
-    attributeDataBuffer = new std::vector <ChunkAttr>(attributeDims);
+    attributeDataBuffer = new std::vector<ChunkAttr>(attributeDims);
     if(attributeDataBuffer == nullptr)
     {
         return dr;
@@ -147,9 +154,12 @@ DatasetReader storyreader::readFromDataset(std::pair <uint64_t, uint64_t> range,
         goto release_resources;
     }
 
-    if(attributeType >= 0) H5Tclose(attributeType);
-    if(attributeDataSpace >= 0) H5Sclose(attributeDataSpace);
-    if(attributeId >= 0) H5Aclose(attributeId);
+    if(attributeType >= 0)
+        H5Tclose(attributeType);
+    if(attributeDataSpace >= 0)
+        H5Sclose(attributeDataSpace);
+    if(attributeId >= 0)
+        H5Aclose(attributeId);
 
     dmm = readDatasetRange(STORY, CHRONICLE);
     if(dmm.status != 0 || dmm.MinMax.first > range.first || dmm.MinMax.second < range.second)
@@ -170,8 +180,8 @@ DatasetReader storyreader::readFromDataset(std::pair <uint64_t, uint64_t> range,
         chunksToRead.first = searchFirstChunk(attributeDataBuffer, range.first, attributeDims - 1, 0);
         if(chunksToRead.first != INT_MIN)
         {
-            chunksToRead.second = searchLastChunk(attributeDataBuffer, range.second, attributeDims - 1
-                                                  , chunksToRead.first);
+            chunksToRead.second =
+                    searchLastChunk(attributeDataBuffer, range.second, attributeDims - 1, chunksToRead.first);
         }
     }
 
@@ -181,8 +191,10 @@ DatasetReader storyreader::readFromDataset(std::pair <uint64_t, uint64_t> range,
      */
     if(chunksToRead.second == INT_MIN || chunksToRead.first == INT_MIN)
     {
-        if(story >= 0) H5Dclose(story);
-        if(chronicle >= 0) H5Fclose(chronicle);
+        if(story >= 0)
+            H5Dclose(story);
+        if(chronicle >= 0)
+            H5Fclose(chronicle);
         return dr;
     }
 
@@ -211,23 +223,32 @@ DatasetReader storyreader::readFromDataset(std::pair <uint64_t, uint64_t> range,
             chunkOffset[0] = {attributeDataBuffer->at(chunkIndex).datasetIndex};
 
             hyperslabMemorySpace = H5Screate_simple(1, storyChunkDims, NULL);
-            memSpaceErr = H5Sselect_hyperslab(hyperslabMemorySpace, H5S_SELECT_SET, datasetHyperslabStart, NULL
-                                              , storyChunkDims, NULL);
-            datasetSpaceError = H5Sselect_hyperslab(storyDatasetSpace, H5S_SELECT_SET, chunkOffset, NULL, storyChunkDims
-                                                    , NULL);
+            memSpaceErr = H5Sselect_hyperslab(hyperslabMemorySpace,
+                                              H5S_SELECT_SET,
+                                              datasetHyperslabStart,
+                                              NULL,
+                                              storyChunkDims,
+                                              NULL);
+            datasetSpaceError =
+                    H5Sselect_hyperslab(storyDatasetSpace, H5S_SELECT_SET, chunkOffset, NULL, storyChunkDims, NULL);
 
-            eventBuffer = new std::vector <Event>(attributeDataBuffer->at(chunkIndex).totalChunkEvents);
+            eventBuffer = new std::vector<Event>(attributeDataBuffer->at(chunkIndex).totalChunkEvents);
             if(eventBuffer == nullptr)
             {
                 goto release_resources;
             }
 
-            status = H5Dread(story, eventType, hyperslabMemorySpace, storyDatasetSpace, H5P_DEFAULT
-                             , eventBuffer->data());
+            status = H5Dread(story,
+                             eventType,
+                             hyperslabMemorySpace,
+                             storyDatasetSpace,
+                             H5P_DEFAULT,
+                             eventBuffer->data());
             if(status < 0 || datasetSpaceError < 0 || memSpaceErr < 0 || hyperslabMemorySpace < 0 ||
                storyDatasetSpace < 0)
             {
-                if(eventBuffer != nullptr) delete eventBuffer;
+                if(eventBuffer != nullptr)
+                    delete eventBuffer;
                 goto release_resources;
             }
 
@@ -238,10 +259,10 @@ DatasetReader storyreader::readFromDataset(std::pair <uint64_t, uint64_t> range,
                     dr.eventData.push_back(eventBuffer->at(i));
                 }
             }
-            delete (eventBuffer);
+            delete(eventBuffer);
         }
     }
-    catch(const std::bad_alloc &e)
+    catch(const std::bad_alloc& e)
     {
         goto release_resources;
     }
@@ -249,23 +270,35 @@ DatasetReader storyreader::readFromDataset(std::pair <uint64_t, uint64_t> range,
     /* 
     * Release resources
     */
-    if(attributeDataBuffer != nullptr) delete (attributeDataBuffer);
-    if(storyDatasetSpace >= 0) H5Sclose(storyDatasetSpace);
-    if(hyperslabMemorySpace >= 0) H5Sclose(hyperslabMemorySpace);
-    if(eventType >= 0) H5Tclose(eventType);
-    if(story >= 0) H5Dclose(story);
-    if(chronicle >= 0) H5Fclose(chronicle);
+    if(attributeDataBuffer != nullptr)
+        delete(attributeDataBuffer);
+    if(storyDatasetSpace >= 0)
+        H5Sclose(storyDatasetSpace);
+    if(hyperslabMemorySpace >= 0)
+        H5Sclose(hyperslabMemorySpace);
+    if(eventType >= 0)
+        H5Tclose(eventType);
+    if(story >= 0)
+        H5Dclose(story);
+    if(chronicle >= 0)
+        H5Fclose(chronicle);
     dr.status = 0;
     return dr;
 
-    //goto
-    release_resources:
-    if(attributeDataBuffer != nullptr) delete (attributeDataBuffer);
-    if(storyDatasetSpace >= 0) H5Sclose(storyDatasetSpace);
-    if(hyperslabMemorySpace >= 0) H5Sclose(hyperslabMemorySpace);
-    if(eventType >= 0) H5Tclose(eventType);
-    if(story >= 0) H5Dclose(story);
-    if(chronicle >= 0) H5Fclose(chronicle);
+//goto
+release_resources:
+    if(attributeDataBuffer != nullptr)
+        delete(attributeDataBuffer);
+    if(storyDatasetSpace >= 0)
+        H5Sclose(storyDatasetSpace);
+    if(hyperslabMemorySpace >= 0)
+        H5Sclose(hyperslabMemorySpace);
+    if(eventType >= 0)
+        H5Tclose(eventType);
+    if(story >= 0)
+        H5Dclose(story);
+    if(chronicle >= 0)
+        H5Fclose(chronicle);
     dr.status = -1;
     dr.eventData.erase(dr.eventData.begin(), dr.eventData.end());
     return dr;
@@ -278,12 +311,12 @@ DatasetReader storyreader::readFromDataset(std::pair <uint64_t, uint64_t> range,
  * @return: struct DatasetMinMax ->{0,MinMax} (MinMax is pair consisting of Min nd Max of dataset respectively) if successful, else \n
  *          return {-1,MinMax}   (MinMax empty) if failed.
  */
-DatasetMinMax storyreader::readDatasetRange(const char*STORY, const char*CHRONICLE)
+DatasetMinMax storyreader::readDatasetRange(const char* STORY, const char* CHRONICLE)
 {
 
-    std::pair <uint64_t, uint64_t> datasetRange;
+    std::pair<uint64_t, uint64_t> datasetRange;
     DatasetMinMax d(-1, datasetRange);
-    std::vector <uint64_t> DatasetReader(2);
+    std::vector<uint64_t> DatasetReader(2);
     hid_t chronicle, story, attributeMinId, attributeMinDataSpace, attributeMaxId, attributeMaxDataSpace;
     herr_t statusErrorMin, statusErrorMax;
     uint64_t attribute_value;
@@ -311,12 +344,18 @@ DatasetMinMax storyreader::readDatasetRange(const char*STORY, const char*CHRONIC
     if(chronicle < 0 || story < 0 || attributeMinId < 0 || statusErrorMin < 0 || attributeMinDataSpace < 0 ||
        attributeMaxId < 0 || attributeMaxDataSpace < 0 || statusErrorMax < 0)
     {
-        if(attributeMinDataSpace >= 0) H5Sclose(attributeMinDataSpace);
-        if(attributeMinId >= 0) H5Aclose(attributeMinId);
-        if(attributeMaxDataSpace >= 0) H5Sclose(attributeMaxDataSpace);
-        if(attributeMaxId >= 0) H5Aclose(attributeMaxId);
-        if(story >= 0) H5Dclose(story);
-        if(chronicle >= 0) H5Fclose(chronicle);
+        if(attributeMinDataSpace >= 0)
+            H5Sclose(attributeMinDataSpace);
+        if(attributeMinId >= 0)
+            H5Aclose(attributeMinId);
+        if(attributeMaxDataSpace >= 0)
+            H5Sclose(attributeMaxDataSpace);
+        if(attributeMaxId >= 0)
+            H5Aclose(attributeMaxId);
+        if(story >= 0)
+            H5Dclose(story);
+        if(chronicle >= 0)
+            H5Fclose(chronicle);
         return d;
     }
 
@@ -327,12 +366,18 @@ DatasetMinMax storyreader::readDatasetRange(const char*STORY, const char*CHRONIC
     /*
      * Release resources
      */
-    if(attributeMinDataSpace >= 0) H5Sclose(attributeMinDataSpace);
-    if(attributeMinId >= 0) H5Aclose(attributeMinId);
-    if(attributeMaxDataSpace >= 0) H5Sclose(attributeMaxDataSpace);
-    if(attributeMaxId >= 0) H5Aclose(attributeMaxId);
-    if(story >= 0) H5Dclose(story);
-    if(chronicle >= 0) H5Fclose(chronicle);
+    if(attributeMinDataSpace >= 0)
+        H5Sclose(attributeMinDataSpace);
+    if(attributeMinId >= 0)
+        H5Aclose(attributeMinId);
+    if(attributeMaxDataSpace >= 0)
+        H5Sclose(attributeMaxDataSpace);
+    if(attributeMaxId >= 0)
+        H5Aclose(attributeMaxId);
+    if(story >= 0)
+        H5Dclose(story);
+    if(chronicle >= 0)
+        H5Fclose(chronicle);
 
     return d;
 }

--- a/ChronoStore/src/storywriter.cpp
+++ b/ChronoStore/src/storywriter.cpp
@@ -17,16 +17,14 @@
 #define ATTRIBUTE_DATASET_MAX "Max"
 #define ATTRIBUTE_TOTAL_DATASET_STORY_EVENTS "TotalStoryEvents"
 #define ATTRIBUTE_CHUNKMETADATA_RANK 1
-#define DEBUG 0 // Set to 1 to print H5 error messages to console
+#define DEBUG 0          // Set to 1 to print H5 error messages to console
 #define CHUNK_SIZE 40000 // Number of events equal to page size of 4MB
 
 // Constructor storywriter
-storywriter::storywriter()
-{}
+storywriter::storywriter() {}
 
 // Destructor storywriter
-storywriter::~storywriter()
-{}
+storywriter::~storywriter() {}
 
 /**
  * Write/Append data to storyDataset. 
@@ -35,7 +33,7 @@ storywriter::~storywriter()
  * @param CHRONICLE: chronicle name
  * @return: 0 if successful, else -1, if failed.
  */
-int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STORY, const char*CHRONICLE)
+int storywriter::writeStoryChunk(std::vector<Event>* storyChunk, const char* STORY, const char* CHRONICLE)
 {
 
     // Disable automatic printing of HDF5 error stack to console
@@ -44,14 +42,16 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
         H5Eset_auto(H5E_DEFAULT, NULL, NULL);
     }
 
-    hid_t ChronicleH5 = -1, storyDataset = -1, storyDatasetSpace = -1, chunkPropId = -1, hyperslabMemorySpace = -1, eventType = -1, chunkmetaAttribute = -1, attr = -1, attr1 = -1, attr_DatasetMin = -1, attr_DatasetMax = -1, attr_DatasetTotalStoryEvents = -1;
+    hid_t ChronicleH5 = -1, storyDataset = -1, storyDatasetSpace = -1, chunkPropId = -1, hyperslabMemorySpace = -1,
+          eventType = -1, chunkmetaAttribute = -1, attr = -1, attr1 = -1, attr_DatasetMin = -1, attr_DatasetMax = -1,
+          attr_DatasetTotalStoryEvents = -1;
     hid_t attributeId = -1, attributeType = -1, attributeDataSpace = -1;
     herr_t status = -1, ret = -1;
     hsize_t attributeCount = 0;
     hsize_t chunksize = CHUNK_SIZE;
     hsize_t datasetHyperslabStart[1] = {0};
     hsize_t storySpaceStart[1] = {0};
-    std::vector <ChunkAttr>*attributeDataBuffer, *extendChunkMetadataBuffer;
+    std::vector<ChunkAttr>*attributeDataBuffer, *extendChunkMetadataBuffer;
 
     /*
     * Chunk Dimension and number of events in a story chunk
@@ -62,7 +62,7 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
     /*
     * Allocate memory for attribute buffer
     */
-    attributeDataBuffer = new std::vector <ChunkAttr>((numberOfEvents / CHUNK_SIZE) + 1);
+    attributeDataBuffer = new std::vector<ChunkAttr>((numberOfEvents / CHUNK_SIZE) + 1);
     if(attributeDataBuffer == nullptr)
     {
         return -1;
@@ -82,7 +82,8 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
     dataError = H5Tinsert(eventType, "data", HOFFSET(Event, data), H5T_NATIVE_CHAR);
     if(eventType < 0 || dataError < 0 || timeStampError < 0)
     {
-        if(eventType >= 0) H5Tclose(eventType);
+        if(eventType >= 0)
+            H5Tclose(eventType);
         return -1;
     }
 
@@ -100,7 +101,8 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
         ChronicleH5 = H5Fopen(CHRONICLE, H5F_ACC_RDWR, H5P_DEFAULT);
         if(ChronicleH5 < 0)
         {
-            if(eventType >= 0) H5Tclose(eventType);
+            if(eventType >= 0)
+                H5Tclose(eventType);
             return -1;
         }
         if(H5Lexists(ChronicleH5, STORY, H5P_DEFAULT) > 0)
@@ -127,9 +129,12 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
                 goto release_resources;
             }
 
-            if(attributeId >= 0) H5Aclose(attributeId);
-            if(attributeDataSpace >= 0) H5Sclose(attributeDataSpace);
-            if(attributeType >= 0) H5Tclose(attributeType);
+            if(attributeId >= 0)
+                H5Aclose(attributeId);
+            if(attributeDataSpace >= 0)
+                H5Sclose(attributeDataSpace);
+            if(attributeType >= 0)
+                H5Tclose(attributeType);
 
             /*
             * Define the new size of the storyDataset and extend it
@@ -157,7 +162,7 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
                 goto release_resources;
             }
         }
-            /*
+        /*
             * Create the storyDataset
             */
         else
@@ -178,15 +183,15 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
             {
                 goto release_resources;
             }
-            storyDataset = H5Dcreate2(ChronicleH5, STORY, eventType, storyDatasetSpace, H5P_DEFAULT, chunkPropId
-                                      , H5P_DEFAULT);
+            storyDataset =
+                    H5Dcreate2(ChronicleH5, STORY, eventType, storyDatasetSpace, H5P_DEFAULT, chunkPropId, H5P_DEFAULT);
             if(storyDataset < 0)
             {
                 goto release_resources;
             }
         }
     }
-        /*
+    /*
         * Create the ChronicleH5 and storyDataset
         */
     else
@@ -208,8 +213,8 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
             goto release_resources;
         }
 
-        storyDataset = H5Dcreate2(ChronicleH5, STORY, eventType, storyDatasetSpace, H5P_DEFAULT, chunkPropId
-                                  , H5P_DEFAULT);
+        storyDataset =
+                H5Dcreate2(ChronicleH5, STORY, eventType, storyDatasetSpace, H5P_DEFAULT, chunkPropId, H5P_DEFAULT);
         if(storyDataset < 0)
         {
             goto release_resources;
@@ -223,17 +228,21 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
     hyperslabMemorySpace = H5Screate_simple(DATASET_RANK, storyChunkDims, NULL);
 
     herr_t memSpaceErr, datasetSpaceError;
-    memSpaceErr = H5Sselect_hyperslab(hyperslabMemorySpace, H5S_SELECT_SET, datasetHyperslabStart, NULL, storyChunkDims
-                                      , NULL);
-    datasetSpaceError = H5Sselect_hyperslab(storyDatasetSpace, H5S_SELECT_SET, storySpaceStart, NULL, storyChunkDims
-                                            , NULL);
+    memSpaceErr = H5Sselect_hyperslab(hyperslabMemorySpace,
+                                      H5S_SELECT_SET,
+                                      datasetHyperslabStart,
+                                      NULL,
+                                      storyChunkDims,
+                                      NULL);
+    datasetSpaceError =
+            H5Sselect_hyperslab(storyDatasetSpace, H5S_SELECT_SET, storySpaceStart, NULL, storyChunkDims, NULL);
     if(memSpaceErr < 0 || datasetSpaceError < 0 || hyperslabMemorySpace < 0)
     {
         goto release_resources;
     }
 
-    status = H5Dwrite(storyDataset, eventType, hyperslabMemorySpace, storyDatasetSpace, H5P_DEFAULT
-                      , storyChunk->data());
+    status =
+            H5Dwrite(storyDataset, eventType, hyperslabMemorySpace, storyDatasetSpace, H5P_DEFAULT, storyChunk->data());
     if(status < 0)
     {
         goto release_resources;
@@ -258,14 +267,15 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
     /*
     * Create datatype for the ChunkMetadata attribute.
     */
-    herr_t startError, endError, datasetIndexError, totalChunkEventsError, attrMaxError, attrStoryEventsError, attrMinError, attrError;
+    herr_t startError, endError, datasetIndexError, totalChunkEventsError, attrMaxError, attrStoryEventsError,
+            attrMinError, attrError;
     chunkmetaAttribute = H5Tcreate(H5T_COMPOUND, sizeof(ChunkAttr));
     startError = H5Tinsert(chunkmetaAttribute, "startTimeStamp", HOFFSET(ChunkAttr, startTimeStamp), H5T_NATIVE_ULONG);
     endError = H5Tinsert(chunkmetaAttribute, "endTimeStamp", HOFFSET(ChunkAttr, endTimeStamp), H5T_NATIVE_ULONG);
-    datasetIndexError = H5Tinsert(chunkmetaAttribute, "datasetIndex", HOFFSET(ChunkAttr, datasetIndex)
-                                  , H5T_NATIVE_UINT);
-    totalChunkEventsError = H5Tinsert(chunkmetaAttribute, "totalChunkEvents", HOFFSET(ChunkAttr, totalChunkEvents)
-                                      , H5T_NATIVE_UINT);
+    datasetIndexError =
+            H5Tinsert(chunkmetaAttribute, "datasetIndex", HOFFSET(ChunkAttr, datasetIndex), H5T_NATIVE_UINT);
+    totalChunkEventsError =
+            H5Tinsert(chunkmetaAttribute, "totalChunkEvents", HOFFSET(ChunkAttr, totalChunkEvents), H5T_NATIVE_UINT);
     if(chunkmetaAttribute < 0 || endError < 0 || startError < 0 || totalChunkEventsError < 0 || datasetIndexError < 0)
     {
         goto release_resources;
@@ -283,7 +293,7 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
         H5Sclose(attributeDataSpace);
 
         hsize_t attributeDims[] = {attributeChunkMetadataDims + attributeCount};
-        extendChunkMetadataBuffer = new std::vector <ChunkAttr>(attributeDims[0]);
+        extendChunkMetadataBuffer = new std::vector<ChunkAttr>(attributeDims[0]);
         if(extendChunkMetadataBuffer == nullptr)
         {
             goto release_resources;
@@ -297,7 +307,8 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
             goto release_resources;
         }
 
-        if(attributeId >= 0) H5Aclose(attributeId);
+        if(attributeId >= 0)
+            H5Aclose(attributeId);
         herr_t deleteError = H5Adelete(storyDataset, ATTRIBUTE_CHUNKMETADATA);
 
         attr = H5Screate(H5S_SIMPLE);
@@ -314,16 +325,14 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
                              (*extendChunkMetadataBuffer)[attributeChunkMetadataDims - 1].totalChunkEvents;
         for(auto index = 0; index < attributeCount; index++)
         {
-            extendChunkMetadataBuffer->at(attributeChunkMetadataDims + index).startTimeStamp = attributeDataBuffer->at(
-                    index).startTimeStamp;
-            extendChunkMetadataBuffer->at(attributeChunkMetadataDims + index).endTimeStamp = attributeDataBuffer->at(
-                    index).endTimeStamp;
+            extendChunkMetadataBuffer->at(attributeChunkMetadataDims + index).startTimeStamp =
+                    attributeDataBuffer->at(index).startTimeStamp;
+            extendChunkMetadataBuffer->at(attributeChunkMetadataDims + index).endTimeStamp =
+                    attributeDataBuffer->at(index).endTimeStamp;
             extendChunkMetadataBuffer->at(attributeChunkMetadataDims + index).datasetIndex =
                     attributeDataBuffer->at(index).datasetIndex + lastEventIndex;
-            extendChunkMetadataBuffer->at(
-                    attributeChunkMetadataDims + index).totalChunkEvents = attributeDataBuffer->at(
-                    index).totalChunkEvents;
-
+            extendChunkMetadataBuffer->at(attributeChunkMetadataDims + index).totalChunkEvents =
+                    attributeDataBuffer->at(index).totalChunkEvents;
         }
         ret = H5Awrite(attr1, attributeType, extendChunkMetadataBuffer->data());
 
@@ -363,16 +372,20 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
         attributeDims[0] = {1};
         attr = H5Screate_simple(1, attributeDims, NULL);
 
-        attr_DatasetMin = H5Acreate2(storyDataset, ATTRIBUTE_DATASET_MIN, H5T_NATIVE_ULONG, attr, H5P_DEFAULT
-                                     , H5P_DEFAULT);
+        attr_DatasetMin =
+                H5Acreate2(storyDataset, ATTRIBUTE_DATASET_MIN, H5T_NATIVE_ULONG, attr, H5P_DEFAULT, H5P_DEFAULT);
         attrMinError = H5Awrite(attr_DatasetMin, H5T_NATIVE_ULONG, &storyChunk->at(0).timeStamp);
 
-        attr_DatasetMax = H5Acreate2(storyDataset, ATTRIBUTE_DATASET_MAX, H5T_NATIVE_ULONG, attr, H5P_DEFAULT
-                                     , H5P_DEFAULT);
+        attr_DatasetMax =
+                H5Acreate2(storyDataset, ATTRIBUTE_DATASET_MAX, H5T_NATIVE_ULONG, attr, H5P_DEFAULT, H5P_DEFAULT);
         attrMaxError = H5Awrite(attr_DatasetMax, H5T_NATIVE_ULONG, &storyChunk->at(storyChunkDims[0] - 1).timeStamp);
 
-        attr_DatasetTotalStoryEvents = H5Acreate2(storyDataset, ATTRIBUTE_TOTAL_DATASET_STORY_EVENTS, H5T_NATIVE_ULONG
-                                                  , attr, H5P_DEFAULT, H5P_DEFAULT);
+        attr_DatasetTotalStoryEvents = H5Acreate2(storyDataset,
+                                                  ATTRIBUTE_TOTAL_DATASET_STORY_EVENTS,
+                                                  H5T_NATIVE_ULONG,
+                                                  attr,
+                                                  H5P_DEFAULT,
+                                                  H5P_DEFAULT);
         attrStoryEventsError = H5Awrite(attr_DatasetTotalStoryEvents, H5T_NATIVE_ULONG, &storyChunkDims[0]);
         if(attrStoryEventsError < 0 || attr_DatasetTotalStoryEvents < 0 || attrMinError < 0 || attr_DatasetMin < 0 ||
            attrMaxError < 0 || attr_DatasetMax < 0 || attr < 0 || attr1 < 0 || attrError < 0)
@@ -385,39 +398,69 @@ int storywriter::writeStoryChunk(std::vector <Event>*storyChunk, const char*STOR
     * Release resources
     */
     if(attributeDataBuffer != nullptr)
-    { delete attributeDataBuffer; }
-    if(attr1 >= 0) H5Aclose(attr1);
-    if(attr >= 0) H5Sclose(attr);
-    if(chunkPropId >= 0) H5Pclose(chunkPropId);
-    if(attributeDataSpace >= 0) H5Sclose(attributeDataSpace);
-    if(attributeId >= 0) H5Aclose(attributeId);
-    if(attributeType >= 0) H5Tclose(attributeType);
-    if(attr_DatasetMin >= 0) H5Aclose(attr_DatasetMin);
-    if(attr_DatasetMax >= 0) H5Aclose(attr_DatasetMax);
-    if(attr_DatasetTotalStoryEvents >= 0) H5Aclose(attr_DatasetTotalStoryEvents);
-    if(chunkmetaAttribute >= 0) H5Tclose(chunkmetaAttribute);
-    if(eventType >= 0) H5Tclose(eventType);
-    if(storyDataset >= 0) H5Dclose(storyDataset);
-    if(ChronicleH5 >= 0) H5Fclose(ChronicleH5);
+    {
+        delete attributeDataBuffer;
+    }
+    if(attr1 >= 0)
+        H5Aclose(attr1);
+    if(attr >= 0)
+        H5Sclose(attr);
+    if(chunkPropId >= 0)
+        H5Pclose(chunkPropId);
+    if(attributeDataSpace >= 0)
+        H5Sclose(attributeDataSpace);
+    if(attributeId >= 0)
+        H5Aclose(attributeId);
+    if(attributeType >= 0)
+        H5Tclose(attributeType);
+    if(attr_DatasetMin >= 0)
+        H5Aclose(attr_DatasetMin);
+    if(attr_DatasetMax >= 0)
+        H5Aclose(attr_DatasetMax);
+    if(attr_DatasetTotalStoryEvents >= 0)
+        H5Aclose(attr_DatasetTotalStoryEvents);
+    if(chunkmetaAttribute >= 0)
+        H5Tclose(chunkmetaAttribute);
+    if(eventType >= 0)
+        H5Tclose(eventType);
+    if(storyDataset >= 0)
+        H5Dclose(storyDataset);
+    if(ChronicleH5 >= 0)
+        H5Fclose(ChronicleH5);
     return 0;
 
 
-    // goto
-    release_resources:
+// goto
+release_resources:
     if(attributeDataBuffer != nullptr)
-    { delete attributeDataBuffer; }
-    if(attr1 >= 0) H5Aclose(attr1);
-    if(attr >= 0) H5Sclose(attr);
-    if(chunkPropId >= 0) H5Pclose(chunkPropId);
-    if(attributeDataSpace >= 0) H5Sclose(attributeDataSpace);
-    if(attributeId >= 0) H5Aclose(attributeId);
-    if(attributeType >= 0) H5Tclose(attributeType);
-    if(attr_DatasetMin >= 0) H5Aclose(attr_DatasetMin);
-    if(attr_DatasetMax >= 0) H5Aclose(attr_DatasetMax);
-    if(attr_DatasetTotalStoryEvents >= 0) H5Aclose(attr_DatasetTotalStoryEvents);
-    if(chunkmetaAttribute >= 0) H5Tclose(chunkmetaAttribute);
-    if(eventType >= 0) H5Tclose(eventType);
-    if(storyDataset >= 0) H5Dclose(storyDataset);
-    if(ChronicleH5 >= 0) H5Fclose(ChronicleH5);
+    {
+        delete attributeDataBuffer;
+    }
+    if(attr1 >= 0)
+        H5Aclose(attr1);
+    if(attr >= 0)
+        H5Sclose(attr);
+    if(chunkPropId >= 0)
+        H5Pclose(chunkPropId);
+    if(attributeDataSpace >= 0)
+        H5Sclose(attributeDataSpace);
+    if(attributeId >= 0)
+        H5Aclose(attributeId);
+    if(attributeType >= 0)
+        H5Tclose(attributeType);
+    if(attr_DatasetMin >= 0)
+        H5Aclose(attr_DatasetMin);
+    if(attr_DatasetMax >= 0)
+        H5Aclose(attr_DatasetMax);
+    if(attr_DatasetTotalStoryEvents >= 0)
+        H5Aclose(attr_DatasetTotalStoryEvents);
+    if(chunkmetaAttribute >= 0)
+        H5Tclose(chunkmetaAttribute);
+    if(eventType >= 0)
+        H5Tclose(eventType);
+    if(storyDataset >= 0)
+        H5Dclose(storyDataset);
+    if(ChronicleH5 >= 0)
+        H5Fclose(ChronicleH5);
     return -1;
 }

--- a/ChronoStore/src/storywriter.cpp
+++ b/ChronoStore/src/storywriter.cpp
@@ -3,9 +3,9 @@
 #define H5_SIZEOF_SSIZE_T H5_SIZEOF_LONG_LONG
 
 #include <hdf5.h>
+#include <cstring>
 #include <fstream>
 #include <string>
-#include <cstring>
 #include <vector>
 #include <event.h>
 #include <chunkattr.h>

--- a/ChronoStore/test/cmp_vlen_bytes_dtype_test.cpp
+++ b/ChronoStore/test/cmp_vlen_bytes_dtype_test.cpp
@@ -43,7 +43,7 @@ typedef struct LogEvent
     uint64_t eventTime;
     ClientId clientId;
     uint32_t eventIndex;
-//    uint64_t logRecordSize;
+    //    uint64_t logRecordSize;
     hvl_t logRecord;
 } LogEvent;
 
@@ -58,44 +58,44 @@ typedef struct StoryChunk
     uint64_t endTime;
     uint64_t revisionTime;
     uint64_t numLogEvents;
-    LogEvent*logEvents;
+    LogEvent* logEvents;
 
-    [[nodiscard]] uint64_t getStoryID() const
-    { return storyId; }
+    [[nodiscard]] uint64_t getStoryID() const { return storyId; }
 
-    [[nodiscard]] uint64_t getStartTime() const
-    { return startTime; }
+    [[nodiscard]] uint64_t getStartTime() const { return startTime; }
 
-    [[nodiscard]] uint64_t getEndTime() const
-    { return endTime; }
+    [[nodiscard]] uint64_t getEndTime() const { return endTime; }
 
-    [[nodiscard]] uint64_t getNumEvents() const
-    { return numLogEvents; }
+    [[nodiscard]] uint64_t getNumEvents() const { return numLogEvents; }
 
-    [[nodiscard]] uint64_t getRevisionTime() const
-    { return revisionTime; }
+    [[nodiscard]] uint64_t getRevisionTime() const { return revisionTime; }
 
-    [[nodiscard]] LogEvent*getLogEvents() const
-    { return logEvents; }
+    [[nodiscard]] LogEvent* getLogEvents() const { return logEvents; }
 
     [[nodiscard]] size_t getTotalPayloadSize() const
     {
         size_t total_size = 0;
-        for(uint64_t i = 0; i < numLogEvents; i++)
-        { total_size += logEvents[i].logRecord.len; }
+        for(uint64_t i = 0; i < numLogEvents; i++) { total_size += logEvents[i].logRecord.len; }
         return total_size;
     }
 } StoryChunk;
 
-StoryChunk*generateStoryChunkArray(uint64_t story_id, uint64_t client_id, uint64_t start_time, uint64_t time_step
-                                   , uint64_t end_time, uint64_t mean_event_size, uint64_t min_event_size
-                                   , uint64_t max_event_size, double stddev, uint64_t num_events_per_story_chunk
-                                   , uint64_t num_story_chunks)
+StoryChunk* generateStoryChunkArray(uint64_t story_id,
+                                    uint64_t client_id,
+                                    uint64_t start_time,
+                                    uint64_t time_step,
+                                    uint64_t end_time,
+                                    uint64_t mean_event_size,
+                                    uint64_t min_event_size,
+                                    uint64_t max_event_size,
+                                    double stddev,
+                                    uint64_t num_events_per_story_chunk,
+                                    uint64_t num_story_chunks)
 {
-    auto*story_chunk_array = new StoryChunk[num_story_chunks];
+    auto* story_chunk_array = new StoryChunk[num_story_chunks];
     std::random_device rd;
     std::mt19937_64 rng(rd());
-    std::normal_distribution <double> event_size_dist((double)mean_event_size, stddev);
+    std::normal_distribution<double> event_size_dist((double)mean_event_size, stddev);
 
     for(uint64_t i = 0; i < num_story_chunks; i++)
     {
@@ -113,15 +113,16 @@ StoryChunk*generateStoryChunkArray(uint64_t story_id, uint64_t client_id, uint64
             story_chunk_array[i].logEvents[j].clientId = client_id;
             story_chunk_array[i].logEvents[j].eventIndex = j;
             auto log_record_size = (size_t)event_size_dist(rng);
-            log_record_size = log_record_size < min_event_size ? min_event_size : log_record_size > max_event_size
-                                                                                  ? max_event_size : log_record_size;
+            log_record_size = log_record_size < min_event_size   ? min_event_size
+                              : log_record_size > max_event_size ? max_event_size
+                                                                 : log_record_size;
             story_chunk_array[i].logEvents[j].logRecord.len = log_record_size;
             story_chunk_array[i].logEvents[j].logRecord.p = new uint8_t[log_record_size + 1];
             for(uint64_t k = 0; k < log_record_size; k++)
             {
                 ((uint8_t*)story_chunk_array[i].logEvents[j].logRecord.p)[k] = (j + k + 1) % 255;
             }
-//            ((uint8_t *)story_chunk_array[i].logEvents[j].logRecord.p)[log_record_size] = '\0';
+            //            ((uint8_t *)story_chunk_array[i].logEvents[j].logRecord.p)[log_record_size] = '\0';
         }
 
         story_id++;
@@ -130,15 +131,22 @@ StoryChunk*generateStoryChunkArray(uint64_t story_id, uint64_t client_id, uint64
     return story_chunk_array;
 }
 
-std::map <uint64_t, StoryChunk>
-generateStoryChunkMap(uint64_t story_id, uint64_t client_id, uint64_t start_time, uint64_t time_step, uint64_t end_time
-                      , uint64_t mean_event_size, uint64_t min_event_size, uint64_t max_event_size, double stddev
-                      , uint64_t num_events_per_story_chunk, uint64_t num_story_chunks)
+std::map<uint64_t, StoryChunk> generateStoryChunkMap(uint64_t story_id,
+                                                     uint64_t client_id,
+                                                     uint64_t start_time,
+                                                     uint64_t time_step,
+                                                     uint64_t end_time,
+                                                     uint64_t mean_event_size,
+                                                     uint64_t min_event_size,
+                                                     uint64_t max_event_size,
+                                                     double stddev,
+                                                     uint64_t num_events_per_story_chunk,
+                                                     uint64_t num_story_chunks)
 {
-    std::map <uint64_t, StoryChunk> story_chunk_map;
+    std::map<uint64_t, StoryChunk> story_chunk_map;
     std::random_device rd;
     std::mt19937_64 rng(rd());
-    std::normal_distribution <double> event_size_dist((double)mean_event_size, stddev);
+    std::normal_distribution<double> event_size_dist((double)mean_event_size, stddev);
 
     for(uint64_t i = 0; i < num_story_chunks; i++)
     {
@@ -157,15 +165,16 @@ generateStoryChunkMap(uint64_t story_id, uint64_t client_id, uint64_t start_time
             story_chunk.logEvents[j].clientId = client_id;
             story_chunk.logEvents[j].eventIndex = j;
             auto log_record_size = (size_t)event_size_dist(rng);
-            log_record_size = log_record_size < min_event_size ? min_event_size : log_record_size > max_event_size
-                                                                                  ? max_event_size : log_record_size;
+            log_record_size = log_record_size < min_event_size   ? min_event_size
+                              : log_record_size > max_event_size ? max_event_size
+                                                                 : log_record_size;
             story_chunk.logEvents[j].logRecord.len = log_record_size;
             story_chunk.logEvents[j].logRecord.p = new uint8_t[log_record_size + 1];
             for(uint64_t k = 0; k < log_record_size; k++)
             {
                 ((uint8_t*)story_chunk.logEvents[j].logRecord.p)[k] = (j + k + 1) % 255;
             }
-//            ((uint8_t *)story_chunk.logEvents[j].logRecord.p)[log_record_size] = '\0';
+            //            ((uint8_t *)story_chunk.logEvents[j].logRecord.p)[log_record_size] = '\0';
         }
         story_chunk_map.emplace(story_id, story_chunk);
 
@@ -175,20 +184,22 @@ generateStoryChunkMap(uint64_t story_id, uint64_t client_id, uint64_t start_time
     return story_chunk_map;
 }
 
-int writeStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChunk*story_chunk_array
-                     , const std::string &chronicle_dir, hvl_t*wdata)
+int writeStoryChunks(std::map<uint64_t, StoryChunk>& story_chunk_map,
+                     StoryChunk* story_chunk_array,
+                     const std::string& chronicle_dir,
+                     hvl_t* wdata)
 {
     herr_t status;
     uint64_t story_id;
     auto story_chunk_map_it = story_chunk_map.begin();
-    std::unordered_map <uint64_t, hid_t> story_chunk_fd_map;
+    std::unordered_map<uint64_t, hid_t> story_chunk_fd_map;
     LOG_INFO("Writing StoryChunks to Chronicle ...");
-//    for (;
-//            story_chunk_map_it != story_chunk_map.end();
-//            story_chunk_map_it++)
+    //    for (;
+    //            story_chunk_map_it != story_chunk_map.end();
+    //            story_chunk_map_it++)
     for(uint64_t i = 0; i < 1; i++)
     {
-//        StoryChunk story_chunk = story_chunk_map_it->second;
+        //        StoryChunk story_chunk = story_chunk_map_it->second;
         StoryChunk story_chunk = story_chunk_array[i];
         // Check if the Story file has been opened/created already
         hid_t story_file;
@@ -196,23 +207,23 @@ int writeStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChun
         std::string story_file_name = chronicle_dir + "/" + std::to_string(story_id) + ".h5";
         story_file = H5Fcreate(story_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
         LOG_DEBUG("H5Fcreate returns: {}", story_file);
-//        if (story_chunk_fd_map.find(story_id) != story_chunk_fd_map.end())
-//        {
-//            story_file = story_chunk_fd_map.find(story_id)->second;
-//            LOG_DEBUG("Story file already opened: {}", story_file_name.c_str());
-//        }
+        //        if (story_chunk_fd_map.find(story_id) != story_chunk_fd_map.end())
+        //        {
+        //            story_file = story_chunk_fd_map.find(story_id)->second;
+        //            LOG_DEBUG("Story file already opened: {}", story_file_name.c_str());
+        //        }
         // Story file does not exist, create the Story file if it does not exist
-//        else if (stat(story_file_name.c_str(), &st) != 0)
-//        {
-//            story_file = H5Fcreate(story_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-//            if (story_file == H5I_INVALID_HID)
-//            {
-//                LOG_ERROR("Failed to create story file: {}", story_file_name.c_str());
-//                return chronolog::CL_ERR_UNKNOWN;
-//            }
-//            story_chunk_fd_map.emplace(story_id, story_file);
-//        }
-//        else
+        //        else if (stat(story_file_name.c_str(), &st) != 0)
+        //        {
+        //            story_file = H5Fcreate(story_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+        //            if (story_file == H5I_INVALID_HID)
+        //            {
+        //                LOG_ERROR("Failed to create story file: {}", story_file_name.c_str());
+        //                return chronolog::CL_ERR_UNKNOWN;
+        //            }
+        //            story_chunk_fd_map.emplace(story_id, story_file);
+        //        }
+        //        else
         {
             // Open the Story file if it exists
             story_file = H5Fopen(story_file_name.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
@@ -221,7 +232,7 @@ int writeStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChun
                 LOG_ERROR("Failed to open story file: {}", story_file_name.c_str());
                 return chronolog::CL_ERR_UNKNOWN;
             }
-//            story_chunk_fd_map.emplace(story_id, story_file);
+            //            story_chunk_fd_map.emplace(story_id, story_file);
         }
 
         // Check if the dataset for the Story Chunk exists
@@ -275,8 +286,13 @@ int writeStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChun
         status = H5Pset_chunk(story_chunk_dset_creation_plist, DATASET_RANK, story_chunk_dset_chunk_dims);
         LOG_DEBUG("H5Pset_chunk returns: {}", status);
         LOG_INFO("Creating StoryChunk {} in Story file: {}", story_chunk_dset_name.c_str(), story_file_name.c_str());
-        story_chunk_dset = H5Dcreate(story_file, story_chunk_dset_name.c_str(), log_event_filetype, story_chunk_dspace
-                                     , H5P_DEFAULT, story_chunk_dset_creation_plist, H5P_DEFAULT);
+        story_chunk_dset = H5Dcreate(story_file,
+                                     story_chunk_dset_name.c_str(),
+                                     log_event_filetype,
+                                     story_chunk_dspace,
+                                     H5P_DEFAULT,
+                                     story_chunk_dset_creation_plist,
+                                     H5P_DEFAULT);
         status = H5Pclose(story_chunk_dset_creation_plist);
         LOG_DEBUG("H5Pclose returns: {}", status);
         if(story_chunk_dset < 0)
@@ -291,11 +307,11 @@ int writeStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChun
         LOG_DEBUG("{}", ((char*)story_chunk.logEvents[0].logRecord.p)[0]);
         LOG_DEBUG("{}", ((char*)story_chunk.logEvents[0].logRecord.p)[7]);
         LOG_INFO("Writing StoryChunk {} to Story file: {}", story_chunk_dset_name.c_str(), story_file_name.c_str());
-//        status = H5Dwrite(story_chunk_dset, H5T_NATIVE_B8, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-//                          &story_chunk_map_it->second);
+        //        status = H5Dwrite(story_chunk_dset, H5T_NATIVE_B8, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+        //                          &story_chunk_map_it->second);
         status = H5Dwrite(story_chunk_dset, log_event_memtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, wdata);
         LOG_DEBUG("H5Dwrite returns: {}", status);
-//        free(event_payload_data);
+        //        free(event_payload_data);
         if(status < 0)
         {
             LOG_ERROR("Failed to write story chunk to dataset: {}", story_chunk_dset_name.c_str());
@@ -303,12 +319,15 @@ int writeStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChun
             H5Eprint(H5E_DEFAULT, stderr);
 
             // Get the error stack and retrieve the error message
-            H5Ewalk2(H5E_DEFAULT, H5E_WALK_DOWNWARD
-                     , [](unsigned n, const H5E_error2_t*err_desc, void*client_data) -> herr_t
+            H5Ewalk2(
+                    H5E_DEFAULT,
+                    H5E_WALK_DOWNWARD,
+                    [](unsigned n, const H5E_error2_t* err_desc, void* client_data) -> herr_t
                     {
                         printf("Error #%u: {}\n", n, err_desc->desc);
                         return 0;
-                    }, nullptr);
+                    },
+                    nullptr);
             return chronolog::CL_ERR_UNKNOWN;
         }
         status = H5Dvlen_reclaim(log_event_memtype, story_chunk_dspace, H5P_DEFAULT, &g_events);
@@ -331,26 +350,26 @@ int writeStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChun
         LOG_DEBUG("H5Tclose returns: {}", status);
         if(status < 0)
         {
-            LOG_ERROR("Failed to close dataset or dataspace or file for story chunk: {}"
-                      , story_chunk_dset_name.c_str());
+            LOG_ERROR("Failed to close dataset or dataspace or file for story chunk: {}",
+                      story_chunk_dset_name.c_str());
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
 
     // Close all files at the end
-//    for (auto &story_chunk_fd_map_it : story_chunk_fd_map)
-//    {
-//        status = H5Fclose(story_chunk_fd_map_it.second);
-//        if (status < 0)
-//        {
-//            char *story_file_name = new char[128];
-//            size_t file_name_len = 0;
-//            H5Fget_name(story_chunk_fd_map_it.second, story_file_name, file_name_len);
-//            LOG_ERROR("Failed to close file for story chunk: {}", story_file_name);
-//            free(story_file_name);
-//            return chronolog::CL_ERR_UNKNOWN;
-//        }
-//    }
+    //    for (auto &story_chunk_fd_map_it : story_chunk_fd_map)
+    //    {
+    //        status = H5Fclose(story_chunk_fd_map_it.second);
+    //        if (status < 0)
+    //        {
+    //            char *story_file_name = new char[128];
+    //            size_t file_name_len = 0;
+    //            H5Fget_name(story_chunk_fd_map_it.second, story_file_name, file_name_len);
+    //            LOG_ERROR("Failed to close file for story chunk: {}", story_file_name);
+    //            free(story_file_name);
+    //            return chronolog::CL_ERR_UNKNOWN;
+    //        }
+    //    }
     LOG_INFO("Done writing StoryChunks to Chronicle file ...");
     return chronolog::CL_SUCCESS;
 }
@@ -368,11 +387,11 @@ hid_t genLogEventDataType(hid_t vlen_memtype_id)
     LOG_DEBUG("H5Tinsert returns: {}", status);
     status = H5Tinsert(log_event_dtype, "eventIndex", HOFFSET(LogEvent, eventIndex), H5T_NATIVE_UINT32);
     LOG_DEBUG("H5Tinsert returns: {}", status);
-//        status = H5Tinsert(log_event_memtype,
-//                           "logRecordSize",
-//                           HOFFSET(LogEvent, logRecordSize),
-//                           H5T_NATIVE_UINT64);
-//        LOG_DEBUG("H5Tinsert returns: {}", status);
+    //        status = H5Tinsert(log_event_memtype,
+    //                           "logRecordSize",
+    //                           HOFFSET(LogEvent, logRecordSize),
+    //                           H5T_NATIVE_UINT64);
+    //        LOG_DEBUG("H5Tinsert returns: {}", status);
     status = H5Tinsert(log_event_dtype, "logRecord", HOFFSET(LogEvent, logRecord), vlen_memtype_id);
     LOG_DEBUG("H5Tinsert returns: {}", status);
     if(status < 0)
@@ -383,19 +402,21 @@ hid_t genLogEventDataType(hid_t vlen_memtype_id)
     return log_event_dtype;
 }
 
-int readStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChunk*story_chunk_array
-                    , const std::string &chronicle_dir, hvl_t*rdata)
+int readStoryChunks(std::map<uint64_t, StoryChunk>& story_chunk_map,
+                    StoryChunk* story_chunk_array,
+                    const std::string& chronicle_dir,
+                    hvl_t* rdata)
 {
     herr_t status;
     uint64_t story_id;
     auto story_chunk_map_it = story_chunk_map.begin();
-    std::unordered_map <uint64_t, hid_t> story_chunk_fd_map;
+    std::unordered_map<uint64_t, hid_t> story_chunk_fd_map;
     LOG_INFO("Reading StoryChunks from Chronicle ...");
     // Read StoryChunks
     LOG_INFO("Reading StoryChunks ...");
     for(uint64_t i = 0; i < 1; i++)
     {
-//        StoryChunk story_chunk = story_chunk_map_it->second;
+        //        StoryChunk story_chunk = story_chunk_map_it->second;
         StoryChunk story_chunk = story_chunk_array[i];
         // Open the Story file
         hid_t story_file;
@@ -434,8 +455,10 @@ int readStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChunk
         hsize_t story_chunk_dset_dims[1] = {story_chunk.getNumEvents()};
         story_chunk_dspace = H5Dget_space(story_chunk_dset);
         int ndims = H5Sget_simple_extent_dims(story_chunk_dspace, story_chunk_dset_dims, nullptr);
-        LOG_INFO("Allocating memory for {}-D dimensional data in StoryChunk {} in Story file: {}", ndims
-                 , story_chunk_dset_name.c_str(), story_file_name.c_str());
+        LOG_INFO("Allocating memory for {}-D dimensional data in StoryChunk {} in Story file: {}",
+                 ndims,
+                 story_chunk_dset_name.c_str(),
+                 story_file_name.c_str());
         rdata = (hvl_t*)malloc((story_chunk_dset_dims[0] + 1) * sizeof(hvl_t));
 
         // Read data
@@ -450,8 +473,8 @@ int readStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChunk
         status += H5Fclose(story_file);
         if(status < 0)
         {
-            LOG_ERROR("Failed to close dataset or dataspace or file for story chunk: {}"
-                      , story_chunk_dset_name.c_str());
+            LOG_ERROR("Failed to close dataset or dataspace or file for story chunk: {}",
+                      story_chunk_dset_name.c_str());
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
@@ -459,7 +482,7 @@ int readStoryChunks(std::map <uint64_t, StoryChunk> &story_chunk_map, StoryChunk
     return chronolog::CL_SUCCESS;
 }
 
-int main(int argc, char*argv[])
+int main(int argc, char* argv[])
 {
     if(argc < 8)
     {
@@ -470,13 +493,21 @@ int main(int argc, char*argv[])
     }
     int i, ret, nCount = 10;
     size_t len;
-    hvl_t*wdata, *rdata = nullptr;
-    char*bptr;
-    char*str[] = {"Wake Me up When", "September", "Ends", "Ever tried", "Ever failed", "No matter", "Try again"
-                  , "Fail again", "Fail better", "I am the master of my fate"};
-//    std::random_device rd;
-//    std::mt19937_64 rng(rd());
-    std::uniform_int_distribution <uint64_t> dist(0, UINT64_MAX);
+    hvl_t *wdata, *rdata = nullptr;
+    char* bptr;
+    char* str[] = {"Wake Me up When",
+                   "September",
+                   "Ends",
+                   "Ever tried",
+                   "Ever failed",
+                   "No matter",
+                   "Try again",
+                   "Fail again",
+                   "Fail better",
+                   "I am the master of my fate"};
+    //    std::random_device rd;
+    //    std::mt19937_64 rng(rd());
+    std::uniform_int_distribution<uint64_t> dist(0, UINT64_MAX);
     uint64_t num_story_chunks = strtol(argv[1], nullptr, 10);
     uint64_t num_events_per_story_chunk = strtol(argv[2], nullptr, 10);
     uint64_t mean_event_size = strtol(argv[3], nullptr, 10);
@@ -490,18 +521,27 @@ int main(int argc, char*argv[])
     uint64_t story_id = STORY_ID; //dist(rng);
     uint64_t client_id = CLIENT_ID;
 
-    int result = chronolog::chrono_monitor::initialize("console", "cmp_vlen_bytes_dtype_test.log", spdlog::level::debug
-                                                       , "cmp_vlen_bytes_dtype_test", 102400, 1, spdlog::level::debug);
+    int result = chronolog::chrono_monitor::initialize("console",
+                                                       "cmp_vlen_bytes_dtype_test.log",
+                                                       spdlog::level::debug,
+                                                       "cmp_vlen_bytes_dtype_test",
+                                                       102400,
+                                                       1,
+                                                       spdlog::level::debug);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
     }
 
-    std::cout << "StoryID: " << story_id << std::endl << "#StoryChunks: " << num_story_chunks << std::endl
-              << "#EventsInEachChunk: " << num_events_per_story_chunk << std::endl << "meanEventSize: "
-              << mean_event_size << std::endl << "minEventSize: " << min_event_size << std::endl << "maxEventSize: "
-              << max_event_size << std::endl << "stddev: " << stddev << std::endl << "startTime: " << start_time
-              << std::endl << "endTime: " << end_time << std::endl;
+    std::cout << "StoryID: " << story_id << std::endl
+              << "#StoryChunks: " << num_story_chunks << std::endl
+              << "#EventsInEachChunk: " << num_events_per_story_chunk << std::endl
+              << "meanEventSize: " << mean_event_size << std::endl
+              << "minEventSize: " << min_event_size << std::endl
+              << "maxEventSize: " << max_event_size << std::endl
+              << "stddev: " << stddev << std::endl
+              << "startTime: " << start_time << std::endl
+              << "endTime: " << end_time << std::endl;
 
     for(i = 0; i < nCount; i++)
     {
@@ -510,7 +550,7 @@ int main(int argc, char*argv[])
         g_events[i].clientId = (i + 1) * 10;
         g_events[i].eventIndex = i;
         len = strlen(str[i]);
-//        g_events[i].logRecordSize = len;
+        //        g_events[i].logRecordSize = len;
         if((bptr = (char*)malloc(++len * sizeof(char))))
         {
 
@@ -531,27 +571,43 @@ int main(int argc, char*argv[])
     // Generate StoryChunks
     std::cout << "Generating StoryChunks..." << std::endl;
     uint64_t time_step = (end_time - start_time) / num_events_per_story_chunk;
-    StoryChunk*story_chunk_array = generateStoryChunkArray(story_id, client_id, start_time, time_step, end_time
-                                                           , mean_event_size, min_event_size, max_event_size, stddev
-                                                           , num_events_per_story_chunk, num_story_chunks);
-    std::map <uint64_t, StoryChunk> story_chunk_map = generateStoryChunkMap(story_id, client_id, start_time, time_step
-                                                                            , end_time, mean_event_size, min_event_size
-                                                                            , max_event_size, stddev
-                                                                            , num_events_per_story_chunk
-                                                                            , num_story_chunks);
+    StoryChunk* story_chunk_array = generateStoryChunkArray(story_id,
+                                                            client_id,
+                                                            start_time,
+                                                            time_step,
+                                                            end_time,
+                                                            mean_event_size,
+                                                            min_event_size,
+                                                            max_event_size,
+                                                            stddev,
+                                                            num_events_per_story_chunk,
+                                                            num_story_chunks);
+    std::map<uint64_t, StoryChunk> story_chunk_map = generateStoryChunkMap(story_id,
+                                                                           client_id,
+                                                                           start_time,
+                                                                           time_step,
+                                                                           end_time,
+                                                                           mean_event_size,
+                                                                           min_event_size,
+                                                                           max_event_size,
+                                                                           stddev,
+                                                                           num_events_per_story_chunk,
+                                                                           num_story_chunks);
 
     hsize_t total_num_events = 0;
-    std::vector <hsize_t> num_events;
+    std::vector<hsize_t> num_events;
     for(uint64_t j = 0; j < num_story_chunks; j++)
     {
-//        hsize_t num_events_per_chunk = story_chunk_array[j].getNumEvents();
+        //        hsize_t num_events_per_chunk = story_chunk_array[j].getNumEvents();
         hsize_t num_events_per_chunk = story_chunk_map[j].getNumEvents();
         num_events.push_back(num_events_per_chunk);
         total_num_events += num_events_per_chunk;
     }
 
     // Check if the directory for the Chronicle already exists
-    struct stat st{};
+    struct stat st
+    {
+    };
     std::string chronicle_dir = CHRONICLE_ROOT_DIR + chronicle_name;
     if(stat(chronicle_dir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode))
     {
@@ -572,12 +628,10 @@ int main(int argc, char*argv[])
     assert(ret == chronolog::CL_SUCCESS);
 
     // Cleanup
-    for(i = 0; i < nCount; i++)
-    { free(g_events[i].logRecord.p); }
+    for(i = 0; i < nCount; i++) { free(g_events[i].logRecord.p); }
     for(uint64_t j = 0; j < num_story_chunks; j++)
     {
-        for(uint64_t k = 0; k < num_events[j]; k++)
-        { free(story_chunk_array[j].logEvents[k].logRecord.p); }
+        for(uint64_t k = 0; k < num_events[j]; k++) { free(story_chunk_array[j].logEvents[k].logRecord.p); }
         delete[] story_chunk_array[j].logEvents;
     }
     delete[] story_chunk_array;

--- a/ChronoStore/test/cmp_vlen_bytes_dtype_test.cpp
+++ b/ChronoStore/test/cmp_vlen_bytes_dtype_test.cpp
@@ -8,10 +8,14 @@
 #include <unordered_map>
 #include <map>
 #include <filesystem>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <cassert>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <cassert>
 #include <hdf5.h>
+#include <spdlog/spdlog.h>
 #include <chrono_monitor.h>
 #include <chronolog_errcode.h>
 //#include <story_chunk_test_utils.h>

--- a/ChronoStore/test/cmp_vlen_bytes_vs_blob_map.cpp
+++ b/ChronoStore/test/cmp_vlen_bytes_vs_blob_map.cpp
@@ -52,14 +52,14 @@ struct LogEvent
         , eventTime(0)
         , clientId(0)
         , eventIndex(0)
-        , logRecord(){};
+        , logRecord() {};
 
     LogEvent(uint64_t storyId, uint64_t eventTime, uint32_t clientId, uint32_t eventIndex, hvl_t logRecord)
         : storyId(storyId)
         , eventTime(eventTime)
         , clientId(clientId)
         , eventIndex(eventIndex)
-        , logRecord(logRecord){};
+        , logRecord(logRecord) {};
 
     [[nodiscard]] uint64_t const& time() const { return eventTime; }
 

--- a/ChronoStore/test/cmp_vlen_bytes_vs_blob_map.cpp
+++ b/ChronoStore/test/cmp_vlen_bytes_vs_blob_map.cpp
@@ -24,7 +24,7 @@ const hsize_t n_dims = 1;
 uint64_t n_records = 1000000;
 hsize_t mean_length = 100;
 int range_start_percentage = -1; // [0..100]
-int range_end_percentage = -1;  // [0..100]
+int range_end_percentage = -1;   // [0..100]
 int range_step_percentage = 10;
 hsize_t total_story_chunk_size = 0;
 const std::string story_chunk_dataset_name = "08h00m00_08h10m00";
@@ -47,37 +47,42 @@ struct LogEvent
     uint32_t eventIndex{};
     hvl_t logRecord{};
 
-    LogEvent(): storyId(0), eventTime(0), clientId(0), eventIndex(0), logRecord()
-    {};
+    LogEvent()
+        : storyId(0)
+        , eventTime(0)
+        , clientId(0)
+        , eventIndex(0)
+        , logRecord(){};
 
-    LogEvent(uint64_t storyId, uint64_t eventTime, uint32_t clientId, uint32_t eventIndex, hvl_t logRecord): storyId(
-            storyId), eventTime(eventTime), clientId(clientId), eventIndex(eventIndex), logRecord(logRecord)
-    {};
+    LogEvent(uint64_t storyId, uint64_t eventTime, uint32_t clientId, uint32_t eventIndex, hvl_t logRecord)
+        : storyId(storyId)
+        , eventTime(eventTime)
+        , clientId(clientId)
+        , eventIndex(eventIndex)
+        , logRecord(logRecord){};
 
-    [[nodiscard]] uint64_t const &time() const
-    { return eventTime; }
+    [[nodiscard]] uint64_t const& time() const { return eventTime; }
 
-    [[nodiscard]] uint32_t const &index() const
-    { return eventIndex; }
+    [[nodiscard]] uint32_t const& index() const { return eventIndex; }
 
     [[nodiscard]] std::string toString() const
     {
-        std::string str =
-                "storyId: " + std::to_string(storyId) + "\n" + "eventTime: " + std::to_string(eventTime) + "\n" +
-                "clientId: " + std::to_string(clientId) + "\n" + "eventIndex: " + std::to_string(eventIndex) + "\n";
+        std::string str = "storyId: " + std::to_string(storyId) + "\n" + "eventTime: " + std::to_string(eventTime) +
+                          "\n" + "clientId: " + std::to_string(clientId) + "\n" +
+                          "eventIndex: " + std::to_string(eventIndex) + "\n";
         str += "logRecord: ";
-        char*ptr = static_cast<char*>(logRecord.p);
+        char* ptr = static_cast<char*>(logRecord.p);
         for(hsize_t i = 0; i < logRecord.len; i++)
         {
             str += *(ptr + i);
             str += " ";
         }
         str += "\n";
-//        LOG_DEBUG("logRecord len: {}", logRecord.len);
+        //        LOG_DEBUG("logRecord len: {}", logRecord.len);
         return str;
     }
 
-    bool operator==(const LogEvent &other) const
+    bool operator==(const LogEvent& other) const
     {
         if(storyId != other.storyId)
         {
@@ -105,15 +110,9 @@ struct LogEvent
         return true;
     }
 
-    bool operator!=(const LogEvent &other) const
-    {
-        return !(*this == other);
-    }
+    bool operator!=(const LogEvent& other) const { return !(*this == other); }
 
-    bool operator<(const LogEvent &other) const
-    {
-        return eventTime < other.eventTime;
-    }
+    bool operator<(const LogEvent& other) const { return eventTime < other.eventTime; }
 };
 
 struct StoryChunk
@@ -123,83 +122,77 @@ struct StoryChunk
     typedef uint64_t StoryId;
     typedef uint64_t ChronicleId;
     typedef uint32_t ClientId;
-    typedef std::tuple <chrono_time, ClientId, chrono_index> EventSequence;
+    typedef std::tuple<chrono_time, ClientId, chrono_index> EventSequence;
 
-    explicit StoryChunk(StoryId const &story_id = 0, uint64_t start_time = 0, uint64_t end_time = 0): storyId(story_id)
-                                                                                                      , startTime(
-                    start_time), endTime(end_time), revisionTime(start_time)
+    explicit StoryChunk(StoryId const& story_id = 0, uint64_t start_time = 0, uint64_t end_time = 0)
+        : storyId(story_id)
+        , startTime(start_time)
+        , endTime(end_time)
+        , revisionTime(start_time)
     {}
 
     ~StoryChunk() = default;
 
-    [[nodiscard]] StoryId const &getStoryId() const
-    { return storyId; }
+    [[nodiscard]] StoryId const& getStoryId() const { return storyId; }
 
-    [[nodiscard]] uint64_t getStartTime() const
-    { return startTime; }
+    [[nodiscard]] uint64_t getStartTime() const { return startTime; }
 
-    [[nodiscard]] uint64_t getEndTime() const
-    { return endTime; }
+    [[nodiscard]] uint64_t getEndTime() const { return endTime; }
 
-    [[nodiscard]] bool empty() const
-    { return logEvents.empty(); }
+    [[nodiscard]] bool empty() const { return logEvents.empty(); }
 
-    [[nodiscard]] size_t getNumEvents() const
-    { return logEvents.size(); }
+    [[nodiscard]] size_t getNumEvents() const { return logEvents.size(); }
 
     [[nodiscard]] size_t getTotalPayloadSize() const
     {
         size_t total_size = 0;
-        for(auto const &event: logEvents)
-        { total_size += event.second.logRecord.len; }
+        for(auto const& event: logEvents) { total_size += event.second.logRecord.len; }
         return total_size;
     }
 
-    [[nodiscard]] std::map <EventSequence, LogEvent>::const_iterator begin() const
-    { return logEvents.begin(); }
+    [[nodiscard]] std::map<EventSequence, LogEvent>::const_iterator begin() const { return logEvents.begin(); }
 
-    [[nodiscard]] std::map <EventSequence, LogEvent>::const_iterator end() const
-    { return logEvents.end(); }
+    [[nodiscard]] std::map<EventSequence, LogEvent>::const_iterator end() const { return logEvents.end(); }
 
-    [[nodiscard]] std::map <EventSequence, LogEvent>::const_iterator lower_bound(uint64_t chrono_time) const
-    { return logEvents.lower_bound(EventSequence{chrono_time, 0, 0}); }
+    [[nodiscard]] std::map<EventSequence, LogEvent>::const_iterator lower_bound(uint64_t chrono_time) const
+    {
+        return logEvents.lower_bound(EventSequence{chrono_time, 0, 0});
+    }
 
-    [[nodiscard]] uint64_t firstEventTime() const
-    { return (*logEvents.begin()).second.time(); }
+    [[nodiscard]] uint64_t firstEventTime() const { return (*logEvents.begin()).second.time(); }
 
-    int insertEvent(LogEvent const &event)
+    int insertEvent(LogEvent const& event)
     {
         if((event.time() >= startTime) && (event.time() < endTime))
         {
-            logEvents.insert(std::pair <EventSequence, LogEvent>({event.time(), event.clientId, event.index()}, event));
+            logEvents.insert(std::pair<EventSequence, LogEvent>({event.time(), event.clientId, event.index()}, event));
             return 1;
         }
         else
-        { return 0; }
+        {
+            return 0;
+        }
     }
 
-    bool operator==(const StoryChunk &other) const
+    bool operator==(const StoryChunk& other) const
     {
         return ((storyId == other.storyId) && (startTime == other.startTime) && (endTime == other.endTime) &&
                 (revisionTime == other.revisionTime) && (logEvents == other.logEvents));
     }
 
-    bool operator!=(const StoryChunk &other) const
-    {
-        return !(*this == other);
-    }
+    bool operator!=(const StoryChunk& other) const { return !(*this == other); }
 
     [[nodiscard]] std::string toString() const
     {
         std::stringstream ss;
         ss << "StoryChunk:{" << storyId << ":" << startTime << ":" << endTime << "} has " << logEvents.size()
            << " events: ";
-        for(auto const &event: logEvents)
+        for(auto const& event: logEvents)
         {
-            ss << "<" << std::get <0>(event.first) << ", " << std::get <1>(event.first) << ", "
-               << std::get <2>(event.first) << ">: " << event.second.toString();
+            ss << "<" << std::get<0>(event.first) << ", " << std::get<1>(event.first) << ", "
+               << std::get<2>(event.first) << ">: " << event.second.toString();
         }
-//        LOG_DEBUG("string size in StoryChunk::toString(): {}", ss.str().size());
+        //        LOG_DEBUG("string size in StoryChunk::toString(): {}", ss.str().size());
         return ss.str();
     }
 
@@ -208,8 +201,7 @@ struct StoryChunk
     uint64_t endTime;
     uint64_t revisionTime;
 
-    std::map <EventSequence, LogEvent> logEvents;
-
+    std::map<EventSequence, LogEvent> logEvents;
 };
 
 struct StoryChunk2
@@ -220,17 +212,19 @@ struct StoryChunk2
     typedef uint64_t ChronicleId;
     typedef uint32_t ClientId;
 
-    typedef std::tuple <chrono_time, ClientId, chrono_index> EventSequence;
-    typedef std::tuple <uint64_t, uint64_t> EventOffsetSize;
+    typedef std::tuple<chrono_time, ClientId, chrono_index> EventSequence;
+    typedef std::tuple<uint64_t, uint64_t> EventOffsetSize;
 
-    explicit StoryChunk2(StoryId const &story_id = 0, uint64_t start_time = 0, uint64_t end_time = 0): storyId(story_id)
-                                                                                                       , startTime(
-                    start_time), endTime(end_time), revisionTime(start_time)
+    explicit StoryChunk2(StoryId const& story_id = 0, uint64_t start_time = 0, uint64_t end_time = 0)
+        : storyId(story_id)
+        , startTime(start_time)
+        , endTime(end_time)
+        , revisionTime(start_time)
     {
         eventData = (unsigned char*)malloc(max_story_chunk2_size);
     }
 
-    StoryChunk2(StoryChunk2 &other)
+    StoryChunk2(StoryChunk2& other)
     {
         storyId = other.storyId;
         startTime = other.startTime;
@@ -243,69 +237,72 @@ struct StoryChunk2
         memcpy(eventData, other.eventData, totalSize);
     }
 
-    ~StoryChunk2()
-    {
-        free(eventData);
-    }
+    ~StoryChunk2() { free(eventData); }
 
-    int insertEvent(LogEvent const &event)
+    int insertEvent(LogEvent const& event)
     {
         if((event.time() >= startTime) && (event.time() < endTime))
         {
-            std::lock_guard <std::mutex> lock(offsetMapMutex);
+            std::lock_guard<std::mutex> lock(offsetMapMutex);
             memcpy((uint8_t*)eventData + currentOffset, event.logRecord.p, event.logRecord.len);
             offsetSizeMap.insert(
-                    std::pair <EventSequence, EventOffsetSize>({event.time(), event.clientId, event.index()}, {
-                            currentOffset, event.logRecord.len}));
+                    std::pair<EventSequence, EventOffsetSize>({event.time(), event.clientId, event.index()},
+                                                              {currentOffset, event.logRecord.len}));
             totalEventCount++;
             currentOffset += event.logRecord.len;
             totalSize += event.logRecord.len;
             return 1;
         }
         else
-        { return 0; }
+        {
+            return 0;
+        }
     }
 
-    bool operator==(const StoryChunk2 &other) const
+    bool operator==(const StoryChunk2& other) const
     {
         if((storyId != other.storyId) || (startTime != other.startTime) || (endTime != other.endTime) ||
            (revisionTime != other.revisionTime))
             return false;
-        if(totalSize != other.totalSize) return false;
-        if(currentOffset != other.currentOffset) return false;
-        if(offsetSizeMap.size() != other.offsetSizeMap.size()) return false;
-        for(auto const &entry: offsetSizeMap)
+        if(totalSize != other.totalSize)
+            return false;
+        if(currentOffset != other.currentOffset)
+            return false;
+        if(offsetSizeMap.size() != other.offsetSizeMap.size())
+            return false;
+        for(auto const& entry: offsetSizeMap)
         {
-            if(other.offsetSizeMap.find(entry.first) == other.offsetSizeMap.end()) return false;
-            if(other.offsetSizeMap.at(entry.first) != entry.second) return false;
+            if(other.offsetSizeMap.find(entry.first) == other.offsetSizeMap.end())
+                return false;
+            if(other.offsetSizeMap.at(entry.first) != entry.second)
+                return false;
         }
         for(size_t i = 0; i < currentOffset; i++)
         {
-            if(((uint8_t*)eventData)[i] != ((uint8_t*)other.eventData)[i]) return false;
+            if(((uint8_t*)eventData)[i] != ((uint8_t*)other.eventData)[i])
+                return false;
         }
         return true;
     }
 
-    bool operator!=(const StoryChunk2 &other) const
-    {
-        return !(*this == other);
-    }
+    bool operator!=(const StoryChunk2& other) const { return !(*this == other); }
 
     [[nodiscard]] std::string toString() const
     {
         std::stringstream ss;
         ss << "StoryChunk2:{" << storyId << ":" << startTime << ":" << endTime << "} has " << offsetSizeMap.size()
            << " events: ";
-        for(auto const &offsetSizeEntry: offsetSizeMap)
+        for(auto const& offsetSizeEntry: offsetSizeMap)
         {
-            ss << "<" << std::get <0>(offsetSizeEntry.first) << ", " << std::get <1>(offsetSizeEntry.first) << ", "
-               << std::get <2>(offsetSizeEntry.first) << ">: ";
-            for(size_t i = std::get <0>(offsetSizeEntry.second);
-                i < std::get <0>(offsetSizeEntry.second) + std::get <1>(offsetSizeEntry.second); i++)
-//            ss << "<" << offsetSizeEntry.first.time << ", " << offsetSizeEntry.first.clientId << ", "
-//               << offsetSizeEntry.first.index << ">: ";
-//            for(size_t i = offsetSizeEntry.second.offset;
-//                i < offsetSizeEntry.second.offset + offsetSizeEntry.second.size; i++)
+            ss << "<" << std::get<0>(offsetSizeEntry.first) << ", " << std::get<1>(offsetSizeEntry.first) << ", "
+               << std::get<2>(offsetSizeEntry.first) << ">: ";
+            for(size_t i = std::get<0>(offsetSizeEntry.second);
+                i < std::get<0>(offsetSizeEntry.second) + std::get<1>(offsetSizeEntry.second);
+                i++)
+            //            ss << "<" << offsetSizeEntry.first.time << ", " << offsetSizeEntry.first.clientId << ", "
+            //               << offsetSizeEntry.first.index << ">: ";
+            //            for(size_t i = offsetSizeEntry.second.offset;
+            //                i < offsetSizeEntry.second.offset + offsetSizeEntry.second.size; i++)
             {
                 ss << ((uint8_t*)eventData)[i];
             }
@@ -319,12 +316,12 @@ struct StoryChunk2
     uint64_t endTime;
     uint64_t revisionTime;
 
-    std::map <EventSequence, EventOffsetSize> offsetSizeMap;
+    std::map<EventSequence, EventOffsetSize> offsetSizeMap;
     uint64_t totalEventCount = 0;
     uint64_t currentOffset = 0;
     uint64_t totalSize = 0;
     std::mutex offsetMapMutex;
-    unsigned char*eventData{};
+    unsigned char* eventData{};
 };
 
 struct OffsetMapEntry
@@ -338,24 +335,30 @@ struct OffsetMapEntry
         offsetSize = StoryChunk2::EventOffsetSize(0, 0);
     }
 
-    OffsetMapEntry(StoryChunk2::EventSequence eventId, StoryChunk2::EventOffsetSize offsetSize): eventId(
-            std::move(eventId)), offsetSize(std::move(offsetSize))
+    OffsetMapEntry(StoryChunk2::EventSequence eventId, StoryChunk2::EventOffsetSize offsetSize)
+        : eventId(std::move(eventId))
+        , offsetSize(std::move(offsetSize))
     {}
 };
 
 /**********************************************************************************************************************
  * Global variables
  *********************************************************************************************************************/
-std::vector <std::vector <uint8_t>> log_record_bytes;
-std::vector <LogEvent> events;
+std::vector<std::vector<uint8_t>> log_record_bytes;
+std::vector<LogEvent> events;
 
-void parseCommandLineOptions(int argc, char*argv[])
+void parseCommandLineOptions(int argc, char* argv[])
 {
-    if(argc > 1) n_records = std::stoi(argv[1]);
-    if(argc > 2) mean_length = std::stoi(argv[2]);
-    if(argc > 3) range_start_percentage = std::stoi(argv[3]);
-    if(argc > 4) range_end_percentage = std::stoi(argv[4]);
-    if(argc > 5) range_step_percentage = std::stoi(argv[5]);
+    if(argc > 1)
+        n_records = std::stoi(argv[1]);
+    if(argc > 2)
+        mean_length = std::stoi(argv[2]);
+    if(argc > 3)
+        range_start_percentage = std::stoi(argv[3]);
+    if(argc > 4)
+        range_end_percentage = std::stoi(argv[4]);
+    if(argc > 5)
+        range_step_percentage = std::stoi(argv[5]);
     std::cout << "n_records: " << n_records << std::endl;
     std::cout << "mean_length: " << mean_length << std::endl;
     std::cout << "range_start_percentage: " << range_start_percentage << std::endl;
@@ -388,7 +391,7 @@ H5::CompType createStoryChunkCompoundType()
 /**********************************************************************************************************************
  * Data generation functions
  *********************************************************************************************************************/
-std::vector <LogEvent> generateEvents(uint64_t &start_timestamp)
+std::vector<LogEvent> generateEvents(uint64_t& start_timestamp)
 {
     hsize_t total_payload_size = 0;
     log_record_bytes.clear();
@@ -402,20 +405,17 @@ std::vector <LogEvent> generateEvents(uint64_t &start_timestamp)
 
     std::random_device rd;
     std::mt19937 gen(rd());
-    std::normal_distribution <double> value_dist(0.0, 25.0);
-    std::normal_distribution <double> size_dist((double)mean_length, (double)mean_length * 0.1);
-//    std::poisson_distribution<hsize_t> size_dist(mean_length);
+    std::normal_distribution<double> value_dist(0.0, 25.0);
+    std::normal_distribution<double> size_dist((double)mean_length, (double)mean_length * 0.1);
+    //    std::poisson_distribution<hsize_t> size_dist(mean_length);
 
-//    start_timestamp = (uint64_t)std::abs(value_dist(gen)) / 255 * 1000000000;
+    //    start_timestamp = (uint64_t)std::abs(value_dist(gen)) / 255 * 1000000000;
     for(uint64_t idx = 0; idx < n_records; idx++)
     {
         size_t size = (size_t)std::min(std::max(size_dist(gen), 1.0), static_cast<double>(mean_length) * 3.0);
         log_record_bytes.emplace_back();
 
-        for(hsize_t i = 0; i < size; i++)
-        {
-            log_record_bytes.at(idx).emplace_back(idx % 26 + 'a');
-        }
+        for(hsize_t i = 0; i < size; i++) { log_record_bytes.at(idx).emplace_back(idx % 26 + 'a'); }
 
         // set len and pointer for the variable length descriptor
         uint64_t event_time = start_timestamp + idx * 100;
@@ -443,10 +443,12 @@ StoryChunk generateStoryChunk()
     uint64_t start_timestamp = test_start_timestamp;
     StoryChunk story_chunk(test_story_id, start_timestamp, start_timestamp + n_records * 1000 + 1);
     size_t event_idx = 0;
-    for(auto const &event: events)
+    for(auto const& event: events)
     {
         if(story_chunk.insertEvent(event) == 0)
-        { LOG_ERROR("Failed to insert {}-th event", event_idx); }
+        {
+            LOG_ERROR("Failed to insert {}-th event", event_idx);
+        }
         event_idx++;
     }
 
@@ -458,10 +460,12 @@ StoryChunk2 generateStoryChunk2()
     uint64_t start_timestamp = test_start_timestamp;
     StoryChunk2 story_chunk(test_story_id, start_timestamp, start_timestamp + n_records * 1000 + 1);
     size_t event_idx = 0;
-    for(auto const &event: events)
+    for(auto const& event: events)
     {
         if(story_chunk.insertEvent(event) == 0)
-        { LOG_ERROR("Failed to insert {}-th event", event_idx); }
+        {
+            LOG_ERROR("Failed to insert {}-th event", event_idx);
+        }
         event_idx++;
     }
 
@@ -471,24 +475,25 @@ StoryChunk2 generateStoryChunk2()
 /**********************************************************************************************************************
  * Read/write Events using variable length datatype in HDF5
  *********************************************************************************************************************/
-hsize_t writeVlenBytesEvents(H5::H5File*file, std::vector <LogEvent> &data)
+hsize_t writeVlenBytesEvents(H5::H5File* file, std::vector<LogEvent>& data)
 {
     try
     {
         /*
          * Create a group in the file
         */
-        auto*group = new H5::Group(file->createGroup(group_name));
+        auto* group = new H5::Group(file->createGroup(group_name));
 
         hsize_t dim_size = n_records;
-        auto*dataspace = new H5::DataSpace(n_dims, &dim_size);
+        auto* dataspace = new H5::DataSpace(n_dims, &dim_size);
 
         // target dtype for the file
         H5::CompType data_type = createEventCompoundType();
 
-        auto*dataset = new H5::DataSet(
-                file->createDataSet("/" + group_name + "/" + story_chunk_dataset_name + ".vlen_bytes", data_type
-                                    , *dataspace));
+        auto* dataset =
+                new H5::DataSet(file->createDataSet("/" + group_name + "/" + story_chunk_dataset_name + ".vlen_bytes",
+                                                    data_type,
+                                                    *dataspace));
 
 
         dataset->write(&data.front(), data_type);
@@ -499,32 +504,32 @@ hsize_t writeVlenBytesEvents(H5::H5File*file, std::vector <LogEvent> &data)
 
         return data.size();
     }
-        // catch failure caused by the H5File operations
-    catch(H5::FileIException &error)
+    // catch failure caused by the H5File operations
+    catch(H5::FileIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return -1;
     }
 
-        // catch failure caused by the DataSet operations
-    catch(H5::DataSetIException &error)
+    // catch failure caused by the DataSet operations
+    catch(H5::DataSetIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return -1;
     }
 
-        // catch failure caused by the DataSpace operations
-    catch(H5::DataSpaceIException &error)
+    // catch failure caused by the DataSpace operations
+    catch(H5::DataSpaceIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return -1;
     }
 
-        // catch failure caused by the DataType operations
-    catch(H5::DataTypeIException &error)
+    // catch failure caused by the DataType operations
+    catch(H5::DataTypeIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
@@ -532,7 +537,7 @@ hsize_t writeVlenBytesEvents(H5::H5File*file, std::vector <LogEvent> &data)
     }
 }
 
-int readVlenBytesEvents(H5::H5File*file, std::vector <LogEvent> &data)
+int readVlenBytesEvents(H5::H5File* file, std::vector<LogEvent>& data)
 {
     try
     {
@@ -564,32 +569,32 @@ int readVlenBytesEvents(H5::H5File*file, std::vector <LogEvent> &data)
         data.resize(dims_out[0]);
         dataset.read(data.data(), defined_comp_type);
     }
-        // catch failure caused by the H5File operations
-    catch(H5::FileIException &error)
+    // catch failure caused by the H5File operations
+    catch(H5::FileIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return -1;
     }
 
-        // catch failure caused by the DataSet operations
-    catch(H5::DataSetIException &error)
+    // catch failure caused by the DataSet operations
+    catch(H5::DataSetIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return -1;
     }
 
-        // catch failure caused by the DataSpace operations
-    catch(H5::DataSpaceIException &error)
+    // catch failure caused by the DataSpace operations
+    catch(H5::DataSpaceIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return -1;
     }
 
-        // catch failure caused by the DataType operations
-    catch(H5::DataTypeIException &error)
+    // catch failure caused by the DataType operations
+    catch(H5::DataTypeIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
@@ -601,15 +606,12 @@ int readVlenBytesEvents(H5::H5File*file, std::vector <LogEvent> &data)
 /**********************************************************************************************************************
  * Read/write StoryChunks using variable length datatype in HDF5
  *********************************************************************************************************************/
-hsize_t writeStoryChunkUsingVlenBytesEvents(StoryChunk &story_chunk)
+hsize_t writeStoryChunkUsingVlenBytesEvents(StoryChunk& story_chunk)
 {
-    std::vector <LogEvent> data;
+    std::vector<LogEvent> data;
     data.reserve(story_chunk.getNumEvents());
-    for(auto const &event: story_chunk.logEvents)
-    {
-        data.push_back(event.second);
-    }
-    auto*file = new H5::H5File(story_file_name + ".vlen.h5", H5F_ACC_TRUNC);
+    for(auto const& event: story_chunk.logEvents) { data.push_back(event.second); }
+    auto* file = new H5::H5File(story_file_name + ".vlen.h5", H5F_ACC_TRUNC);
     writeVlenBytesEvents(file, data);
     file->flush(H5F_SCOPE_GLOBAL);
     hsize_t file_size = file->getFileSize();
@@ -618,17 +620,19 @@ hsize_t writeStoryChunkUsingVlenBytesEvents(StoryChunk &story_chunk)
     return file_size;
 }
 
-int readStoryChunkUsingVlenBytesEvents(StoryChunk &story_chunk)
+int readStoryChunkUsingVlenBytesEvents(StoryChunk& story_chunk)
 {
-    std::vector <LogEvent> data;
+    std::vector<LogEvent> data;
     data.reserve(story_chunk.getNumEvents());
-    auto*file = new H5::H5File(story_file_name + ".vlen.h5", H5F_ACC_RDONLY);
+    auto* file = new H5::H5File(story_file_name + ".vlen.h5", H5F_ACC_RDONLY);
     readVlenBytesEvents(file, data);
     size_t event_idx = 0;
-    for(auto const &event: data)
+    for(auto const& event: data)
     {
         if(story_chunk.insertEvent(event) == 0)
-        { LOG_ERROR("Failed to insert {}-th event", event_idx); }
+        {
+            LOG_ERROR("Failed to insert {}-th event", event_idx);
+        }
         event_idx++;
     }
     return chronolog::CL_SUCCESS;
@@ -637,15 +641,15 @@ int readStoryChunkUsingVlenBytesEvents(StoryChunk &story_chunk)
 /**********************************************************************************************************************
  * Read/write StoryChunks using blob data and key-value pairs in HDF5
  *********************************************************************************************************************/
-hsize_t writeBlob(H5::H5File*file, void*data, const H5::DataType &type, hsize_t size)
+hsize_t writeBlob(H5::H5File* file, void* data, const H5::DataType& type, hsize_t size)
 {
     try
     {
-        auto*group = new H5::Group(file->createGroup(group_name));
+        auto* group = new H5::Group(file->createGroup(group_name));
 
-        auto*dataspace = new H5::DataSpace(n_dims, &size);
+        auto* dataspace = new H5::DataSpace(n_dims, &size);
 
-        auto*dataset = new H5::DataSet(
+        auto* dataset = new H5::DataSet(
                 file->createDataSet("/" + group_name + "/" + story_chunk_dataset_name + ".data", type, *dataspace));
 
         file->getFileSize();
@@ -658,32 +662,32 @@ hsize_t writeBlob(H5::H5File*file, void*data, const H5::DataType &type, hsize_t 
 
         return size;
     }
-        // catch failure caused by the H5File operations
-    catch(H5::FileIException &error)
+    // catch failure caused by the H5File operations
+    catch(H5::FileIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return -1;
     }
 
-        // catch failure caused by the DataSet operations
-    catch(H5::DataSetIException &error)
+    // catch failure caused by the DataSet operations
+    catch(H5::DataSetIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return -1;
     }
 
-        // catch failure caused by the DataSpace operations
-    catch(H5::DataSpaceIException &error)
+    // catch failure caused by the DataSpace operations
+    catch(H5::DataSpaceIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return -1;
     }
 
-        // catch failure caused by the DataType operations
-    catch(H5::DataTypeIException &error)
+    // catch failure caused by the DataType operations
+    catch(H5::DataTypeIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
@@ -691,7 +695,7 @@ hsize_t writeBlob(H5::H5File*file, void*data, const H5::DataType &type, hsize_t 
     }
 }
 
-int readBlob(H5::H5File*file, void*data, const H5::DataType &type)
+int readBlob(H5::H5File* file, void* data, const H5::DataType& type)
 {
     try
     {
@@ -702,32 +706,32 @@ int readBlob(H5::H5File*file, void*data, const H5::DataType &type)
         dataset.read(data, type);
         return chronolog::CL_SUCCESS;
     }
-        // catch failure caused by the H5File operations
-    catch(H5::FileIException &error)
+    // catch failure caused by the H5File operations
+    catch(H5::FileIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return chronolog::CL_ERR_UNKNOWN;
     }
 
-        // catch failure caused by the DataSet operations
-    catch(H5::DataSetIException &error)
+    // catch failure caused by the DataSet operations
+    catch(H5::DataSetIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return chronolog::CL_ERR_UNKNOWN;
     }
 
-        // catch failure caused by the DataSpace operations
-    catch(H5::DataSpaceIException &error)
+    // catch failure caused by the DataSpace operations
+    catch(H5::DataSpaceIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return chronolog::CL_ERR_UNKNOWN;
     }
 
-        // catch failure caused by the DataType operations
-    catch(H5::DataTypeIException &error)
+    // catch failure caused by the DataType operations
+    catch(H5::DataTypeIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
@@ -764,35 +768,32 @@ H5::CompType createOffsetMapEntryCompoundType()
     return data_type;
 }
 
-int writeMapAsKVPairs(H5::H5File*file, std::map <StoryChunk2::EventSequence, StoryChunk2::EventOffsetSize> &offsetMap)
+int writeMapAsKVPairs(H5::H5File* file, std::map<StoryChunk2::EventSequence, StoryChunk2::EventOffsetSize>& offsetMap)
 {
     try
     {
         hsize_t max_dims = offsetMap.size();
-        auto*dataspace = new H5::DataSpace(n_dims, &max_dims);
+        auto* dataspace = new H5::DataSpace(n_dims, &max_dims);
         auto offset_dtype = createOffsetMapEntryCompoundType();
-        auto*dataset = new H5::DataSet(
-                file->createDataSet("/" + group_name + "/" + story_chunk_dataset_name + ".meta", offset_dtype
-                                    , *dataspace));
-        std::vector <OffsetMapEntry> offsetMapEntries;
+        auto* dataset = new H5::DataSet(file->createDataSet("/" + group_name + "/" + story_chunk_dataset_name + ".meta",
+                                                            offset_dtype,
+                                                            *dataspace));
+        std::vector<OffsetMapEntry> offsetMapEntries;
         offsetMapEntries.reserve(offsetMap.size());
-        for(auto const &entry: offsetMap)
-        {
-            offsetMapEntries.emplace_back(entry.first, entry.second);
-        }
+        for(auto const& entry: offsetMap) { offsetMapEntries.emplace_back(entry.first, entry.second); }
         dataset->write(&offsetMapEntries.front(), offset_dtype);
         delete dataset;
         delete dataspace;
         return chronolog::CL_SUCCESS;
     }
-    catch(H5::Exception &error)
+    catch(H5::Exception& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         return chronolog::CL_ERR_UNKNOWN;
     }
 }
 
-int readMapAsKVPairs(std::map <StoryChunk2::EventSequence, StoryChunk2::EventOffsetSize> &offsetMap, H5::H5File*file)
+int readMapAsKVPairs(std::map<StoryChunk2::EventSequence, StoryChunk2::EventOffsetSize>& offsetMap, H5::H5File* file)
 {
     try
     {
@@ -818,27 +819,24 @@ int readMapAsKVPairs(std::map <StoryChunk2::EventSequence, StoryChunk2::EventOff
             std::cout << "Compound type mismatch" << std::endl;
             return -1;
         }
-        std::vector <OffsetMapEntry> offsetMapEntries;
+        std::vector<OffsetMapEntry> offsetMapEntries;
         offsetMapEntries.resize(dims_out[0]);
         dataset.read(offsetMapEntries.data(), defined_comp_type);
-        for(auto const &entry: offsetMapEntries)
-        {
-            offsetMap.insert({entry.eventId, entry.offsetSize});
-        }
+        for(auto const& entry: offsetMapEntries) { offsetMap.insert({entry.eventId, entry.offsetSize}); }
         return chronolog::CL_SUCCESS;
     }
-    catch(H5::Exception &error)
+    catch(H5::Exception& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         return chronolog::CL_ERR_UNKNOWN;
     }
 }
 
-hsize_t writeStoryChunkUsingBlobAndKVPairs(StoryChunk2 &story_chunk)
+hsize_t writeStoryChunkUsingBlobAndKVPairs(StoryChunk2& story_chunk)
 {
     try
     {
-        auto*file = new H5::H5File(story_file_name + ".blob+map.h5", H5F_ACC_TRUNC);
+        auto* file = new H5::H5File(story_file_name + ".blob+map.h5", H5F_ACC_TRUNC);
         writeBlob(file, story_chunk.eventData, H5::PredType::NATIVE_UINT8, story_chunk.totalSize);
         writeMapAsKVPairs(file, story_chunk.offsetSizeMap);
         file->flush(H5F_SCOPE_GLOBAL);
@@ -847,27 +845,27 @@ hsize_t writeStoryChunkUsingBlobAndKVPairs(StoryChunk2 &story_chunk)
         delete file;
         return file_size;
     }
-    catch(H5::Exception &error)
+    catch(H5::Exception& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         return chronolog::CL_ERR_UNKNOWN;
     }
 }
 
-int readStoryChunkUsingBlobAndKVPairs(StoryChunk2 &story_chunk)
+int readStoryChunkUsingBlobAndKVPairs(StoryChunk2& story_chunk)
 {
     try
     {
-        auto*file = new H5::H5File(story_file_name + ".blob+map.h5", H5F_ACC_RDONLY);
+        auto* file = new H5::H5File(story_file_name + ".blob+map.h5", H5F_ACC_RDONLY);
         H5::Group group = file->openGroup(group_name);
         readMapAsKVPairs(story_chunk.offsetSizeMap, file);
         readBlob(file, story_chunk.eventData, H5::PredType::NATIVE_UINT8);
         delete file;
         uint64_t total_size = 0, total_events = 0;
-        for(auto const &entry: story_chunk.offsetSizeMap)
+        for(auto const& entry: story_chunk.offsetSizeMap)
         {
-            total_size += std::get <1>(entry.second);
-//            total_size += entry.second.size;
+            total_size += std::get<1>(entry.second);
+            //            total_size += entry.second.size;
             total_events++;
         }
         story_chunk.totalSize = total_size;
@@ -875,22 +873,22 @@ int readStoryChunkUsingBlobAndKVPairs(StoryChunk2 &story_chunk)
         story_chunk.currentOffset = total_size;
         return chronolog::CL_SUCCESS;
     }
-    catch(H5::Exception &error)
+    catch(H5::Exception& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         return chronolog::CL_ERR_UNKNOWN;
     }
 }
 
-int rangeQuery(uint64_t start_time, uint64_t end_time, StoryChunk2 &res_story_chunk, void*res_data_blob)
+int rangeQuery(uint64_t start_time, uint64_t end_time, StoryChunk2& res_story_chunk, void* res_data_blob)
 {
     try
     {
-        auto*file = new H5::H5File(story_file_name + ".blob+map.h5", H5F_ACC_RDONLY);
+        auto* file = new H5::H5File(story_file_name + ".blob+map.h5", H5F_ACC_RDONLY);
         H5::Group group = file->openGroup(group_name);
         H5::DataSet dataset = file->openDataSet("/" + group_name + "/" + story_chunk_dataset_name + ".data");
         H5::DataSpace dataspace = dataset.getSpace();
-        std::map <StoryChunk2::EventSequence, StoryChunk2::EventOffsetSize> offsetSizeMap;
+        std::map<StoryChunk2::EventSequence, StoryChunk2::EventOffsetSize> offsetSizeMap;
 
         // read out the entire offsetSizeMap
         readMapAsKVPairs(offsetSizeMap, file);
@@ -899,30 +897,30 @@ int rangeQuery(uint64_t start_time, uint64_t end_time, StoryChunk2 &res_story_ch
         // FIXME: what if the clientId and eventIdx are not 0?
         auto lower_it = offsetSizeMap.lower_bound(StoryChunk2::EventSequence{start_time, 0, 0});
         auto upper_it = offsetSizeMap.upper_bound(StoryChunk2::EventSequence{end_time, 0, 0});
-//        auto start_idx = std::distance(offsetSizeMap.begin(), lower_it);
-//        auto end_idx = std::distance(offsetSizeMap.begin(), upper_it);
-//        auto range_size = std::distance(lower_it, upper_it);
+        //        auto start_idx = std::distance(offsetSizeMap.begin(), lower_it);
+        //        auto end_idx = std::distance(offsetSizeMap.begin(), upper_it);
+        //        auto range_size = std::distance(lower_it, upper_it);
 
         // calculate the total size of the result event payloads
         uint64_t range_data_size = 0;
         for(auto it = lower_it; it != upper_it; it++)
         {
-            auto event_payload_len = std::get <1>(it->second);
-//            LOG_DEBUG("event_payload_len of result event {}: {}", range_offset++, event_payload_len);
+            auto event_payload_len = std::get<1>(it->second);
+            //            LOG_DEBUG("event_payload_len of result event {}: {}", range_offset++, event_payload_len);
             range_data_size += event_payload_len;
         }
         LOG_DEBUG("Total size of result events: {}", range_data_size);
 
         // read out the result event payloads
         res_data_blob = malloc(range_data_size);
-        hsize_t start_offset = std::get <0>(lower_it->second);
+        hsize_t start_offset = std::get<0>(lower_it->second);
         hsize_t data_size = range_data_size;
-//        LOG_DEBUG("Total storage size of dataset: {}", dataset.getStorageSize());
-//        hsize_t ndims = dataspace.getSimpleExtentNdims();
-//        LOG_DEBUG("Dataspace ndims: {}", ndims);
-//        hsize_t dims[2] = {0, 0};
-//        dataspace.getSimpleExtentDims(dims, nullptr);
-//        LOG_DEBUG("Dataspace dims: {} x {}", dims[0], dims[1]);
+        //        LOG_DEBUG("Total storage size of dataset: {}", dataset.getStorageSize());
+        //        hsize_t ndims = dataspace.getSimpleExtentNdims();
+        //        LOG_DEBUG("Dataspace ndims: {}", ndims);
+        //        hsize_t dims[2] = {0, 0};
+        //        dataspace.getSimpleExtentDims(dims, nullptr);
+        //        LOG_DEBUG("Dataspace dims: {} x {}", dims[0], dims[1]);
 
         // select file hyperslab
         LOG_DEBUG("Selecting hyperslab of size {} starting from offset {} ...", data_size, start_offset);
@@ -939,23 +937,23 @@ int rangeQuery(uint64_t start_time, uint64_t end_time, StoryChunk2 &res_story_ch
         dataset.read(res_data_blob, H5::PredType::NATIVE_UINT8, memspace, dataspace);
 
         // fill in the result event vector
-        std::map <StoryChunk2::EventSequence, StoryChunk2::EventOffsetSize> res_offsetSizeMap;
+        std::map<StoryChunk2::EventSequence, StoryChunk2::EventOffsetSize> res_offsetSizeMap;
         for(auto it = lower_it; it != upper_it; it++)
         {
-            uint64_t offset = std::get <0>(it->second) - start_offset;
-            uint64_t size = std::get <1>(it->second);
+            uint64_t offset = std::get<0>(it->second) - start_offset;
+            uint64_t size = std::get<1>(it->second);
             LogEvent event;
             event.storyId = test_story_id;
-            event.eventTime = std::get <0>(it->first);
-            event.clientId = std::get <1>(it->first);
-            event.eventIndex = std::get <2>(it->first);
+            event.eventTime = std::get<0>(it->first);
+            event.clientId = std::get<1>(it->first);
+            event.eventIndex = std::get<2>(it->first);
             event.logRecord.p = (void*)((uint8_t*)res_data_blob + offset);
             event.logRecord.len = size;
             res_story_chunk.insertEvent(event);
         }
         return chronolog::CL_SUCCESS;
     }
-    catch(H5::Exception &error)
+    catch(H5::Exception& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         return chronolog::CL_ERR_UNKNOWN;
@@ -965,11 +963,11 @@ int rangeQuery(uint64_t start_time, uint64_t end_time, StoryChunk2 &res_story_ch
 /**********************************************************************************************************************
  * Utils
  *********************************************************************************************************************/
-void writeEventVectorToFile(std::vector <LogEvent> &data, const std::string &filename)
+void writeEventVectorToFile(std::vector<LogEvent>& data, const std::string& filename)
 {
     std::ofstream outputFile(filename); // Open the file for writing
 
-    for(const auto &entry: data) // Iterate over the vector
+    for(const auto& entry: data) // Iterate over the vector
     {
         outputFile << entry.toString(); // Write each element
         outputFile << "\n";
@@ -979,7 +977,7 @@ void writeEventVectorToFile(std::vector <LogEvent> &data, const std::string &fil
 }
 
 template <typename T>
-void writeStoryChunkToFile(T &story_chunk, const std::string &filename)
+void writeStoryChunkToFile(T& story_chunk, const std::string& filename)
 {
     std::ofstream outputFile(filename); // Open the file for writing
 
@@ -991,13 +989,13 @@ void writeStoryChunkToFile(T &story_chunk, const std::string &filename)
 /**********************************************************************************************************************
  * Read/write StoryChunks using serialized JSON strings in HDF5
  *********************************************************************************************************************/
-std::string serializeStoryChunk(StoryChunk &story_chunk)
+std::string serializeStoryChunk(StoryChunk& story_chunk)
 {
-    json_object*obj = json_object_new_object();
+    json_object* obj = json_object_new_object();
     std::string story_chunk_name =
             std::to_string(story_chunk.getStartTime()) + "_" + std::to_string(story_chunk.getEndTime());
     std::string story_chunk_str = story_chunk.toString();
-    json_object*story_chunk_json_array = json_object_new_array();
+    json_object* story_chunk_json_array = json_object_new_array();
     for(unsigned long i = 0; i < story_chunk_str.size() / 4; i++)
     {
         json_object_array_add(story_chunk_json_array, json_object_new_int(story_chunk_str.c_str()[i]));
@@ -1007,9 +1005,9 @@ std::string serializeStoryChunk(StoryChunk &story_chunk)
     return {json_object_to_json_string(obj)};
 }
 
-StoryChunk deserializeStoryChunk(char*story_chunk_json_str, uint64_t &story_id, uint64_t start_time, uint64_t end_time)
+StoryChunk deserializeStoryChunk(char* story_chunk_json_str, uint64_t& story_id, uint64_t start_time, uint64_t end_time)
 {
-    struct json_object*obj = json_tokener_parse(story_chunk_json_str);
+    struct json_object* obj = json_tokener_parse(story_chunk_json_str);
     StoryChunk story_chunk(story_id, start_time, end_time);
     enum json_type type = json_object_get_type(obj);
     if(type == json_type_object)
@@ -1029,14 +1027,16 @@ StoryChunk deserializeStoryChunk(char*story_chunk_json_str, uint64_t &story_id, 
             uint32_t client_id = std::stoul(key_str.substr(comma_pos1 + 2, comma_pos2 - comma_pos1 - 2));
             uint32_t index = std::stoul(key_str.substr(comma_pos2 + 2, closing_bracket_pos - comma_pos2 - 2));
 
-//            LOG_DEBUG("val: {}", json_object_get_string(val));
+            //            LOG_DEBUG("val: {}", json_object_get_string(val));
             hvl_t log_record;
             log_record.p = (void*)json_object_get_string(val);
             log_record.len = strlen(json_object_get_string(val));
             LogEvent event(story_id, event_time, client_id, index, log_record);
             if(story_chunk.insertEvent(event) == 0)
-            { LOG_ERROR("Failed to insert event"); }
-//            LOG_DEBUG("#Events: {}", story_chunk.getNumEvents());
+            {
+                LOG_ERROR("Failed to insert event");
+            }
+            //            LOG_DEBUG("#Events: {}", story_chunk.getNumEvents());
         }
     }
     else
@@ -1044,27 +1044,27 @@ StoryChunk deserializeStoryChunk(char*story_chunk_json_str, uint64_t &story_id, 
         LOG_ERROR("Failed to parse story_chunk_json_str: {}", story_chunk_json_str);
         exit(chronolog::CL_ERR_UNKNOWN);
     }
-//    LOG_DEBUG("#Events: {}", story_chunk.getNumEvents());
+    //    LOG_DEBUG("#Events: {}", story_chunk.getNumEvents());
     return story_chunk;
 }
 
-hsize_t writeStoryChunkInJSON(StoryChunk &story_chunk)
+hsize_t writeStoryChunkInJSON(StoryChunk& story_chunk)
 {
     try
     {
-        auto*file = new H5::H5File(ref_json_file_name, H5F_ACC_TRUNC);
+        auto* file = new H5::H5File(ref_json_file_name, H5F_ACC_TRUNC);
 
-        auto*group = new H5::Group(file->createGroup(group_name));
+        auto* group = new H5::Group(file->createGroup(group_name));
 
         std::string story_chunk_json_str = serializeStoryChunk(story_chunk);
-//        LOG_DEBUG("size of story_chunk_json_str: {}", story_chunk_json_str.size());
+        //        LOG_DEBUG("size of story_chunk_json_str: {}", story_chunk_json_str.size());
 
         hsize_t dims[] = {1};
-        auto*dataspace = new H5::DataSpace(n_dims, dims);
+        auto* dataspace = new H5::DataSpace(n_dims, dims);
 
         H5::StrType datatype(H5::PredType::C_S1, H5T_VARIABLE);
-        H5::DataSet dataset = file->createDataSet("/" + group_name + "/" + story_chunk_dataset_name + ".json", datatype
-                                                  , *dataspace);
+        H5::DataSet dataset =
+                file->createDataSet("/" + group_name + "/" + story_chunk_dataset_name + ".json", datatype, *dataspace);
 
         dataset.write(story_chunk_json_str, datatype);
 
@@ -1077,32 +1077,32 @@ hsize_t writeStoryChunkInJSON(StoryChunk &story_chunk)
 
         return file_size;
     }
-        // catch failure caused by the H5File operations
-    catch(H5::FileIException &error)
+    // catch failure caused by the H5File operations
+    catch(H5::FileIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return chronolog::CL_ERR_UNKNOWN;
     }
 
-        // catch failure caused by the DataSet operations
-    catch(H5::DataSetIException &error)
+    // catch failure caused by the DataSet operations
+    catch(H5::DataSetIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return chronolog::CL_ERR_UNKNOWN;
     }
 
-        // catch failure caused by the DataSpace operations
-    catch(H5::DataSpaceIException &error)
+    // catch failure caused by the DataSpace operations
+    catch(H5::DataSpaceIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return chronolog::CL_ERR_UNKNOWN;
     }
 
-        // catch failure caused by the DataType operations
-    catch(H5::DataTypeIException &error)
+    // catch failure caused by the DataType operations
+    catch(H5::DataTypeIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
@@ -1110,7 +1110,7 @@ hsize_t writeStoryChunkInJSON(StoryChunk &story_chunk)
     }
 }
 
-int readStoryChunkInJSON(StoryChunk &story_chunk)
+int readStoryChunkInJSON(StoryChunk& story_chunk)
 {
     try
     {
@@ -1127,32 +1127,32 @@ int readStoryChunkInJSON(StoryChunk &story_chunk)
         story_chunk = deserializeStoryChunk((char*)story_chunk_json_str.c_str(), story_id, 0, 0);
         return chronolog::CL_SUCCESS;
     }
-        // catch failure caused by the H5File operations
-    catch(H5::FileIException &error)
+    // catch failure caused by the H5File operations
+    catch(H5::FileIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return chronolog::CL_ERR_UNKNOWN;
     }
 
-        // catch failure caused by the DataSet operations
-    catch(H5::DataSetIException &error)
+    // catch failure caused by the DataSet operations
+    catch(H5::DataSetIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return chronolog::CL_ERR_UNKNOWN;
     }
 
-        // catch failure caused by the DataSpace operations
-    catch(H5::DataSpaceIException &error)
+    // catch failure caused by the DataSpace operations
+    catch(H5::DataSpaceIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
         return chronolog::CL_ERR_UNKNOWN;
     }
 
-        // catch failure caused by the DataType operations
-    catch(H5::DataTypeIException &error)
+    // catch failure caused by the DataType operations
+    catch(H5::DataTypeIException& error)
     {
         std::cout << error.getCDetailMsg() << std::endl;
         H5::FileIException::printErrorStack();
@@ -1160,10 +1160,15 @@ int readStoryChunkInJSON(StoryChunk &story_chunk)
     }
 }
 
-int main(int argc, char*argv[])
+int main(int argc, char* argv[])
 {
-    int result = chronolog::chrono_monitor::initialize("console", "cmp_vlen_bytes_vs_blob_map.log", spdlog::level::debug
-                                                       , "cmp_vlen_bytes_vs_blob_map", 102400, 1, spdlog::level::debug);
+    int result = chronolog::chrono_monitor::initialize("console",
+                                                       "cmp_vlen_bytes_vs_blob_map.log",
+                                                       spdlog::level::debug,
+                                                       "cmp_vlen_bytes_vs_blob_map",
+                                                       102400,
+                                                       1,
+                                                       spdlog::level::debug);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
@@ -1171,7 +1176,7 @@ int main(int argc, char*argv[])
 
     parseCommandLineOptions(argc, argv);
 
-    std::chrono::time_point <std::chrono::high_resolution_clock> start, end;
+    std::chrono::time_point<std::chrono::high_resolution_clock> start, end;
     uint64_t file_size;
     long duration_ns;
     double duration_s;
@@ -1196,10 +1201,11 @@ int main(int argc, char*argv[])
         file_size = writeStoryChunkUsingVlenBytesEvents(wdata);
         end = std::chrono::high_resolution_clock::now();
         storage_efficiency = (double)total_story_chunk_size / (double)file_size;
-        duration_ns = std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count();
+        duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
         duration_s = (double)duration_ns / 1e9;
         std::cout << std::endl << "Storage efficiency of events: " << storage_efficiency * 100 << "%" << std::endl;
-        std::cout << std::endl << "Time taken to write events: " << duration_s << " seconds" << std::endl
+        std::cout << std::endl
+                  << "Time taken to write events: " << duration_s << " seconds" << std::endl
                   << "Write bandwidth: " << ((double)total_story_chunk_size / (1e+6 * duration_s)) << " MB/second"
                   << std::endl;
 
@@ -1208,20 +1214,23 @@ int main(int argc, char*argv[])
         start = std::chrono::high_resolution_clock::now();
         readStoryChunkUsingVlenBytesEvents(rdata);
         end = std::chrono::high_resolution_clock::now();
-        duration_ns = std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count();
+        duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
         duration_s = (double)duration_ns / 1e9;
-        std::cout << std::endl << "Time taken to read events: " << duration_s / 1e9 << " seconds" << std::endl
+        std::cout << std::endl
+                  << "Time taken to read events: " << duration_s / 1e9 << " seconds" << std::endl
                   << "Read bandwidth: " << ((double)total_story_chunk_size / (1e+6 * duration_s)) << " MB/second"
                   << std::endl;
 
         if(wdata != rdata)
         {
-            std::cerr << "\n\n" << "Writing events using vlen-bytes datatype: Data mismatch" << "\n\n" << std::endl;
+            std::cerr << "\n\n"
+                      << "Writing events using vlen-bytes datatype: Data mismatch" << "\n\n"
+                      << std::endl;
             std::cout << "Data written:" << wdata.toString() << std::endl;
             std::cout << "Data read:" << rdata.toString() << std::endl;
             writeStoryChunkToFile(wdata, "wdata.txt");
             writeStoryChunkToFile(rdata, "rdata.txt");
-//        return -1;
+            //        return -1;
         }
     }
 
@@ -1241,11 +1250,12 @@ int main(int argc, char*argv[])
         start = std::chrono::high_resolution_clock::now();
         file_size = writeStoryChunkUsingBlobAndKVPairs(wdata2);
         end = std::chrono::high_resolution_clock::now();
-        duration_ns = std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count();
+        duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
         duration_s = (double)duration_ns / 1e9;
         storage_efficiency = (double)total_story_chunk_size / (double)file_size;
         std::cout << std::endl << "Storage efficiency of blob+map: " << storage_efficiency * 100 << "%" << std::endl;
-        std::cout << std::endl << "Time taken to write blob+map: " << duration_s / 1e9 << " seconds" << std::endl
+        std::cout << std::endl
+                  << "Time taken to write blob+map: " << duration_s / 1e9 << " seconds" << std::endl
                   << "Write bandwidth: " << ((double)total_story_chunk_size / (1e+6 * duration_s)) << " MB/second"
                   << std::endl;
 
@@ -1253,37 +1263,42 @@ int main(int argc, char*argv[])
         start = std::chrono::high_resolution_clock::now();
         readStoryChunkUsingBlobAndKVPairs(rdata2);
         end = std::chrono::high_resolution_clock::now();
-        duration_ns = std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count();
+        duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
         duration_s = (double)duration_ns / 1e9;
-        std::cout << std::endl << "Time taken to read blob: " << duration_s / 1e9 << " seconds" << std::endl
+        std::cout << std::endl
+                  << "Time taken to read blob: " << duration_s / 1e9 << " seconds" << std::endl
                   << "Read bandwidth: " << ((double)total_story_chunk_size / (1e+6 * duration_s)) << " MB/second"
                   << std::endl;
 
         if(wdata2 != rdata2)
         {
-            std::cerr << "\n\n" << "Writing events as blob+metadata kv-pairs: Data mismatch" << "\n\n" << std::endl;
-//        std::cout << "Data written:" << wdata2.toString() << std::endl;
-//        std::cout << "Data read:" << rdata2.toString() << std::endl;
+            std::cerr << "\n\n"
+                      << "Writing events as blob+metadata kv-pairs: Data mismatch" << "\n\n"
+                      << std::endl;
+            //        std::cout << "Data written:" << wdata2.toString() << std::endl;
+            //        std::cout << "Data read:" << rdata2.toString() << std::endl;
             writeStoryChunkToFile(wdata2, "wdata2.txt");
             writeStoryChunkToFile(rdata2, "rdata2.txt");
-//        return -1;
+            //        return -1;
         }
 
         /*
          * Range query
          */
-//        size_t idx = 0;
-//        for(auto const &event: events)
-//        {
-//            LOG_DEBUG("Raw event {}: {}", idx++, event.toString().c_str());
-//        }
+        //        size_t idx = 0;
+        //        for(auto const &event: events)
+        //        {
+        //            LOG_DEBUG("Raw event {}: {}", idx++, event.toString().c_str());
+        //        }
         for(auto start_percent = range_start_percentage, end_percent = range_start_percentage + range_step_percentage;
-            end_percent <= range_end_percentage; end_percent += range_step_percentage)
+            end_percent <= range_end_percentage;
+            end_percent += range_step_percentage)
         {
             std::cout << "======================================================================================="
                       << std::endl;
-            StoryChunk2 res_story_chunk(test_story_id, test_start_timestamp,
-                    test_start_timestamp + n_records * 1000 + 1);
+            StoryChunk2 res_story_chunk(test_story_id,
+                                        test_start_timestamp,
+                                        test_start_timestamp + n_records * 1000 + 1);
             auto range_event_time_start_offset =
                     (events.back().eventTime - events.front().eventTime) * start_percent / 100;
             auto range_event_time_end_offset = (events.back().eventTime - events.front().eventTime) * end_percent / 100;
@@ -1296,8 +1311,9 @@ int main(int argc, char*argv[])
             auto start_idx = static_cast<int>(events.size() * start_percent / 100);
             auto end_idx = static_cast<int>(events.size() * end_percent / 100);
             LOG_DEBUG("Expected result events range from {} to {}", start_idx, end_idx);
-            StoryChunk2 expected_res_story_chunk(test_story_id, test_start_timestamp,
-                    test_start_timestamp + n_records * 1000 + 1);
+            StoryChunk2 expected_res_story_chunk(test_story_id,
+                                                 test_start_timestamp,
+                                                 test_start_timestamp + n_records * 1000 + 1);
             uint64_t total_res_payload_size = 0;
             for(auto i = start_idx; i < end_idx; i++)
             {
@@ -1305,20 +1321,23 @@ int main(int argc, char*argv[])
                 total_res_payload_size += events[i].logRecord.len;
             }
             LOG_DEBUG("Total size of expected result event payloads: {}", total_res_payload_size);
-            void*res_data_blob = nullptr;
+            void* res_data_blob = nullptr;
 
             // test rangeQuery
             start = std::chrono::high_resolution_clock::now();
             rangeQuery(range_start_time, range_end_time, res_story_chunk, res_data_blob);
             end = std::chrono::high_resolution_clock::now();
-            duration_ns = std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count();
+            duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
             duration_s = (double)duration_ns / 1e9;
-            std::cout << std::endl << "Time taken to range query: " << duration_s / 1e9 << " seconds" << std::endl
+            std::cout << std::endl
+                      << "Time taken to range query: " << duration_s / 1e9 << " seconds" << std::endl
                       << "Read bandwidth: " << ((double)total_res_payload_size / (1e+6 * duration_s)) << " MB/second"
                       << std::endl;
             if(res_story_chunk != expected_res_story_chunk)
             {
-                std::cerr << "\n\n" << "Range query: Data mismatch" << "\n\n" << std::endl;
+                std::cerr << "\n\n"
+                          << "Range query: Data mismatch" << "\n\n"
+                          << std::endl;
                 writeStoryChunkToFile(expected_res_story_chunk, "expected_res_story_chunk.txt");
                 writeStoryChunkToFile(res_story_chunk, "res_story_chunk.txt");
                 free(res_data_blob);

--- a/ChronoStore/test/cmp_vlen_bytes_vs_blob_map.cpp
+++ b/ChronoStore/test/cmp_vlen_bytes_vs_blob_map.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <string>
 #include <chrono>
+#include <cstdlib>
+#include <cstring>
 #include <H5Cpp.h>
 #include <utility>
 #include <vector>

--- a/ChronoStore/test/cmp_vlen_str_dtype_test.cpp
+++ b/ChronoStore/test/cmp_vlen_str_dtype_test.cpp
@@ -44,7 +44,7 @@ typedef struct LogEvent
     ClientId clientId;
     uint32_t eventIndex;
     uint64_t logRecordSize;
-    char*logRecord;
+    char* logRecord;
 } LogEvent;
 
 LogEvent g_events[3];
@@ -56,58 +56,52 @@ typedef struct StoryChunk
     uint64_t endTime;
     uint64_t revisionTime;
     uint64_t numLogEvents;
-    LogEvent*logEvents;
+    LogEvent* logEvents;
 
-    [[nodiscard]] uint64_t getStoryID() const
-    { return storyId; }
+    [[nodiscard]] uint64_t getStoryID() const { return storyId; }
 
-    [[nodiscard]] uint64_t getStartTime() const
-    { return startTime; }
+    [[nodiscard]] uint64_t getStartTime() const { return startTime; }
 
-    [[nodiscard]] uint64_t getEndTime() const
-    { return endTime; }
+    [[nodiscard]] uint64_t getEndTime() const { return endTime; }
 
-    [[nodiscard]] uint64_t getNumEvents() const
-    { return numLogEvents; }
+    [[nodiscard]] uint64_t getNumEvents() const { return numLogEvents; }
 
-    [[nodiscard]] uint64_t getRevisionTime() const
-    { return revisionTime; }
+    [[nodiscard]] uint64_t getRevisionTime() const { return revisionTime; }
 
-    [[nodiscard]] LogEvent*getLogEvents() const
-    { return logEvents; }
+    [[nodiscard]] LogEvent* getLogEvents() const { return logEvents; }
 
     [[nodiscard]] size_t getTotalPayloadSize() const
     {
         size_t total_size = 0;
-        for(uint64_t i = 0; i < numLogEvents; i++)
-        { total_size += strlen(logEvents[i].logRecord) + 1; }
+        for(uint64_t i = 0; i < numLogEvents; i++) { total_size += strlen(logEvents[i].logRecord) + 1; }
         return total_size;
     }
 } StoryChunk;
 
-void freeLogEvent(LogEvent &event)
-{
-    delete[] event.logRecord;
-}
+void freeLogEvent(LogEvent& event) { delete[] event.logRecord; }
 
-void freeStoryChunk(StoryChunk &chunk)
+void freeStoryChunk(StoryChunk& chunk)
 {
-    for(uint64_t i = 0; i < chunk.numLogEvents; i++)
-    {
-        freeLogEvent(chunk.logEvents[i]);
-    }
+    for(uint64_t i = 0; i < chunk.numLogEvents; i++) { freeLogEvent(chunk.logEvents[i]); }
     delete[] chunk.logEvents;
 }
 
-StoryChunk*generateStoryChunkArray(uint64_t story_id, uint64_t client_id, uint64_t start_time, uint64_t time_step
-                                   , uint64_t end_time, uint64_t mean_event_size, uint64_t min_event_size
-                                   , uint64_t max_event_size, double stddev, uint64_t num_events_per_story_chunk
-                                   , uint64_t num_story_chunks)
+StoryChunk* generateStoryChunkArray(uint64_t story_id,
+                                    uint64_t client_id,
+                                    uint64_t start_time,
+                                    uint64_t time_step,
+                                    uint64_t end_time,
+                                    uint64_t mean_event_size,
+                                    uint64_t min_event_size,
+                                    uint64_t max_event_size,
+                                    double stddev,
+                                    uint64_t num_events_per_story_chunk,
+                                    uint64_t num_story_chunks)
 {
-    auto*story_chunk_array = new StoryChunk[num_story_chunks];
+    auto* story_chunk_array = new StoryChunk[num_story_chunks];
     std::random_device rd;
     std::mt19937_64 rng(rd());
-    std::normal_distribution <double> event_size_dist((double)mean_event_size, stddev);
+    std::normal_distribution<double> event_size_dist((double)mean_event_size, stddev);
 
     for(uint64_t i = 0; i < num_story_chunks; i++)
     {
@@ -125,8 +119,9 @@ StoryChunk*generateStoryChunkArray(uint64_t story_id, uint64_t client_id, uint64
             story_chunk_array[i].logEvents[j].clientId = client_id;
             story_chunk_array[i].logEvents[j].eventIndex = j;
             auto log_record_size = (size_t)event_size_dist(rng);
-            log_record_size = log_record_size < min_event_size ? min_event_size : log_record_size > max_event_size
-                                                                                  ? max_event_size : log_record_size;
+            log_record_size = log_record_size < min_event_size   ? min_event_size
+                              : log_record_size > max_event_size ? max_event_size
+                                                                 : log_record_size;
             story_chunk_array[i].logEvents[j].logRecordSize = log_record_size;
             story_chunk_array[i].logEvents[j].logRecord = new char[log_record_size + 1];
             for(uint64_t k = 0; k < log_record_size; k++)
@@ -142,15 +137,22 @@ StoryChunk*generateStoryChunkArray(uint64_t story_id, uint64_t client_id, uint64
     return story_chunk_array;
 }
 
-std::map <uint64_t, StoryChunk>
-generateStoryChunkMap(uint64_t story_id, uint64_t client_id, uint64_t start_time, uint64_t time_step, uint64_t end_time
-                      , uint64_t mean_event_size, uint64_t min_event_size, uint64_t max_event_size, double stddev
-                      , uint64_t num_events_per_story_chunk, uint64_t num_story_chunks)
+std::map<uint64_t, StoryChunk> generateStoryChunkMap(uint64_t story_id,
+                                                     uint64_t client_id,
+                                                     uint64_t start_time,
+                                                     uint64_t time_step,
+                                                     uint64_t end_time,
+                                                     uint64_t mean_event_size,
+                                                     uint64_t min_event_size,
+                                                     uint64_t max_event_size,
+                                                     double stddev,
+                                                     uint64_t num_events_per_story_chunk,
+                                                     uint64_t num_story_chunks)
 {
-    std::map <uint64_t, StoryChunk> story_chunk_map;
+    std::map<uint64_t, StoryChunk> story_chunk_map;
     std::random_device rd;
     std::mt19937_64 rng(rd());
-    std::normal_distribution <double> event_size_dist((double)mean_event_size, stddev);
+    std::normal_distribution<double> event_size_dist((double)mean_event_size, stddev);
 
     for(uint64_t i = 0; i < num_story_chunks; i++)
     {
@@ -169,8 +171,9 @@ generateStoryChunkMap(uint64_t story_id, uint64_t client_id, uint64_t start_time
             story_chunk.logEvents[j].clientId = client_id;
             story_chunk.logEvents[j].eventIndex = j;
             auto log_record_size = (size_t)event_size_dist(rng);
-            log_record_size = log_record_size < min_event_size ? min_event_size : log_record_size > max_event_size
-                                                                                  ? max_event_size : log_record_size;
+            log_record_size = log_record_size < min_event_size   ? min_event_size
+                              : log_record_size > max_event_size ? max_event_size
+                                                                 : log_record_size;
             story_chunk.logEvents[j].logRecordSize = log_record_size;
             story_chunk.logEvents[j].logRecord = new char[log_record_size + 1];
             for(uint64_t k = 0; k < log_record_size; k++)
@@ -187,7 +190,7 @@ generateStoryChunkMap(uint64_t story_id, uint64_t client_id, uint64_t start_time
     return story_chunk_map;
 }
 
-int main(int argc, char*argv[])
+int main(int argc, char* argv[])
 {
     if(argc < 8)
     {
@@ -198,11 +201,11 @@ int main(int argc, char*argv[])
     }
     int i, nCount = 3;
     size_t len;
-    char*bptr;
-    char const*str[] = {"Wake Me up When", "September", "Ends"};
+    char* bptr;
+    char const* str[] = {"Wake Me up When", "September", "Ends"};
     std::random_device rd;
     std::mt19937_64 rng(rd());
-    std::uniform_int_distribution <uint64_t> dist(0, UINT64_MAX);
+    std::uniform_int_distribution<uint64_t> dist(0, UINT64_MAX);
     uint64_t num_story_chunks = strtol(argv[1], nullptr, 10);
     uint64_t num_events_per_story_chunk = strtol(argv[2], nullptr, 10);
     uint64_t mean_event_size = strtol(argv[3], nullptr, 10);
@@ -216,18 +219,27 @@ int main(int argc, char*argv[])
     uint64_t story_id = STORY_ID; //dist(rng);
     uint64_t client_id = CLIENT_ID;
 
-    int result = chronolog::chrono_monitor::initialize("console", "cmp_vlen_str_dtype_test.log", spdlog::level::debug
-                                                       , "cmp_vlen_str_dtype_test", 102400, 1, spdlog::level::debug);
+    int result = chronolog::chrono_monitor::initialize("console",
+                                                       "cmp_vlen_str_dtype_test.log",
+                                                       spdlog::level::debug,
+                                                       "cmp_vlen_str_dtype_test",
+                                                       102400,
+                                                       1,
+                                                       spdlog::level::debug);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
     }
 
-    std::cout << "StoryID: " << story_id << std::endl << "#StoryChunks: " << num_story_chunks << std::endl
-              << "#EventsInEachChunk: " << num_events_per_story_chunk << std::endl << "meanEventSize: "
-              << mean_event_size << std::endl << "minEventSize: " << min_event_size << std::endl << "maxEventSize: "
-              << max_event_size << std::endl << "stddev: " << stddev << std::endl << "startTime: " << start_time
-              << std::endl << "endTime: " << end_time << std::endl;
+    std::cout << "StoryID: " << story_id << std::endl
+              << "#StoryChunks: " << num_story_chunks << std::endl
+              << "#EventsInEachChunk: " << num_events_per_story_chunk << std::endl
+              << "meanEventSize: " << mean_event_size << std::endl
+              << "minEventSize: " << min_event_size << std::endl
+              << "maxEventSize: " << max_event_size << std::endl
+              << "stddev: " << stddev << std::endl
+              << "startTime: " << start_time << std::endl
+              << "endTime: " << end_time << std::endl;
 
     for(i = 0; i < nCount; i++)
     {
@@ -250,69 +262,77 @@ int main(int argc, char*argv[])
     // Generate StoryChunks
     std::cout << "Generating StoryChunks..." << std::endl;
     uint64_t time_step = (end_time - start_time) / num_events_per_story_chunk;
-//    StoryChunk*story_chunk_array = generateStoryChunkArray(story_id, client_id, start_time, time_step, end_time
-//                                                           , mean_event_size, min_event_size, max_event_size, stddev
-//                                                           , num_events_per_story_chunk, num_story_chunks);
-    std::map <uint64_t, StoryChunk> story_chunk_map = generateStoryChunkMap(story_id, client_id, start_time, time_step
-                                                                            , end_time, mean_event_size, min_event_size
-                                                                            , max_event_size, stddev
-                                                                            , num_events_per_story_chunk
-                                                                            , num_story_chunks);
+    //    StoryChunk*story_chunk_array = generateStoryChunkArray(story_id, client_id, start_time, time_step, end_time
+    //                                                           , mean_event_size, min_event_size, max_event_size, stddev
+    //                                                           , num_events_per_story_chunk, num_story_chunks);
+    std::map<uint64_t, StoryChunk> story_chunk_map = generateStoryChunkMap(story_id,
+                                                                           client_id,
+                                                                           start_time,
+                                                                           time_step,
+                                                                           end_time,
+                                                                           mean_event_size,
+                                                                           min_event_size,
+                                                                           max_event_size,
+                                                                           stddev,
+                                                                           num_events_per_story_chunk,
+                                                                           num_story_chunks);
 
     hsize_t total_num_events = 0;
-    std::vector <hsize_t> num_events;
+    std::vector<hsize_t> num_events;
     for(uint64_t j = 0; j < num_story_chunks; j++)
     {
-//        hsize_t num_events_per_chunk = story_chunk_array[j].getNumEvents();
+        //        hsize_t num_events_per_chunk = story_chunk_array[j].getNumEvents();
         hsize_t num_events_per_chunk = story_chunk_map[j].getNumEvents();
         num_events.push_back(num_events_per_chunk);
         total_num_events += num_events_per_chunk;
     }
 
     // Check if the directory for the Chronicle already exists
-    struct stat st{};
+    struct stat st
+    {
+    };
     std::string chronicle_dir = CHRONICLE_ROOT_DIR + chronicle_name;
-//    if (stat(chronicle_dir.c_str(), &st) != 0 || ! S_ISDIR(st.st_mode))
-//    {
-//        // Create the directory for the Chronicle
-//        if (!std::filesystem::create_directory(chronicle_dir.c_str()))
-//        {
-//            LOG_ERROR("Failed to create chronicle directory: {}, errno: {}", chronicle_dir.c_str(), errno);
-//            return chronolog::CL_ERR_UNKNOWN;
-//        }
-//    }
+    //    if (stat(chronicle_dir.c_str(), &st) != 0 || ! S_ISDIR(st.st_mode))
+    //    {
+    //        // Create the directory for the Chronicle
+    //        if (!std::filesystem::create_directory(chronicle_dir.c_str()))
+    //        {
+    //            LOG_ERROR("Failed to create chronicle directory: {}, errno: {}", chronicle_dir.c_str(), errno);
+    //            return chronolog::CL_ERR_UNKNOWN;
+    //        }
+    //    }
 
     herr_t status;
     auto story_chunk_map_it = story_chunk_map.begin();
-    std::unordered_map <uint64_t, hid_t> story_chunk_fd_map;
+    std::unordered_map<uint64_t, hid_t> story_chunk_fd_map;
     for(; story_chunk_map_it != story_chunk_map.end(); story_chunk_map_it++)
-//    for (uint64_t i = 0; i < 1; i++)
+    //    for (uint64_t i = 0; i < 1; i++)
     {
         StoryChunk story_chunk = story_chunk_map_it->second;
-//        StoryChunk story_chunk = story_chunk_array[i];
+        //        StoryChunk story_chunk = story_chunk_array[i];
         // Check if the Story file has been opened/created already
         hid_t story_file;
         story_id = story_chunk.getStoryID();
         std::string story_file_name = chronicle_dir + "/" + std::to_string(story_id);
         story_file = H5Fcreate(story_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
         LOG_DEBUG("H5Fcreate returns: {}", story_file);
-//        if (story_chunk_fd_map.find(story_id) != story_chunk_fd_map.end())
-//        {
-//            story_file = story_chunk_fd_map.find(story_id)->second;
-//            LOG_DEBUG("Story file already opened: {}", story_file_name.c_str());
-//        }
+        //        if (story_chunk_fd_map.find(story_id) != story_chunk_fd_map.end())
+        //        {
+        //            story_file = story_chunk_fd_map.find(story_id)->second;
+        //            LOG_DEBUG("Story file already opened: {}", story_file_name.c_str());
+        //        }
         // Story file does not exist, create the Story file if it does not exist
-//        else if (stat(story_file_name.c_str(), &st) != 0)
-//        {
-//            story_file = H5Fcreate(story_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-//            if (story_file == H5I_INVALID_HID)
-//            {
-//                LOG_ERROR("Failed to create story file: {}", story_file_name.c_str());
-//                return chronolog::CL_ERR_UNKNOWN;
-//            }
-//            story_chunk_fd_map.emplace(story_id, story_file);
-//        }
-//        else
+        //        else if (stat(story_file_name.c_str(), &st) != 0)
+        //        {
+        //            story_file = H5Fcreate(story_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+        //            if (story_file == H5I_INVALID_HID)
+        //            {
+        //                LOG_ERROR("Failed to create story file: {}", story_file_name.c_str());
+        //                return chronolog::CL_ERR_UNKNOWN;
+        //            }
+        //            story_chunk_fd_map.emplace(story_id, story_file);
+        //        }
+        //        else
         {
             // Open the Story file if it exists
             story_file = H5Fopen(story_file_name.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
@@ -321,7 +341,7 @@ int main(int argc, char*argv[])
                 LOG_ERROR("Failed to open story file: {}", story_file_name.c_str());
                 return chronolog::CL_ERR_UNKNOWN;
             }
-//            story_chunk_fd_map.emplace(story_id, story_file);
+            //            story_chunk_fd_map.emplace(story_id, story_file);
         }
 
         // Check if the dataset for the Story Chunk exists
@@ -384,10 +404,15 @@ int main(int argc, char*argv[])
         hsize_t story_chunk_dset_chunk_dims[1] = {1}; //{ story_chunk.getNumEvents() };
         status = H5Pset_chunk(story_chunk_dset_creation_plist, DATASET_RANK, story_chunk_dset_chunk_dims);
         LOG_DEBUG("H5Pset_chunk returns: {}", status);
-//        story_chunk_dset = H5Dcreate2(story_file, story_chunk_dset_name.c_str(), story_chunk_type, story_chunk_dspace,
-//                                      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        story_chunk_dset = H5Dcreate(story_file, ("/" + story_chunk_dset_name).c_str(), log_event_type
-                                     , story_chunk_dspace, H5P_DEFAULT, story_chunk_dset_creation_plist, H5P_DEFAULT);
+        //        story_chunk_dset = H5Dcreate2(story_file, story_chunk_dset_name.c_str(), story_chunk_type, story_chunk_dspace,
+        //                                      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        story_chunk_dset = H5Dcreate(story_file,
+                                     ("/" + story_chunk_dset_name).c_str(),
+                                     log_event_type,
+                                     story_chunk_dspace,
+                                     H5P_DEFAULT,
+                                     story_chunk_dset_creation_plist,
+                                     H5P_DEFAULT);
         status = H5Pclose(story_chunk_dset_creation_plist);
         LOG_DEBUG("H5Pclose returns: {}", status);
         if(story_chunk_dset < 0)
@@ -398,29 +423,29 @@ int main(int argc, char*argv[])
 
         // Create a contiguous memory space for the variable-length data
         // A end-of-string character is appended to each string
-//        char *event_payload_data = new char[story_chunk.getTotalPayloadSize()];
-//        size_t offset = 0;
-//        LogEvent *log_events = story_chunk.getLogEvents();
-//        for (int i = 0; i < story_chunk.getNumEvents(); ++i)
-//        {
-//            memcpy(event_payload_data + offset,
-//                   log_events[i].logRecord,
-//                   log_events[i].getPayloadSize());
-//            offset += log_events[i].getPayloadSize();
-//            event_payload_data[offset] = '\0';
-//            offset += 1;
-//        }
+        //        char *event_payload_data = new char[story_chunk.getTotalPayloadSize()];
+        //        size_t offset = 0;
+        //        LogEvent *log_events = story_chunk.getLogEvents();
+        //        for (int i = 0; i < story_chunk.getNumEvents(); ++i)
+        //        {
+        //            memcpy(event_payload_data + offset,
+        //                   log_events[i].logRecord,
+        //                   log_events[i].getPayloadSize());
+        //            offset += log_events[i].getPayloadSize();
+        //            event_payload_data[offset] = '\0';
+        //            offset += 1;
+        //        }
 
         // Write the Story Chunk to the dataset
         LOG_DEBUG("{}", story_chunk.logEvents[0].logRecord[0]);
         LOG_DEBUG("{}", story_chunk.logEvents[0].logRecord[7]);
         LOG_DEBUG("{}", story_chunk.logEvents[9].logRecord[0]);
         LOG_DEBUG("{}", story_chunk.logEvents[9].logRecord[7]);
-//        status = H5Dwrite(story_chunk_dset, H5T_NATIVE_B8, H5S_ALL, H5S_ALL, H5P_DEFAULT,
-//                          &story_chunk_map_it->second);
+        //        status = H5Dwrite(story_chunk_dset, H5T_NATIVE_B8, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+        //                          &story_chunk_map_it->second);
         status = H5Dwrite(story_chunk_dset, log_event_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, &story_chunk.logEvents);
         LOG_DEBUG("H5Dwrite returns: {}", status);
-//        free(event_payload_data);
+        //        free(event_payload_data);
         if(status < 0)
         {
             LOG_ERROR("Failed to write story chunk to dataset: {}", story_chunk_dset_name.c_str());
@@ -428,12 +453,15 @@ int main(int argc, char*argv[])
             H5Eprint(H5E_DEFAULT, stderr);
 
             // Get the error stack and retrieve the error message
-            H5Ewalk2(H5E_DEFAULT, H5E_WALK_DOWNWARD
-                     , [](unsigned n, const H5E_error2_t*err_desc, void*client_data) -> herr_t
+            H5Ewalk2(
+                    H5E_DEFAULT,
+                    H5E_WALK_DOWNWARD,
+                    [](unsigned n, const H5E_error2_t* err_desc, void* client_data) -> herr_t
                     {
                         printf("Error #%u: {}\n", n, err_desc->desc);
                         return 0;
-                    }, nullptr);
+                    },
+                    nullptr);
             return chronolog::CL_ERR_UNKNOWN;
         }
         status = H5Dvlen_reclaim(log_event_type, story_chunk_dspace, H5P_DEFAULT, &g_events);
@@ -454,28 +482,27 @@ int main(int argc, char*argv[])
         LOG_DEBUG("H5Tclose returns: {}", status);
         if(status < 0)
         {
-            LOG_ERROR("Failed to close dataset or dataspace or file for story chunk: {}"
-                      , story_chunk_dset_name.c_str());
+            LOG_ERROR("Failed to close dataset or dataspace or file for story chunk: {}",
+                      story_chunk_dset_name.c_str());
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
 
     // Close all files at the end
-//    for (auto &story_chunk_fd_map_it : story_chunk_fd_map)
-//    {
-//        status = H5Fclose(story_chunk_fd_map_it.second);
-//        if (status < 0)
-//        {
-//            char *story_file_name = new char[128];
-//            size_t file_name_len = 0;
-//            H5Fget_name(story_chunk_fd_map_it.second, story_file_name, file_name_len);
-//            LOG_ERROR("Failed to close file for story chunk: {}", story_file_name);
-//            free(story_file_name);
-//            return chronolog::CL_ERR_UNKNOWN;
-//        }
-//    }
+    //    for (auto &story_chunk_fd_map_it : story_chunk_fd_map)
+    //    {
+    //        status = H5Fclose(story_chunk_fd_map_it.second);
+    //        if (status < 0)
+    //        {
+    //            char *story_file_name = new char[128];
+    //            size_t file_name_len = 0;
+    //            H5Fget_name(story_chunk_fd_map_it.second, story_file_name, file_name_len);
+    //            LOG_ERROR("Failed to close file for story chunk: {}", story_file_name);
+    //            free(story_file_name);
+    //            return chronolog::CL_ERR_UNKNOWN;
+    //        }
+    //    }
 
     // Cleanup
-    for(auto &story_chunk_map_it: story_chunk_map)
-    { freeStoryChunk(story_chunk_map_it.second); }
+    for(auto& story_chunk_map_it: story_chunk_map) { freeStoryChunk(story_chunk_map_it.second); }
 }

--- a/ChronoStore/test/cmp_vlen_str_dtype_test.cpp
+++ b/ChronoStore/test/cmp_vlen_str_dtype_test.cpp
@@ -9,6 +9,9 @@
 #include <unordered_map>
 #include <map>
 #include <filesystem>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/ChronoStore/test/hdf5_archiver_test.cpp
+++ b/ChronoStore/test/hdf5_archiver_test.cpp
@@ -5,6 +5,8 @@
 #include <chrono>
 #include <random>
 #include <filesystem>
+#include <cstdlib>
+#include <cstdint>
 #include <hdf5.h>
 #include <StoryWriter.h>
 #include <StoryReader.h>

--- a/ChronoStore/test/hdf5_archiver_test.cpp
+++ b/ChronoStore/test/hdf5_archiver_test.cpp
@@ -20,7 +20,7 @@
 
 #define CHRONICLE_ROOT_DIR "/home/kfeng/chronolog_store/"
 
-bool compareLogEvent(const chronolog::LogEvent &event1, const chronolog::LogEvent &event2)
+bool compareLogEvent(const chronolog::LogEvent& event1, const chronolog::LogEvent& event2)
 {
     if(event1.storyId != event2.storyId)
     {
@@ -45,7 +45,7 @@ bool compareLogEvent(const chronolog::LogEvent &event1, const chronolog::LogEven
     return true;
 }
 
-bool compareStoryChunk(chronolog::StoryChunk &story_chunk1, chronolog::StoryChunk &story_chunk2)
+bool compareStoryChunk(chronolog::StoryChunk& story_chunk1, chronolog::StoryChunk& story_chunk2)
 {
     auto size1 = std::distance(story_chunk1.begin(), story_chunk1.end());
     auto size2 = std::distance(story_chunk2.begin(), story_chunk2.end());
@@ -71,14 +71,14 @@ bool compareStoryChunk(chronolog::StoryChunk &story_chunk1, chronolog::StoryChun
     return true;
 }
 
-bool compareStoryChunkMaps(std::map <uint64_t, chronolog::StoryChunk> &map1
-                           , std::map <uint64_t, chronolog::StoryChunk> &map2)
+bool compareStoryChunkMaps(std::map<uint64_t, chronolog::StoryChunk>& map1,
+                           std::map<uint64_t, chronolog::StoryChunk>& map2)
 {
     if(map1.size() != map2.size())
     {
         return false;
     }
-    for(auto &it: map1)
+    for(auto& it: map1)
     {
         if(map2.find(it.first) == map2.end())
         {
@@ -92,26 +92,30 @@ bool compareStoryChunkMaps(std::map <uint64_t, chronolog::StoryChunk> &map1
     return true;
 }
 
-void testWriteOperation(const std::map <uint64_t, chronolog::StoryChunk> &story_chunk_map, std::string &chronicle_name
-                        , std::string &story_name)
+void testWriteOperation(const std::map<uint64_t, chronolog::StoryChunk>& story_chunk_map,
+                        std::string& chronicle_name,
+                        std::string& story_name)
 {
     std::string chronicle_root_dir = CHRONICLE_ROOT_DIR;
     StoryWriter writer(chronicle_root_dir);
     writer.writeStoryChunks(story_chunk_map, chronicle_name, story_name);
 }
 
-void testRangeReadOperation(const std::string &chronicle_name, const uint64_t &story_id, uint64_t start_time
-                            , uint64_t end_time, std::map <uint64_t, chronolog::StoryChunk> &story_chunk_map)
+void testRangeReadOperation(const std::string& chronicle_name,
+                            const uint64_t& story_id,
+                            uint64_t start_time,
+                            uint64_t end_time,
+                            std::map<uint64_t, chronolog::StoryChunk>& story_chunk_map)
 {
     std::string chronicle_root_dir = CHRONICLE_ROOT_DIR;
     StoryReader sr(chronicle_root_dir);
     sr.readStoryRange(chronicle_name, story_id, start_time, end_time, story_chunk_map);
 }
 
-std::map <uint64_t, chronolog::StoryChunk> testReadAllOperation(uint64_t story_id, std::string &chronicle_name)
+std::map<uint64_t, chronolog::StoryChunk> testReadAllOperation(uint64_t story_id, std::string& chronicle_name)
 {
     hid_t status;
-    std::map <uint64_t, chronolog::StoryChunk> story_chunk_map;
+    std::map<uint64_t, chronolog::StoryChunk> story_chunk_map;
     std::string chronicle_root_dir = CHRONICLE_ROOT_DIR;
     StoryReader sr(chronicle_root_dir);
     story_chunk_map = sr.readAllStories(chronicle_name);
@@ -126,7 +130,7 @@ std::map <uint64_t, chronolog::StoryChunk> testReadAllOperation(uint64_t story_i
  * @param argv[5]: maximum Event size
  * @param argv[6]: standard deviation of Event size
  */
-int main(int argc, char*argv[])
+int main(int argc, char* argv[])
 {
     if(argc < 8)
     {
@@ -137,7 +141,7 @@ int main(int argc, char*argv[])
     }
     std::random_device rd;
     std::mt19937_64 rng(rd());
-    std::uniform_int_distribution <uint64_t> dist(0, UINT64_MAX);
+    std::uniform_int_distribution<uint64_t> dist(0, UINT64_MAX);
     uint64_t num_story_chunks = strtol(argv[1], nullptr, 10);
     uint64_t num_events_per_story_chunk = strtol(argv[2], nullptr, 10);
     uint64_t mean_event_size = strtol(argv[3], nullptr, 10);
@@ -151,32 +155,46 @@ int main(int argc, char*argv[])
     uint64_t story_id = dist(rng);
     uint64_t client_id = CLIENT_ID;
 
-    int result = chronolog::chrono_monitor::initialize("console", "hdf5_archiver_test.log", spdlog::level::debug
-                                                       , "hdf5_archiver_test", 102400, 1, spdlog::level::debug);
+    int result = chronolog::chrono_monitor::initialize("console",
+                                                       "hdf5_archiver_test.log",
+                                                       spdlog::level::debug,
+                                                       "hdf5_archiver_test",
+                                                       102400,
+                                                       1,
+                                                       spdlog::level::debug);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
     }
 
-    std::cout << "StoryID: " << story_id << std::endl << "#StoryChunks: " << num_story_chunks << std::endl
-              << "#EventsInEachChunk: " << num_events_per_story_chunk << std::endl << "meanEventSize: "
-              << mean_event_size << std::endl << "minEventSize: " << min_event_size << std::endl << "maxEventSize: "
-              << max_event_size << std::endl << "stddev: " << stddev << std::endl << "startTime: " << start_time
-              << std::endl << "endTime: " << end_time << std::endl;
+    std::cout << "StoryID: " << story_id << std::endl
+              << "#StoryChunks: " << num_story_chunks << std::endl
+              << "#EventsInEachChunk: " << num_events_per_story_chunk << std::endl
+              << "meanEventSize: " << mean_event_size << std::endl
+              << "minEventSize: " << min_event_size << std::endl
+              << "maxEventSize: " << max_event_size << std::endl
+              << "stddev: " << stddev << std::endl
+              << "startTime: " << start_time << std::endl
+              << "endTime: " << end_time << std::endl;
 
     // Generate StoryChunks
     std::cout << "Generating StoryChunks..." << std::endl;
     uint64_t time_step = (end_time - start_time) / num_events_per_story_chunk;
-    std::map <uint64_t, chronolog::StoryChunk> story_chunk_map = generateStoryChunks(story_id, client_id, start_time
-                                                                                     , time_step, end_time
-                                                                                     , mean_event_size, min_event_size
-                                                                                     , max_event_size, stddev
-                                                                                     , num_events_per_story_chunk
-                                                                                     , num_story_chunks);
+    std::map<uint64_t, chronolog::StoryChunk> story_chunk_map = generateStoryChunks(story_id,
+                                                                                    client_id,
+                                                                                    start_time,
+                                                                                    time_step,
+                                                                                    end_time,
+                                                                                    mean_event_size,
+                                                                                    min_event_size,
+                                                                                    max_event_size,
+                                                                                    stddev,
+                                                                                    num_events_per_story_chunk,
+                                                                                    num_story_chunks);
 
     // Clean up Chronicle directory
     std::cout << "Cleaning up Chronicle directory..." << std::endl;
-    for(const auto &entry: std::filesystem::directory_iterator(CHRONICLE_ROOT_DIR))
+    for(const auto& entry: std::filesystem::directory_iterator(CHRONICLE_ROOT_DIR))
     {
         std::filesystem::remove_all(entry.path());
     }
@@ -188,7 +206,7 @@ int main(int argc, char*argv[])
 
     // Test read operation
     std::cout << "Testing read operation..." << std::endl;
-    std::map <uint64_t, chronolog::StoryChunk> story_chunk_map2 = testReadAllOperation(story_id, chronicle_name);
+    std::map<uint64_t, chronolog::StoryChunk> story_chunk_map2 = testReadAllOperation(story_id, chronicle_name);
 
     // Validate read all results
     std::cout << "Validating read all results ..." << std::endl;
@@ -200,12 +218,12 @@ int main(int argc, char*argv[])
     {
         std::cout << "Validation failed!" << std::endl;
         std::cout << "Correct: " << std::endl;
-        for(const auto &story_chunk_str: StoryWriter::serializeStoryChunkMap(story_chunk_map))
+        for(const auto& story_chunk_str: StoryWriter::serializeStoryChunkMap(story_chunk_map))
         {
             std::cout << story_chunk_str << std::endl;
         }
         std::cout << "Result: " << std::endl;
-        for(const auto &story_chunk_str: StoryWriter::serializeStoryChunkMap(story_chunk_map2))
+        for(const auto& story_chunk_str: StoryWriter::serializeStoryChunkMap(story_chunk_map2))
         {
             std::cout << story_chunk_str << std::endl;
         }
@@ -215,19 +233,19 @@ int main(int argc, char*argv[])
     std::cout << "Testing range read operation..." << std::endl;
     uint64_t range_start_time = start_time + dist(rng) % (end_time - start_time) / 2;
     uint64_t range_end_time = range_start_time + dist(rng) % (end_time - range_start_time);
-    std::map <uint64_t, chronolog::StoryChunk> story_chunk_map3;
+    std::map<uint64_t, chronolog::StoryChunk> story_chunk_map3;
     testRangeReadOperation(chronicle_name, story_id, range_start_time, range_end_time, story_chunk_map3);
 
     // Generate reference range read results to validate
-    std::map <uint64_t, chronolog::StoryChunk> story_chunk_map4;
-    for(auto &it: story_chunk_map)
+    std::map<uint64_t, chronolog::StoryChunk> story_chunk_map4;
+    for(auto& it: story_chunk_map)
     {
         if(it.first >= range_start_time || it.first < range_end_time)
         {
-            std::map <chronolog::EventSequence, chronolog::LogEvent> event_map;
-            for(const auto &event_it: it.second)
+            std::map<chronolog::EventSequence, chronolog::LogEvent> event_map;
+            for(const auto& event_it: it.second)
             {
-                uint64_t event_time = std::get <0>(event_it.first);
+                uint64_t event_time = std::get<0>(event_it.first);
                 if(event_time >= range_start_time && event_time < range_end_time)
                 {
                     event_map.emplace(event_it.first, event_it.second);
@@ -236,10 +254,7 @@ int main(int argc, char*argv[])
             chronolog::StoryChunk story_chunk;
             if(!event_map.empty())
             {
-                for(const auto &event: event_map)
-                {
-                    story_chunk.insertEvent(event.second);
-                }
+                for(const auto& event: event_map) { story_chunk.insertEvent(event.second); }
             }
         }
     }
@@ -255,12 +270,12 @@ int main(int argc, char*argv[])
     {
         std::cout << "Validation failed!" << std::endl;
         std::cout << "Correct: " << std::endl;
-        for(const auto &story_chunk_str: StoryWriter::serializeStoryChunkMap(story_chunk_map4))
+        for(const auto& story_chunk_str: StoryWriter::serializeStoryChunkMap(story_chunk_map4))
         {
             std::cout << story_chunk_str << std::endl;
         }
         std::cout << "Result: " << std::endl;
-        for(const auto &story_chunk_str: StoryWriter::serializeStoryChunkMap(story_chunk_map3))
+        for(const auto& story_chunk_str: StoryWriter::serializeStoryChunkMap(story_chunk_map3))
         {
             std::cout << story_chunk_str << std::endl;
         }

--- a/ChronoStore/test/story_chunk_test_utils.h
+++ b/ChronoStore/test/story_chunk_test_utils.h
@@ -30,15 +30,22 @@
  * @param total_event_size: Total size of all events in the StoryChunk
  * @return a StoryChunk
  */
-chronolog::StoryChunk
-generateStoryChunk(uint64_t story_id, chronolog::ClientId client_id, uint64_t start_time, uint64_t time_step
-                   , uint64_t end_time, uint64_t mean_event_size, uint64_t min_event_size, uint64_t max_event_size
-                   , double stddev, uint64_t num_events_per_story_chunk, uint64_t &total_event_size)
+chronolog::StoryChunk generateStoryChunk(uint64_t story_id,
+                                         chronolog::ClientId client_id,
+                                         uint64_t start_time,
+                                         uint64_t time_step,
+                                         uint64_t end_time,
+                                         uint64_t mean_event_size,
+                                         uint64_t min_event_size,
+                                         uint64_t max_event_size,
+                                         double stddev,
+                                         uint64_t num_events_per_story_chunk,
+                                         uint64_t& total_event_size)
 {
     chronolog::StoryChunk story_chunk(CHRONICLE_NAME, STORY_NAME, story_id, start_time, end_time);
     std::random_device rd;
     std::mt19937_64 generator(rd());
-    std::normal_distribution <double> normal_dist(mean_event_size, stddev);
+    std::normal_distribution<double> normal_dist(mean_event_size, stddev);
 
     for(int i = 0; i < num_events_per_story_chunk; ++i)
     {
@@ -49,8 +56,10 @@ generateStoryChunk(uint64_t story_id, chronolog::ClientId client_id, uint64_t st
         event.eventTime = start_time + i * time_step;
         event.eventIndex = i;
         uint64_t string_size = static_cast<int>(normal_dist(generator));
-        if(string_size < min_event_size) string_size = min_event_size;
-        if(string_size > max_event_size) string_size = max_event_size;
+        if(string_size < min_event_size)
+            string_size = min_event_size;
+        if(string_size > max_event_size)
+            string_size = max_event_size;
         total_event_size += string_size;
         std::string random_str;
         for(int j = 0; j < string_size; ++j)
@@ -79,21 +88,35 @@ generateStoryChunk(uint64_t story_id, chronolog::ClientId client_id, uint64_t st
  * @param num_story_chunks: Number of chunks to generate
  * @return a map of StoryChunks
  */
-std::map <uint64_t, chronolog::StoryChunk>
-generateStoryChunks(uint64_t story_id, chronolog::ClientId client_id, uint64_t start_time, uint64_t time_step
-                    , uint64_t end_time, uint64_t mean_event_size, uint64_t min_event_size, uint64_t max_event_size
-                    , double stddev, uint64_t num_events_per_story_chunk, uint64_t num_story_chunks)
+std::map<uint64_t, chronolog::StoryChunk> generateStoryChunks(uint64_t story_id,
+                                                              chronolog::ClientId client_id,
+                                                              uint64_t start_time,
+                                                              uint64_t time_step,
+                                                              uint64_t end_time,
+                                                              uint64_t mean_event_size,
+                                                              uint64_t min_event_size,
+                                                              uint64_t max_event_size,
+                                                              double stddev,
+                                                              uint64_t num_events_per_story_chunk,
+                                                              uint64_t num_story_chunks)
 {
-    std::map <uint64_t, chronolog::StoryChunk> story_chunks;
+    std::map<uint64_t, chronolog::StoryChunk> story_chunks;
     uint64_t total_event_size = 0;
     for(int i = 0; i < num_story_chunks; ++i)
     {
         uint64_t chunk_start_time = start_time + i * num_events_per_story_chunk * time_step;
         uint64_t chunk_end_time = chunk_start_time + num_events_per_story_chunk * time_step;
-        chronolog::StoryChunk story_chunk = generateStoryChunk(story_id, client_id, chunk_start_time, time_step
-                                                               , chunk_end_time, mean_event_size, min_event_size
-                                                               , max_event_size, stddev, num_events_per_story_chunk
-                                                               , total_event_size);
+        chronolog::StoryChunk story_chunk = generateStoryChunk(story_id,
+                                                               client_id,
+                                                               chunk_start_time,
+                                                               time_step,
+                                                               chunk_end_time,
+                                                               mean_event_size,
+                                                               min_event_size,
+                                                               max_event_size,
+                                                               stddev,
+                                                               num_events_per_story_chunk,
+                                                               total_event_size);
         story_chunks.emplace(chunk_start_time, story_chunk);
     }
     std::cout << "Total data size: " << total_event_size << std::endl;

--- a/ChronoStore/test/story_chunk_test_utils.h
+++ b/ChronoStore/test/story_chunk_test_utils.h
@@ -5,7 +5,10 @@
 #ifndef CHRONOLOG_STORY_CHUNK_TEST_UTILS_H
 #define CHRONOLOG_STORY_CHUNK_TEST_UTILS_H
 
+#include <iostream>
+#include <map>
 #include <random>
+#include <string>
 #include <StoryChunk.h>
 
 #define CHRONICLE_NAME "Ares_Monitoring"

--- a/ChronoVisor/include/Archive.h
+++ b/ChronoVisor/include/Archive.h
@@ -15,7 +15,7 @@
 class Archive
 {
 public:
-    Archive(){};
+    Archive() {};
 
     const std::string& getName() const { return name_; }
 

--- a/ChronoVisor/include/Archive.h
+++ b/ChronoVisor/include/Archive.h
@@ -15,48 +15,37 @@
 class Archive
 {
 public:
-    Archive()
-    {};
+    Archive(){};
 
-    const std::string &getName() const
-    { return name_; }
+    const std::string& getName() const { return name_; }
 
-    const uint64_t &getAid() const
-    { return aid_; }
+    const uint64_t& getAid() const { return aid_; }
 
-    const uint64_t &getCid() const
-    { return cid_; }
+    const uint64_t& getCid() const { return cid_; }
 
-    const std::unordered_map <std::string, std::string> &getProperty() const
-    { return propertyList_; }
+    const std::unordered_map<std::string, std::string>& getProperty() const { return propertyList_; }
 
-    void setName(const std::string &name)
-    { name_ = name; }
+    void setName(const std::string& name) { name_ = name; }
 
-    void setAid(uint64_t aid)
-    { aid_ = aid; }
+    void setAid(uint64_t aid) { aid_ = aid; }
 
-    void setCid(uint64_t cid)
-    { cid_ = cid; }
+    void setCid(uint64_t cid) { cid_ = cid; }
 
-    void setProperty(const std::unordered_map <std::string, std::string> &attrs)
+    void setProperty(const std::unordered_map<std::string, std::string>& attrs)
     {
-        for(auto const &entry: attrs)
-        {
-            propertyList_.emplace(entry.first, entry.second);
-        }
+        for(auto const& entry: attrs) { propertyList_.emplace(entry.first, entry.second); }
     }
 
-    friend std::ostream &operator<<(std::ostream &os, const Archive &archive);
+    friend std::ostream& operator<<(std::ostream& os, const Archive& archive);
 
 private:
     std::string name_;
     uint64_t aid_{};
     uint64_t cid_{};
-    std::unordered_map <std::string, std::string> propertyList_;
+    std::unordered_map<std::string, std::string> propertyList_;
 };
 
-inline std::ostream &operator<<(std::ostream &os, const Archive &archive)
+inline std::ostream& operator<<(std::ostream& os, const Archive& archive)
 {
     os << "name: " << archive.name_ << ", " << "aid: " << archive.aid_ << ", " << "cid: " << archive.cid_;
     return os;

--- a/ChronoVisor/include/Archive.h
+++ b/ChronoVisor/include/Archive.h
@@ -5,8 +5,9 @@
 #ifndef CHRONOLOG_ARCHIVE_H
 #define CHRONOLOG_ARCHIVE_H
 
-#include <string>
+#include <cstdint>
 #include <ostream>
+#include <string>
 #include <unordered_map>
 
 #include <city.h>

--- a/ChronoVisor/include/Chronicle.h
+++ b/ChronoVisor/include/Chronicle.h
@@ -28,17 +28,23 @@
 
 enum ChronicleIndexingGranularity
 {
-    chronicle_gran_ns = 0, chronicle_gran_us = 1, chronicle_gran_ms = 2, chronicle_gran_sec = 3
+    chronicle_gran_ns = 0,
+    chronicle_gran_us = 1,
+    chronicle_gran_ms = 2,
+    chronicle_gran_sec = 3
 };
 
 enum ChronicleType
 {
-    chronicle_type_standard = 0, chronicle_type_priority = 1
+    chronicle_type_standard = 0,
+    chronicle_type_priority = 1
 };
 
 enum ChronicleTieringPolicy
 {
-    chronicle_tiering_normal = 0, chronicle_tiering_hot = 1, chronicle_tiering_cold = 2
+    chronicle_tiering_normal = 0,
+    chronicle_tiering_hot = 1,
+    chronicle_tiering_cold = 2
 };
 
 typedef struct ChronicleAttrs_
@@ -60,71 +66,58 @@ class Chronicle
 public:
     Chronicle()
     {
-        propertyList_ = std::unordered_map <std::string, std::string>(MAX_CHRONICLE_PROPERTY_LIST_SIZE);
-        metadataMap_ = std::unordered_map <std::string, std::string>(MAX_CHRONICLE_METADATA_MAP_SIZE);
-        storyMap_ = std::unordered_map <uint64_t, Story*>(MAX_STORY_MAP_SIZE);
-        archiveMap_ = std::unordered_map <uint64_t, Archive*>(MAX_ARCHIVE_MAP_SIZE);
+        propertyList_ = std::unordered_map<std::string, std::string>(MAX_CHRONICLE_PROPERTY_LIST_SIZE);
+        metadataMap_ = std::unordered_map<std::string, std::string>(MAX_CHRONICLE_METADATA_MAP_SIZE);
+        storyMap_ = std::unordered_map<uint64_t, Story*>(MAX_STORY_MAP_SIZE);
+        archiveMap_ = std::unordered_map<uint64_t, Archive*>(MAX_ARCHIVE_MAP_SIZE);
         attrs_.size = 0;
         attrs_.indexing_granularity = chronicle_gran_ms;
         attrs_.type = chronicle_type_standard;
         attrs_.tiering_policy = chronicle_tiering_normal;
         attrs_.access_permission = 0;
         stats_.count = 0;
-//        storyName2IdMap_ = new std::unordered_map<std::string, uint64_t>();
-//        storyId2NameMap_ = new std::unordered_map<uint64_t, std::string>();
+        //        storyName2IdMap_ = new std::unordered_map<std::string, uint64_t>();
+        //        storyId2NameMap_ = new std::unordered_map<uint64_t, std::string>();
     }
 
     ~Chronicle()
     {
-//        delete storyName2IdMap_;
-//        delete storyId2NameMap_;
+        //        delete storyName2IdMap_;
+        //        delete storyId2NameMap_;
     }
 
-    void setName(const std::string &name)
-    { name_ = name; }
+    void setName(const std::string& name) { name_ = name; }
 
-    void setCid(const uint64_t &cid)
-    { cid_ = cid; }
+    void setCid(const uint64_t& cid) { cid_ = cid; }
 
-    void setStats(const ChronicleStats &stats)
-    { stats_ = stats; }
+    void setStats(const ChronicleStats& stats) { stats_ = stats; }
 
-    void setProperty(const std::unordered_map <std::string, std::string> &attrs)
+    void setProperty(const std::unordered_map<std::string, std::string>& attrs)
     {
-        for(auto const &entry: attrs)
-        {
-            propertyList_.emplace(entry.first, entry.second);
-        }
+        for(auto const& entry: attrs) { propertyList_.emplace(entry.first, entry.second); }
     }
 
-    const std::string &getName() const
-    { return name_; }
+    const std::string& getName() const { return name_; }
 
-    const uint64_t &getCid() const
-    { return cid_; }
+    const uint64_t& getCid() const { return cid_; }
 
-    const ChronicleStats &getStats() const
-    { return stats_; }
+    const ChronicleStats& getStats() const { return stats_; }
 
-    std::unordered_map <std::string, std::string> &getPropertyList()
-    { return propertyList_; }
+    std::unordered_map<std::string, std::string>& getPropertyList() { return propertyList_; }
 
-    const std::unordered_map <std::string, std::string> &getMetadataMap() const
-    { return metadataMap_; }
+    const std::unordered_map<std::string, std::string>& getMetadataMap() const { return metadataMap_; }
 
-    std::unordered_map <uint64_t, Story*> &getStoryMap()
-    { return storyMap_; }
+    std::unordered_map<uint64_t, Story*>& getStoryMap() { return storyMap_; }
 
-    const std::unordered_map <uint64_t, Archive*> &getArchiveMap() const
-    { return archiveMap_; }
-//    std::unordered_map<std::string, uint64_t> *getName2IdMap() { return storyName2IdMap_; }
-//    std::unordered_map<uint64_t, std::string> *getId2NameMap() { return storyId2NameMap_; }
+    const std::unordered_map<uint64_t, Archive*>& getArchiveMap() const { return archiveMap_; }
+    //    std::unordered_map<std::string, uint64_t> *getName2IdMap() { return storyName2IdMap_; }
+    //    std::unordered_map<uint64_t, std::string> *getId2NameMap() { return storyId2NameMap_; }
 
-    bool hasStory(const std::string &story_name)
+    bool hasStory(const std::string& story_name)
     {
         std::string story_name_for_hash = name_ + story_name;
-//        auto name2IdRecord = storyName2IdMap_->find(story_name_for_hash);
-//        if (name2IdRecord != storyName2IdMap_->end()) return true;
+        //        auto name2IdRecord = storyName2IdMap_->find(story_name_for_hash);
+        //        if (name2IdRecord != storyName2IdMap_->end()) return true;
         uint64_t sid = CityHash64(story_name_for_hash.c_str(), story_name_for_hash.length());
         if(storyMap_.find(sid) != storyMap_.end())
         {
@@ -142,7 +135,7 @@ public:
      * @return StoryID if found \n
      *         0 elsewise
      */
-    uint64_t getStoryId(const std::string &story_name)
+    uint64_t getStoryId(const std::string& story_name)
     {
         if(!hasStory(story_name))
         {
@@ -151,14 +144,14 @@ public:
         else
         {
             std::string story_name_for_hash = name_ + story_name;
-//            return storyName2IdMap_->find(story_name_for_hash)->second;
+            //            return storyName2IdMap_->find(story_name_for_hash)->second;
             return CityHash64(story_name_for_hash.c_str(), story_name_for_hash.length());
         }
     }
 
-    friend std::ostream &operator<<(std::ostream &os, const Chronicle &chronicle);
+    friend std::ostream& operator<<(std::ostream& os, const Chronicle& chronicle);
 
-    int addProperty(const std::string &name, const std::string &value)
+    int addProperty(const std::string& name, const std::string& value)
     {
         if(propertyList_.size() <= MAX_CHRONICLE_PROPERTY_LIST_SIZE)
         {
@@ -178,13 +171,15 @@ public:
         }
     }
 
-    int addMetadata(const std::string &name, const std::string &value)
+    int addMetadata(const std::string& name, const std::string& value)
     {
         if(metadataMap_.size() <= MAX_CHRONICLE_METADATA_MAP_SIZE)
         {
             auto res = metadataMap_.insert_or_assign(name, value);
-            if(res.second) return chronolog::CL_SUCCESS;
-            else return chronolog::CL_ERR_UNKNOWN;
+            if(res.second)
+                return chronolog::CL_SUCCESS;
+            else
+                return chronolog::CL_ERR_UNKNOWN;
         }
         else
         {
@@ -192,81 +187,97 @@ public:
         }
     }
 
-    std::pair <int, Story*>
-    addStory(const std::string &story_name, const std::map <std::string, std::string> &attrs)
+    std::pair<int, Story*> addStory(const std::string& story_name, const std::map<std::string, std::string>& attrs)
     {
         /* Check if Story exists */
         std::string story_name_for_hash = name_ + story_name;
         uint64_t sid = CityHash64(story_name_for_hash.c_str(), story_name_for_hash.length());
         auto story_iter = storyMap_.find(sid);
         if(story_iter != storyMap_.end())
-        { return std::pair <int, Story*>(chronolog::CL_SUCCESS, (*story_iter).second); }
+        {
+            return std::pair<int, Story*>(chronolog::CL_SUCCESS, (*story_iter).second);
+        }
 
-        Story*pStory = new Story();
+        Story* pStory = new Story();
         pStory->setName(story_name);
         pStory->setProperty(attrs);
         pStory->setSid(sid);
         pStory->setCid(cid_);
-        LOG_DEBUG("[Chronicle] Adding to StoryMap at {} with {} entries in Chronicle at {}", static_cast<void*>(&storyMap_)
-             , storyMap_.size(), static_cast<const void*>(this));
+        LOG_DEBUG("[Chronicle] Adding to StoryMap at {} with {} entries in Chronicle at {}",
+                  static_cast<void*>(&storyMap_),
+                  storyMap_.size(),
+                  static_cast<const void*>(this));
         auto res = storyMap_.emplace(sid, pStory);
-//        storyName2IdMap_->insert_or_assign(story_name_for_hash, sid);
-//        storyId2NameMap_->insert_or_assign(sid, story_name_for_hash);
+        //        storyName2IdMap_->insert_or_assign(story_name_for_hash, sid);
+        //        storyId2NameMap_->insert_or_assign(sid, story_name_for_hash);
         if(res.second)
-        { return std::pair <int, Story*>(chronolog::CL_SUCCESS, pStory); }
+        {
+            return std::pair<int, Story*>(chronolog::CL_SUCCESS, pStory);
+        }
         else
-        { return std::pair <int, Story*>(chronolog::CL_ERR_UNKNOWN, nullptr); }
+        {
+            return std::pair<int, Story*>(chronolog::CL_ERR_UNKNOWN, nullptr);
+        }
     }
 
-    int removeStory(std::string const &chronicle_name, const std::string &story_name)
+    int removeStory(std::string const& chronicle_name, const std::string& story_name)
     {
         // add chronicle_name to story_name before hash to allow same story name across chronicles
         std::string story_name_for_hash = chronicle_name + story_name;
         /* Check if Story exists, fail if true */
-//        if(storyName2IdMap_->find(story_name_for_hash) != storyName2IdMap_->end()) {
-//            uint64_t sid = storyName2IdMap_->find(story_name_for_hash)->second;
+        //        if(storyName2IdMap_->find(story_name_for_hash) != storyName2IdMap_->end()) {
+        //            uint64_t sid = storyName2IdMap_->find(story_name_for_hash)->second;
         uint64_t sid = CityHash64(story_name_for_hash.c_str(), story_name_for_hash.length());
         auto storyMapRecord = storyMap_.find(sid);
         if(storyMapRecord != storyMap_.end())
         {
-            Story*pStory = storyMap_.find(sid)->second;
+            Story* pStory = storyMap_.find(sid)->second;
             /* Check if Story is acquired, fail if true */
             if(pStory->getAcquisitionCount() != 0)
             {
                 return chronolog::CL_ERR_ACQUIRED;
             }
             delete pStory;
-            LOG_DEBUG("[Chronicle] Removing from StoryMap at {} with {} entries in Chronicle at {}"
-                 , static_cast<void*>(&storyMap_), storyMap_.size(), static_cast<const void*>(this));
+            LOG_DEBUG("[Chronicle] Removing from StoryMap at {} with {} entries in Chronicle at {}",
+                      static_cast<void*>(&storyMap_),
+                      storyMap_.size(),
+                      static_cast<const void*>(this));
             auto nErased = storyMap_.erase(sid);
-//            storyName2IdMap_->erase(story_name_for_hash);
-//            storyId2NameMap_->erase(sid);
-            if(nErased == 1) return chronolog::CL_SUCCESS;
-            else return chronolog::CL_ERR_UNKNOWN;
+            //            storyName2IdMap_->erase(story_name_for_hash);
+            //            storyId2NameMap_->erase(sid);
+            if(nErased == 1)
+                return chronolog::CL_SUCCESS;
+            else
+                return chronolog::CL_ERR_UNKNOWN;
         }
         return chronolog::CL_ERR_NOT_EXIST;
     }
 
 
-    int addArchive(uint64_t cid, const std::string &name, const std::unordered_map <std::string, std::string> &attrs)
+    int addArchive(uint64_t cid, const std::string& name, const std::unordered_map<std::string, std::string>& attrs)
     {
         // add cid to name before hash to allow same archive name across chronicles
         std::string archive_name_for_hash = std::to_string(cid) + name;
         uint64_t aid = CityHash64(archive_name_for_hash.c_str(), archive_name_for_hash.size());
-        if(archiveMap_.find(aid) != archiveMap_.end()) return false;
-        auto*pArchive = new Archive();
+        if(archiveMap_.find(aid) != archiveMap_.end())
+            return false;
+        auto* pArchive = new Archive();
         pArchive->setName(name);
         pArchive->setProperty(attrs);
         pArchive->setAid(aid);
         pArchive->setCid(cid);
-        LOG_DEBUG("[Chronicle] Adding to ArchiveMap at {} with {} entries in Chronicle at {}"
-             , static_cast<void*>(&archiveMap_), archiveMap_.size(), static_cast<const void*>(this));
+        LOG_DEBUG("[Chronicle] Adding to ArchiveMap at {} with {} entries in Chronicle at {}",
+                  static_cast<void*>(&archiveMap_),
+                  archiveMap_.size(),
+                  static_cast<const void*>(this));
         auto res = archiveMap_.emplace(aid, pArchive);
-        if(res.second) return chronolog::CL_SUCCESS;
-        else return chronolog::CL_ERR_UNKNOWN;
+        if(res.second)
+            return chronolog::CL_SUCCESS;
+        else
+            return chronolog::CL_ERR_UNKNOWN;
     }
 
-    int removeArchive(uint64_t cid, const std::string &name, int flags)
+    int removeArchive(uint64_t cid, const std::string& name, int flags)
     {
         // add cid to name before hash to allow same archive name across chronicles
         std::string archive_name_for_hash = std::to_string(cid) + name;
@@ -274,13 +285,17 @@ public:
         auto storyRecord = archiveMap_.find(aid);
         if(storyRecord != archiveMap_.end())
         {
-            Archive*pArchive = storyRecord->second;
+            Archive* pArchive = storyRecord->second;
             delete pArchive;
-            LOG_DEBUG("[Chronicle] Removing from ArchiveMap at {} with {} entries in Chronicle at {}"
-                 , static_cast<void*>(&archiveMap_), archiveMap_.size(), static_cast<const void*>(this));
+            LOG_DEBUG("[Chronicle] Removing from ArchiveMap at {} with {} entries in Chronicle at {}",
+                      static_cast<void*>(&archiveMap_),
+                      archiveMap_.size(),
+                      static_cast<const void*>(this));
             auto nErased = archiveMap_.erase(aid);
-            if(nErased == 1) return chronolog::CL_SUCCESS;
-            else return chronolog::CL_ERR_UNKNOWN;
+            if(nErased == 1)
+                return chronolog::CL_SUCCESS;
+            else
+                return chronolog::CL_ERR_UNKNOWN;
         }
         return chronolog::CL_ERR_NOT_EXIST;
     }
@@ -297,41 +312,35 @@ public:
         return stats_.count;
     }
 
-    uint64_t getAcquisitionCount() const
-    { return stats_.count; }
+    uint64_t getAcquisitionCount() const { return stats_.count; }
 
-    size_t getPropertyListSize()
-    { return propertyList_.size(); }
+    size_t getPropertyListSize() { return propertyList_.size(); }
 
-    size_t getMetadataMapSize()
-    { return metadataMap_.size(); }
+    size_t getMetadataMapSize() { return metadataMap_.size(); }
 
-    size_t getStoryMapSize()
-    { return storyMap_.size(); }
+    size_t getStoryMapSize() { return storyMap_.size(); }
 
-    size_t getArchiveMapSize()
-    { return archiveMap_.size(); }
+    size_t getArchiveMapSize() { return archiveMap_.size(); }
 
 private:
     std::string name_;
     uint64_t cid_{};
     ChronicleAttrs attrs_{};
     ChronicleStats stats_{};
-    std::unordered_map <std::string, std::string> propertyList_;
-    std::unordered_map <std::string, std::string> metadataMap_;
-    std::unordered_map <uint64_t, Story*> storyMap_;
-    std::unordered_map <uint64_t, Archive*> archiveMap_;
-//    std::unordered_map<std::string, uint64_t> *storyName2IdMap_;
-//    std::unordered_map<uint64_t, std::string> *storyId2NameMap_;
+    std::unordered_map<std::string, std::string> propertyList_;
+    std::unordered_map<std::string, std::string> metadataMap_;
+    std::unordered_map<uint64_t, Story*> storyMap_;
+    std::unordered_map<uint64_t, Archive*> archiveMap_;
+    //    std::unordered_map<std::string, uint64_t> *storyName2IdMap_;
+    //    std::unordered_map<uint64_t, std::string> *storyId2NameMap_;
 };
 
-inline std::ostream &operator<<(std::ostream &os, const Chronicle &chronicle)
+inline std::ostream& operator<<(std::ostream& os, const Chronicle& chronicle)
 {
-    os << "name: " << chronicle.name_ << ", " << "cid: " << chronicle.cid_ << ", " << "access count: "
-       << chronicle.stats_.count << ", " << "properties: ";
+    os << "name: " << chronicle.name_ << ", " << "cid: " << chronicle.cid_ << ", "
+       << "access count: " << chronicle.stats_.count << ", " << "properties: ";
     os << "(";
-    for(auto const &property: chronicle.propertyList_)
-        os << property.first << ": " << property.second << ", ";
+    for(auto const& property: chronicle.propertyList_) os << property.first << ": " << property.second << ", ";
     os << ")";
     return os;
 }

--- a/ChronoVisor/include/Chronicle.h
+++ b/ChronoVisor/include/Chronicle.h
@@ -5,10 +5,14 @@
 #ifndef CHRONOLOG_CHRONICLE_H
 #define CHRONOLOG_CHRONICLE_H
 
-#include <unordered_map>
-#include <ostream>
 #include <atomic>
+#include <cstdint>
+#include <map>
 #include <mutex>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <utility>
 
 #include <city.h>
 #include <chrono_monitor.h>

--- a/ChronoVisor/include/ChronicleMetaDirectory.h
+++ b/ChronoVisor/include/ChronicleMetaDirectory.h
@@ -22,40 +22,43 @@ public:
 
     ~ChronicleMetaDirectory();
 
-    void set_client_registry_manager(ClientRegistryManager*pClientRegistryManager)
+    void set_client_registry_manager(ClientRegistryManager* pClientRegistryManager)
     {
         clientRegistryManager_ = pClientRegistryManager;
     }
 
-    std::unordered_map <uint64_t, Chronicle*>*getChronicleMap()
-    { return chronicleMap_; }
+    std::unordered_map<uint64_t, Chronicle*>* getChronicleMap() { return chronicleMap_; }
 
-    int create_chronicle(const std::string &name, const std::map <std::string, std::string> &attrs);
+    int create_chronicle(const std::string& name, const std::map<std::string, std::string>& attrs);
 
-    int destroy_chronicle(const std::string &name);
+    int destroy_chronicle(const std::string& name);
 
-    int destroy_story(std::string const &chronicle_name, const std::string &story_name);
+    int destroy_story(std::string const& chronicle_name, const std::string& story_name);
 
-    int
-    acquire_story(chronolog::ClientId const &client_id, const std::string &chronicle_name, const std::string &story_name
-                  , const std::map <std::string, std::string> &attrs, int &flags, StoryId &);
+    int acquire_story(chronolog::ClientId const& client_id,
+                      const std::string& chronicle_name,
+                      const std::string& story_name,
+                      const std::map<std::string, std::string>& attrs,
+                      int& flags,
+                      StoryId&);
 
-    int
-    release_story(chronolog::ClientId const &client_id, const std::string &chronicle_name, const std::string &story_name
-                  , StoryId &);
+    int release_story(chronolog::ClientId const& client_id,
+                      const std::string& chronicle_name,
+                      const std::string& story_name,
+                      StoryId&);
 
-    int get_chronicle_attr(std::string const &name, const std::string &key, std::string &value);
+    int get_chronicle_attr(std::string const& name, const std::string& key, std::string& value);
 
-    int edit_chronicle_attr(std::string const &name, const std::string &key, const std::string &value);
+    int edit_chronicle_attr(std::string const& name, const std::string& key, const std::string& value);
 
-    int show_chronicles(std::vector <std::string> &);
+    int show_chronicles(std::vector<std::string>&);
 
-    int show_stories(const std::string &chronicle_name, std::vector <std::string> &);
+    int show_stories(const std::string& chronicle_name, std::vector<std::string>&);
 
 private:
-    std::unordered_map <uint64_t, Chronicle*>*chronicleMap_;
+    std::unordered_map<uint64_t, Chronicle*>* chronicleMap_;
     std::mutex g_chronicleMetaDirectoryMutex_;
-    ClientRegistryManager*clientRegistryManager_ = nullptr;
+    ClientRegistryManager* clientRegistryManager_ = nullptr;
 };
 
 #endif //CHRONOLOG_CHRONICLEMETADIRECTORY_H

--- a/ChronoVisor/include/ChronicleMetaDirectory.h
+++ b/ChronoVisor/include/ChronicleMetaDirectory.h
@@ -1,6 +1,9 @@
 #ifndef CHRONOLOG_CHRONICLEMETADIRECTORY_H
 #define CHRONOLOG_CHRONICLEMETADIRECTORY_H
 
+#include <cstdint>
+#include <map>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/ChronoVisor/include/ClientInfo.h
+++ b/ChronoVisor/include/ClientInfo.h
@@ -5,7 +5,11 @@
 #ifndef CHRONOLOG_CLIENTINFO_H
 #define CHRONOLOG_CLIENTINFO_H
 
+#include <cstdint>
+#include <ostream>
 #include <sstream>
+#include <string>
+#include <unordered_map>
 
 class Story;
 

--- a/ChronoVisor/include/ClientInfo.h
+++ b/ChronoVisor/include/ClientInfo.h
@@ -24,29 +24,26 @@ public:
         std::stringstream ss;
         auto it = acquiredStoryList_.begin();
         ss << it->first;
-        for(++it; it != acquiredStoryList_.end(); ++it)
-        {
-            ss << ", " << it->first;
-        }
+        for(++it; it != acquiredStoryList_.end(); ++it) { ss << ", " << it->first; }
         return str + ss.str();
     }
 
     template <typename A>
-    friend void serialize(A &ar, ClientInfo &r);
+    friend void serialize(A& ar, ClientInfo& r);
 
     std::string addr_;
     uint16_t port_;
-    std::unordered_map <uint64_t, Story*> acquiredStoryList_;
+    std::unordered_map<uint64_t, Story*> acquiredStoryList_;
 };
 
-std::ostream &operator<<(std::ostream &out, const ClientInfo &r);
+std::ostream& operator<<(std::ostream& out, const ClientInfo& r);
 
 template <typename A>
-void serialize(A &ar, ClientInfo &r)
+void serialize(A& ar, ClientInfo& r)
 {
-    ar&r.addr_;
-    ar&r.port_;
-    ar&r.acquiredStoryList_;
+    ar & r.addr_;
+    ar & r.port_;
+    ar & r.acquiredStoryList_;
 }
 
 #endif //CHRONOLOG_CLIENTINFO_H

--- a/ChronoVisor/include/ClientPortalService.h
+++ b/ChronoVisor/include/ClientPortalService.h
@@ -1,6 +1,9 @@
 #ifndef CLIENT_PORTAL_SERVICE_H
 #define CLIENT_PORTAL_SERVICE_H
 
+#include <cstdint>
+#include <map>
+
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>
 #include <thallium/serialization/stl/vector.hpp>

--- a/ChronoVisor/include/ClientPortalService.h
+++ b/ChronoVisor/include/ClientPortalService.h
@@ -21,12 +21,12 @@ namespace tl = thallium;
 namespace chronolog
 {
 
-class ClientPortalService: public thallium::provider <ClientPortalService>
+class ClientPortalService: public thallium::provider<ClientPortalService>
 {
 public:
-
-    static ClientPortalService*CreateClientPortalService(thallium::engine &tl_engine, uint16_t service_provider_id
-                                                         , VisorClientPortal &visor_portal)
+    static ClientPortalService* CreateClientPortalService(thallium::engine& tl_engine,
+                                                          uint16_t service_provider_id,
+                                                          VisorClientPortal& visor_portal)
     {
         return new ClientPortalService(tl_engine, service_provider_id, visor_portal);
     }
@@ -37,93 +37,112 @@ public:
         get_engine().pop_finalize_callback(this);
     }
 
-    void Connect(tl::request const &request, uint32_t client_account, uint32_t client_host_ip, uint32_t client_pid)
+    void Connect(tl::request const& request, uint32_t client_account, uint32_t client_host_ip, uint32_t client_pid)
     {
         ClientId client_id;
         uint64_t clock_offset;
-        int return_code = theVisorClientPortal.ClientConnect(client_account, client_host_ip, client_pid, client_id
-                                                             , clock_offset);
+        int return_code =
+                theVisorClientPortal.ClientConnect(client_account, client_host_ip, client_pid, client_id, clock_offset);
         if(chronolog::CL_SUCCESS == return_code)
-        { request.respond(ConnectResponseMsg(chronolog::CL_SUCCESS, client_id)); }
+        {
+            request.respond(ConnectResponseMsg(chronolog::CL_SUCCESS, client_id));
+        }
         else
-        { request.respond(ConnectResponseMsg(return_code, ClientId{0})); }
+        {
+            request.respond(ConnectResponseMsg(return_code, ClientId{0}));
+        }
     }
 
-    void Disconnect(tl::request const &request, ClientId const &client_token)
+    void Disconnect(tl::request const& request, ClientId const& client_token)
     {
         int return_code = theVisorClientPortal.ClientDisconnect(client_token);
         request.respond(return_code);
     }
 
-    void CreateChronicle(tl::request const &request, ClientId const &client_id, std::string const &chronicle_name
-                         , const std::map <std::string, std::string> &attrs, int &flags)
+    void CreateChronicle(tl::request const& request,
+                         ClientId const& client_id,
+                         std::string const& chronicle_name,
+                         const std::map<std::string, std::string>& attrs,
+                         int& flags)
     {
         int return_code = theVisorClientPortal.CreateChronicle(client_id, chronicle_name, attrs, flags);
         request.respond(return_code);
     }
 
-    void DestroyChronicle(tl::request const &request, ClientId const &client_id, ChronicleName const &chronicle_name)
+    void DestroyChronicle(tl::request const& request, ClientId const& client_id, ChronicleName const& chronicle_name)
     {
         int return_code = theVisorClientPortal.DestroyChronicle(client_id, chronicle_name);
         request.respond(return_code);
     }
 
-    void AcquireStory(tl::request const &request, ClientId const &client_id, std::string const &chronicle_name
-                      , std::string const &story_name, const std::map <std::string, std::string> &attrs
-                      , int &flags)
+    void AcquireStory(tl::request const& request,
+                      ClientId const& client_id,
+                      std::string const& chronicle_name,
+                      std::string const& story_name,
+                      const std::map<std::string, std::string>& attrs,
+                      int& flags)
     {
-        AcquireStoryResponseMsg acquire_response = theVisorClientPortal.AcquireStory(client_id, chronicle_name
-                                                                                     , story_name, attrs, flags);
+        AcquireStoryResponseMsg acquire_response =
+                theVisorClientPortal.AcquireStory(client_id, chronicle_name, story_name, attrs, flags);
         request.respond(acquire_response);
     }
 
-    void ReleaseStory(tl::request const &request, ClientId const &client_id, std::string const &chronicle_name
-                      , std::string const &story_name)
+    void ReleaseStory(tl::request const& request,
+                      ClientId const& client_id,
+                      std::string const& chronicle_name,
+                      std::string const& story_name)
     {
         int return_code = theVisorClientPortal.ReleaseStory(client_id, chronicle_name, story_name);
         request.respond(return_code);
     }
 
-    void DestroyStory(tl::request const &request, ClientId const &client_id, std::string const &chronicle_name
-                      , std::string const &story_name)
+    void DestroyStory(tl::request const& request,
+                      ClientId const& client_id,
+                      std::string const& chronicle_name,
+                      std::string const& story_name)
     {
         request.respond(theVisorClientPortal.DestroyStory(client_id, chronicle_name, story_name));
     }
 
-    void GetChronicleAttr(tl::request const &request, ClientId const &client_id, std::string const &chronicle_name
-                          , std::string const &key, std::string &value)
+    void GetChronicleAttr(tl::request const& request,
+                          ClientId const& client_id,
+                          std::string const& chronicle_name,
+                          std::string const& key,
+                          std::string& value)
     {
         int return_code = theVisorClientPortal.GetChronicleAttr(client_id, chronicle_name, key, value);
         request.respond(return_code);
     }
 
-    void EditChronicleAttr(tl::request const &request, ClientId const &client_id, std::string const &chronicle_name
-                           , std::string const &key, std::string const &value)
+    void EditChronicleAttr(tl::request const& request,
+                           ClientId const& client_id,
+                           std::string const& chronicle_name,
+                           std::string const& key,
+                           std::string const& value)
     {
         int return_code = theVisorClientPortal.EditChronicleAttr(client_id, chronicle_name, key, value);
         request.respond(return_code);
     }
 
-    void ShowChronicles(tl::request const &request, ClientId const &client_id)
+    void ShowChronicles(tl::request const& request, ClientId const& client_id)
     {
-        std::vector <std::string> chronicles;
+        std::vector<std::string> chronicles;
         theVisorClientPortal.ShowChronicles(client_id, chronicles);
         request.respond(chronicles);
     }
 
-    void ShowStories(tl::request const &request, ClientId const &client_id, const std::string &chronicle_name)
+    void ShowStories(tl::request const& request, ClientId const& client_id, const std::string& chronicle_name)
     {
-        std::vector <std::string> stories;
+        std::vector<std::string> stories;
         theVisorClientPortal.ShowStories(client_id, chronicle_name, stories);
 
         request.respond(stories);
     }
 
 private:
-
-    ClientPortalService(tl::engine &tl_engine, uint16_t service_provider_id, VisorClientPortal &visorPortal)
-            : thallium::provider <ClientPortalService>(tl_engine, service_provider_id), theVisorClientPortal(
-            visorPortal)
+    ClientPortalService(tl::engine& tl_engine, uint16_t service_provider_id, VisorClientPortal& visorPortal)
+        : thallium::provider<ClientPortalService>(tl_engine, service_provider_id)
+        , theVisorClientPortal(visorPortal)
     {
         define("Connect", &ClientPortalService::Connect);
         define("Disconnect", &ClientPortalService::Disconnect);
@@ -140,16 +159,15 @@ private:
         std::stringstream ss;
         ss << get_engine().self();
         LOG_INFO("[ClientPortalService] Started at address {} with provider id {}", ss.str(), service_provider_id);
-        get_engine().push_finalize_callback(this, [p = this]()
-        { delete p; });
+        get_engine().push_finalize_callback(this, [p = this]() { delete p; });
     }
 
-    ClientPortalService(ClientPortalService const &) = delete;
+    ClientPortalService(ClientPortalService const&) = delete;
 
-    ClientPortalService &operator=(ClientPortalService const &) = delete;
+    ClientPortalService& operator=(ClientPortalService const&) = delete;
 
-    VisorClientPortal &theVisorClientPortal;
+    VisorClientPortal& theVisorClientPortal;
 };
-}// namespace chronolog
+} // namespace chronolog
 
 #endif

--- a/ChronoVisor/include/ClientRegistryInfo.h
+++ b/ChronoVisor/include/ClientRegistryInfo.h
@@ -6,6 +6,8 @@
 #define SOCKETPP_CLIENTREGISTRYINFO_H
 
 #include <iostream>
+#include <ostream>
+#include <string>
 #include <utility>
 
 class ClientRegistryInfo

--- a/ChronoVisor/include/ClientRegistryInfo.h
+++ b/ChronoVisor/include/ClientRegistryInfo.h
@@ -13,32 +13,31 @@
 class ClientRegistryInfo
 {
 public:
-    ClientRegistryInfo(): addr_()
+    ClientRegistryInfo()
+        : addr_()
     {}
 
-    explicit ClientRegistryInfo(std::string addr): addr_(std::move(addr))
+    explicit ClientRegistryInfo(std::string addr)
+        : addr_(std::move(addr))
     {}
 
-    friend std::ostream &operator<<(std::ostream &out, const ClientRegistryInfo &r)
+    friend std::ostream& operator<<(std::ostream& out, const ClientRegistryInfo& r)
     {
         return out << "addr: " << r.addr_;
     }
 
-    [[nodiscard]] std::string to_string() const
-    {
-        return "addr: " + addr_;
-    }
+    [[nodiscard]] std::string to_string() const { return "addr: " + addr_; }
 
     template <typename A>
-    friend void serialize(A &ar, ClientRegistryInfo &r);
+    friend void serialize(A& ar, ClientRegistryInfo& r);
 
     std::string addr_;
 };
 
 template <typename A>
-void serialize(A &ar, ClientRegistryInfo &r)
+void serialize(A& ar, ClientRegistryInfo& r)
 {
-    ar&r.addr_;
+    ar & r.addr_;
 }
 
 #endif //SOCKETPP_CLIENTREGISTRYINFO_H

--- a/ChronoVisor/include/ClientRegistryManager.h
+++ b/ChronoVisor/include/ClientRegistryManager.h
@@ -24,25 +24,25 @@ public:
 
     ~ClientRegistryManager();
 
-    void setChronicleMetaDirectory(ChronicleMetaDirectory*pChronicleMetaDirectory)
+    void setChronicleMetaDirectory(ChronicleMetaDirectory* pChronicleMetaDirectory)
     {
         chronicleMetaDirectory_ = pChronicleMetaDirectory;
     }
 
-    ClientInfo*get_client_info(chronolog::ClientId const &client_id);
+    ClientInfo* get_client_info(chronolog::ClientId const& client_id);
 
-    int add_story_acquisition(chronolog::ClientId const &client_id, uint64_t &sid, Story*pStory);
+    int add_story_acquisition(chronolog::ClientId const& client_id, uint64_t& sid, Story* pStory);
 
-    int remove_story_acquisition(chronolog::ClientId const &client_id, uint64_t &sid);
+    int remove_story_acquisition(chronolog::ClientId const& client_id, uint64_t& sid);
 
-    int add_client_record(chronolog::ClientId const &client_id, const ClientInfo &record);
+    int add_client_record(chronolog::ClientId const& client_id, const ClientInfo& record);
 
-    int remove_client_record(chronolog::ClientId const &client_id);
+    int remove_client_record(chronolog::ClientId const& client_id);
 
 private:
-    std::unordered_map <chronolog::ClientId, ClientInfo>*clientRegistry_;
+    std::unordered_map<chronolog::ClientId, ClientInfo>* clientRegistry_;
     std::mutex g_clientRegistryMutex_;
-    ChronicleMetaDirectory*chronicleMetaDirectory_{};
+    ChronicleMetaDirectory* chronicleMetaDirectory_{};
 };
 
 #endif //CHRONOLOG_CLIENTREGISTRYMANAGER_H

--- a/ChronoVisor/include/ClientRegistryManager.h
+++ b/ChronoVisor/include/ClientRegistryManager.h
@@ -5,9 +5,10 @@
 #ifndef CHRONOLOG_CLIENTREGISTRYMANAGER_H
 #define CHRONOLOG_CLIENTREGISTRYMANAGER_H
 
+#include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <vector>
-#include <memory>
 
 #include <chronolog_types.h>
 

--- a/ChronoVisor/include/DataStoreAdminClient.h
+++ b/ChronoVisor/include/DataStoreAdminClient.h
@@ -23,16 +23,16 @@ class DataStoreAdminClient
 {
 
 public:
-    static DataStoreAdminClient*
-    CreateDataStoreAdminClient(tl::engine &tl_engine, std::string const &collection_service_addr
-                               , uint16_t collection_provider_id)
+    static DataStoreAdminClient* CreateDataStoreAdminClient(tl::engine& tl_engine,
+                                                            std::string const& collection_service_addr,
+                                                            uint16_t collection_provider_id)
     {
-        DataStoreAdminClient*adminClient = nullptr;
+        DataStoreAdminClient* adminClient = nullptr;
         try
         {
             adminClient = new DataStoreAdminClient(tl_engine, collection_service_addr, collection_provider_id);
         }
-        catch(tl::exception const &ex)
+        catch(tl::exception const& ex)
         {
             LOG_ERROR("[DataStoreAdminClient] Failed to create DataStoreAdminClient");
         }
@@ -47,9 +47,8 @@ public:
         {
             available = collection_service_available.on(service_handle)();
             LOG_DEBUG("[DataStoreAdminClient] Service available: {}", available);
-
         }
-        catch(tl::exception const &ex)
+        catch(tl::exception const& ex)
         {
             LOG_ERROR("[DataStoreAdminClient] Service unavailable: {}", available);
         }
@@ -64,14 +63,15 @@ public:
             LOG_INFO("[DataStoreAdminClient] Shutdown");
             status = shutdown_data_collection.on(service_handle)();
         }
-        catch(tl::exception const &ex)
+        catch(tl::exception const& ex)
         {}
         return status;
     }
 
-    int
-    send_start_story_recording(ChronicleName const &chronicle_name, StoryName const &story_name, StoryId const &story_id
-                               , uint64_t start_time)
+    int send_start_story_recording(ChronicleName const& chronicle_name,
+                                   StoryName const& story_name,
+                                   StoryId const& story_id,
+                                   uint64_t start_time)
     {
         int status = chronolog::CL_ERR_UNKNOWN;
         try
@@ -79,12 +79,12 @@ public:
             LOG_DEBUG("[DataStoreAdminClient] START Story Recording for StoryID={}", story_id);
             status = start_story_recording.on(service_handle)(chronicle_name, story_name, story_id, start_time);
         }
-        catch(tl::exception const &ex)
+        catch(tl::exception const& ex)
         {}
         return status;
     }
 
-    int send_stop_story_recording(StoryId const &story_id)
+    int send_stop_story_recording(StoryId const& story_id)
     {
         int status = chronolog::CL_ERR_UNKNOWN;
         try
@@ -92,7 +92,7 @@ public:
             LOG_DEBUG("[DataStoreAdminClient] STOP Story Recording for StoryId={}", story_id);
             status = stop_story_recording.on(service_handle)(story_id);
         }
-        catch(tl::exception const &ex)
+        catch(tl::exception const& ex)
         {}
         return status;
     }
@@ -106,18 +106,21 @@ public:
     }
 
 private:
-    std::string service_addr;     // na address of Keeper Collection Service 
-    uint16_t service_provider_id;          // Keeper CollectionService provider id
-    tl::provider_handle service_handle;  //provider_handle for remote collector service
+    std::string service_addr;           // na address of Keeper Collection Service
+    uint16_t service_provider_id;       // Keeper CollectionService provider id
+    tl::provider_handle service_handle; //provider_handle for remote collector service
     tl::remote_procedure collection_service_available;
     tl::remote_procedure shutdown_data_collection;
     tl::remote_procedure start_story_recording;
     tl::remote_procedure stop_story_recording;
 
     // constructor is private to make sure thalium rpc objects are created on the heap, not stack
-    DataStoreAdminClient(tl::engine &tl_engine, std::string const &collection_service_addr
-                         , uint16_t collection_provider_id): service_addr(collection_service_addr), service_provider_id(
-            collection_provider_id), service_handle(tl_engine.lookup(collection_service_addr), collection_provider_id)
+    DataStoreAdminClient(tl::engine& tl_engine,
+                         std::string const& collection_service_addr,
+                         uint16_t collection_provider_id)
+        : service_addr(collection_service_addr)
+        , service_provider_id(collection_provider_id)
+        , service_handle(tl_engine.lookup(collection_service_addr), collection_provider_id)
     {
         collection_service_available = tl_engine.define("collection_service_available");
         shutdown_data_collection = tl_engine.define("shutdown_data_collection");
@@ -125,6 +128,6 @@ private:
         stop_story_recording = tl_engine.define("stop_story_recording");
     }
 };
-}
+} // namespace chronolog
 
 #endif

--- a/ChronoVisor/include/DataStoreAdminClient.h
+++ b/ChronoVisor/include/DataStoreAdminClient.h
@@ -1,7 +1,9 @@
 #ifndef DataStoreAdmin_CLIENT_H
 #define DataStoreAdmin_CLIENT_H
 
+#include <cstdint>
 #include <iostream>
+
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>
 

--- a/ChronoVisor/include/KeeperRegistry.h
+++ b/ChronoVisor/include/KeeperRegistry.h
@@ -57,7 +57,7 @@ public:
     }
 
     KeeperProcessEntry(KeeperProcessEntry const& other) = default;
-    ~KeeperProcessEntry() = default;// Registry is reponsible for creating & deleting keeperAdminClient
+    ~KeeperProcessEntry() = default; // Registry is reponsible for creating & deleting keeperAdminClient
 
     KeeperIdCard idCard;
     ServiceId adminServiceId;
@@ -84,7 +84,7 @@ public:
     }
 
     GrapherProcessEntry(GrapherProcessEntry const& other) = default;
-    ~GrapherProcessEntry() = default;// Registry is reponsible for creating & deleting keeperAdminClient
+    ~GrapherProcessEntry() = default; // Registry is reponsible for creating & deleting keeperAdminClient
 
     GrapherIdCard idCard;
     ServiceId adminServiceId;
@@ -94,133 +94,143 @@ public:
     uint64_t lastStatsTime;
     uint32_t activeStoryCount;
     std::list<std::pair<std::time_t, DataStoreAdminClient*>> delayedExitGrapherClients;
-    };
+};
 
 
-    class PlayerProcessEntry
+class PlayerProcessEntry
+{
+public:
+    PlayerProcessEntry(PlayerIdCard const& id_card, ServiceId const& admin_service_id)
+        : idCard(id_card)
+        , adminServiceId(admin_service_id)
+        , adminClient(nullptr)
+        , active(false)
+        , lastStatsTime(0)
     {
-    public:
-        PlayerProcessEntry(PlayerIdCard const& id_card, ServiceId const& admin_service_id)
-            : idCard(id_card)
-            , adminServiceId(admin_service_id)
-            , adminClient(nullptr)
-            , active(false)
-            , lastStatsTime(0)
-        {
-            idCardString += idCard;
-        }
+        idCardString += idCard;
+    }
 
-        PlayerProcessEntry(PlayerProcessEntry const& other) = default;
-        ~PlayerProcessEntry() = default;// Registry is reponsible for creating & deleting AdminClient
+    PlayerProcessEntry(PlayerProcessEntry const& other) = default;
+    ~PlayerProcessEntry() = default; // Registry is reponsible for creating & deleting AdminClient
 
-        PlayerIdCard idCard;
-        ServiceId adminServiceId;
-        std::string idCardString;
-        DataStoreAdminClient* adminClient;
-        bool active;
-        uint64_t lastStatsTime;
-        uint32_t activeStoryCount;
-        std::list<std::pair<std::time_t, DataStoreAdminClient*>> delayedExitPlayerClients;
-    };
+    PlayerIdCard idCard;
+    ServiceId adminServiceId;
+    std::string idCardString;
+    DataStoreAdminClient* adminClient;
+    bool active;
+    uint64_t lastStatsTime;
+    uint32_t activeStoryCount;
+    std::list<std::pair<std::time_t, DataStoreAdminClient*>> delayedExitPlayerClients;
+};
 
 
+class RecordingGroup
+{
+public:
+    RecordingGroup(RecordingGroupId group_id,
+                   GrapherProcessEntry* grapher_ptr = nullptr,
+                   PlayerProcessEntry* player_ptr = nullptr)
+        : groupId(group_id)
+        , activeKeeperCount(0)
+        , grapherProcess(grapher_ptr)
+        , playerProcess(player_ptr)
+    {}
 
+    RecordingGroup(RecordingGroup const& other) = default;
+    ~RecordingGroup() = default;
 
+    bool isActive() const;
+    void startDelayedGrapherExit(GrapherProcessEntry&, std::time_t);
+    void clearDelayedExitGrapher(GrapherProcessEntry&, std::time_t);
+    void startDelayedKeeperExit(KeeperProcessEntry&, std::time_t);
+    void clearDelayedExitKeeper(KeeperProcessEntry&, std::time_t);
+    void startDelayedPlayerExit(PlayerProcessEntry&, std::time_t);
+    void clearDelayedExitPlayer(PlayerProcessEntry&, std::time_t);
 
-    class RecordingGroup
+    std::vector<KeeperIdCard>& getActiveKeepers(std::vector<KeeperIdCard>& keeper_id_cards);
+
+    RecordingGroupId groupId;
+    size_t activeKeeperCount;
+    GrapherProcessEntry* grapherProcess;
+    PlayerProcessEntry* playerProcess;
+    std::map<std::pair<uint32_t, uint16_t>, KeeperProcessEntry> keeperProcesses;
+};
+
+class KeeperRegistry
+{
+    enum RegistryState
     {
-    public:
-        RecordingGroup(RecordingGroupId group_id, GrapherProcessEntry* grapher_ptr = nullptr, PlayerProcessEntry* player_ptr=nullptr)
-            : groupId(group_id)
-            , activeKeeperCount(0)
-            , grapherProcess(grapher_ptr)
-            , playerProcess(player_ptr)
-        {}
-
-        RecordingGroup(RecordingGroup const& other) = default;
-        ~RecordingGroup() = default;
-
-        bool isActive() const;
-        void startDelayedGrapherExit(GrapherProcessEntry&, std::time_t);
-        void clearDelayedExitGrapher(GrapherProcessEntry&, std::time_t);
-        void startDelayedKeeperExit(KeeperProcessEntry&, std::time_t);
-        void clearDelayedExitKeeper(KeeperProcessEntry&, std::time_t);
-        void startDelayedPlayerExit(PlayerProcessEntry&, std::time_t);
-        void clearDelayedExitPlayer(PlayerProcessEntry&, std::time_t);
-
-        std::vector<KeeperIdCard>& getActiveKeepers(std::vector<KeeperIdCard>& keeper_id_cards);
-
-        RecordingGroupId groupId;
-        size_t activeKeeperCount;
-        GrapherProcessEntry* grapherProcess;
-        PlayerProcessEntry* playerProcess;
-        std::map<std::pair<uint32_t, uint16_t>, KeeperProcessEntry> keeperProcesses;
+        UNKNOWN = 0,
+        INITIALIZED = 1,  // RegistryService is initialized, no active keepers
+        RUNNING = 2,      // RegistryService and active Keepers
+        SHUTTING_DOWN = 3 // Shutting down services
     };
 
-    class KeeperRegistry
-    {
-        enum RegistryState
-        {
-            UNKNOWN = 0,
-            INITIALIZED = 1, // RegistryService is initialized, no active keepers
-            RUNNING = 2,     // RegistryService and active Keepers
-            SHUTTING_DOWN = 3// Shutting down services
-        };
+public:
+    KeeperRegistry();
 
-    public:
-        KeeperRegistry();
+    ~KeeperRegistry();
 
-        ~KeeperRegistry();
+    bool is_initialized() const { return (INITIALIZED == registryState); }
 
-        bool is_initialized() const { return (INITIALIZED == registryState); }
+    bool is_running() const { return (RUNNING == registryState); }
 
-        bool is_running() const { return (RUNNING == registryState); }
+    bool is_shutting_down() const { return (SHUTTING_DOWN == registryState); }
 
-        bool is_shutting_down() const { return (SHUTTING_DOWN == registryState); }
+    int InitializeRegistryService(VisorConfiguration const&);
 
-        int InitializeRegistryService(VisorConfiguration const&);
+    int ShutdownRegistryService();
 
-        int ShutdownRegistryService();
+    int registerKeeperProcess(KeeperRegistrationMsg const& keeper_reg_msg);
+    int unregisterKeeperProcess(KeeperIdCard const& keeper_id_card);
+    void updateKeeperProcessStats(KeeperStatsMsg const& keeperStatsMsg);
 
-        int registerKeeperProcess(KeeperRegistrationMsg const& keeper_reg_msg);
-        int unregisterKeeperProcess(KeeperIdCard const& keeper_id_card);
-        void updateKeeperProcessStats(KeeperStatsMsg const& keeperStatsMsg);
+    int notifyRecordingGroupOfStoryRecordingStart(ChronicleName const&,
+                                                  StoryName const&,
+                                                  StoryId const&,
+                                                  std::vector<KeeperIdCard>&,
+                                                  ServiceId&);
+    int notifyRecordingGroupOfStoryRecordingStop(StoryId const&);
 
-        int notifyRecordingGroupOfStoryRecordingStart(ChronicleName const &, StoryName const &, StoryId const &
-                                                      , std::vector <KeeperIdCard> &, ServiceId &);
-        int notifyRecordingGroupOfStoryRecordingStop(StoryId const&);
+    int registerGrapherProcess(GrapherRegistrationMsg const& reg_msg);
+    int unregisterGrapherProcess(GrapherIdCard const& id_card);
+    void updateGrapherProcessStats(GrapherStatsMsg const&);
 
-        int registerGrapherProcess(GrapherRegistrationMsg const& reg_msg);
-        int unregisterGrapherProcess(GrapherIdCard const& id_card);
-        void updateGrapherProcessStats(GrapherStatsMsg const& );
+    int registerPlayerProcess(PlayerRegistrationMsg const& reg_msg);
+    int unregisterPlayerProcess(PlayerIdCard const& id_card);
+    void updatePlayerProcessStats(PlayerStatsMsg const&);
 
-        int registerPlayerProcess(PlayerRegistrationMsg const& reg_msg);
-        int unregisterPlayerProcess(PlayerIdCard const& id_card);
-        void updatePlayerProcessStats(PlayerStatsMsg const& );
+private:
+    KeeperRegistry(KeeperRegistry const&) = delete; //disable copying
+    KeeperRegistry& operator=(KeeperRegistry const&) = delete;
 
-    private:
-        KeeperRegistry(KeeperRegistry const&) = delete;//disable copying
-        KeeperRegistry& operator=(KeeperRegistry const&) = delete;
+    int notifyGrapherOfStoryRecordingStart(RecordingGroup&,
+                                           ChronicleName const&,
+                                           StoryName const&,
+                                           StoryId const&,
+                                           uint64_t);
+    int notifyGrapherOfStoryRecordingStop(RecordingGroup&, StoryId const&);
+    int notifyKeepersOfStoryRecordingStart(RecordingGroup&,
+                                           std::vector<KeeperIdCard>&,
+                                           ChronicleName const&,
+                                           StoryName const&,
+                                           StoryId const&,
+                                           uint64_t);
+    int notifyKeepersOfStoryRecordingStop(RecordingGroup&, std::vector<KeeperIdCard> const&, StoryId const&);
 
-        int notifyGrapherOfStoryRecordingStart(RecordingGroup &, ChronicleName const &, StoryName const &, StoryId const & , uint64_t);
-        int notifyGrapherOfStoryRecordingStop(RecordingGroup&, StoryId const&);
-        int notifyKeepersOfStoryRecordingStart(RecordingGroup&, std::vector<KeeperIdCard> &, ChronicleName const &
-                                               , StoryName const &, StoryId const &, uint64_t);
-        int notifyKeepersOfStoryRecordingStop(RecordingGroup &, std::vector <KeeperIdCard> const &, StoryId const &);
+    RegistryState registryState;
+    std::mutex registryLock;
+    thallium::engine* registryEngine;
+    KeeperRegistryService* keeperRegistryService;
+    std::string dataStoreAdminServiceProtocol;
+    size_t delayedDataAdminExitSeconds;
 
-        RegistryState registryState;
-        std::mutex registryLock;
-        thallium::engine* registryEngine;
-        KeeperRegistryService* keeperRegistryService;
-        std::string dataStoreAdminServiceProtocol;
-        size_t delayedDataAdminExitSeconds;
-
-        std::map<RecordingGroupId, RecordingGroup> recordingGroups;
-        std::vector<RecordingGroup*> activeGroups;
-        std::mt19937 mt_random;//mersene twister random int generator
-        std::uniform_int_distribution<size_t> group_id_distribution;
-        std::map<StoryId, RecordingGroup*> activeStories;
-    };
-}
+    std::map<RecordingGroupId, RecordingGroup> recordingGroups;
+    std::vector<RecordingGroup*> activeGroups;
+    std::mt19937 mt_random; //mersene twister random int generator
+    std::uniform_int_distribution<size_t> group_id_distribution;
+    std::map<StoryId, RecordingGroup*> activeStories;
+};
+} // namespace chronolog
 
 #endif

--- a/ChronoVisor/include/KeeperRegistry.h
+++ b/ChronoVisor/include/KeeperRegistry.h
@@ -2,9 +2,14 @@
 #define KEEPER_REGISTRY_H
 
 #include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <list>
 #include <map>
 #include <mutex>
 #include <random>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <thallium.hpp>

--- a/ChronoVisor/include/KeeperRegistryService.h
+++ b/ChronoVisor/include/KeeperRegistryService.h
@@ -24,13 +24,13 @@ namespace tl = thallium;
 namespace chronolog
 {
 
-class KeeperRegistryService: public tl::provider <KeeperRegistryService>
+class KeeperRegistryService: public tl::provider<KeeperRegistryService>
 {
 
 private:
-    KeeperRegistry &theKeeperProcessRegistry;
+    KeeperRegistry& theKeeperProcessRegistry;
 
-    void register_keeper(tl::request const &request, chronolog::KeeperRegistrationMsg const &keeperMsg)
+    void register_keeper(tl::request const& request, chronolog::KeeperRegistrationMsg const& keeperMsg)
     {
         int return_code = 0;
         std::stringstream ss, s1;
@@ -41,7 +41,7 @@ private:
         request.respond(return_code);
     }
 
-    void unregister_keeper(tl::request const &request, chronolog::KeeperIdCard const &keeper_id_card)
+    void unregister_keeper(tl::request const& request, chronolog::KeeperIdCard const& keeper_id_card)
     {
         int return_code = 0;
         std::stringstream ss;
@@ -51,16 +51,17 @@ private:
         request.respond(return_code);
     }
 
-    void handle_stats_msg(chronolog::KeeperStatsMsg const &keeper_stats_msg)
+    void handle_stats_msg(chronolog::KeeperStatsMsg const& keeper_stats_msg)
     {
         std::stringstream ss;
         ss << keeper_stats_msg.getKeeperIdCard();
-        LOG_DEBUG("[RegistryService] Keeper Stats: KeeperIdCard: {}, ActiveStoryCount: {}", ss.str()
-             , keeper_stats_msg.getActiveStoryCount());
+        LOG_DEBUG("[RegistryService] Keeper Stats: KeeperIdCard: {}, ActiveStoryCount: {}",
+                  ss.str(),
+                  keeper_stats_msg.getActiveStoryCount());
         theKeeperProcessRegistry.updateKeeperProcessStats(keeper_stats_msg);
     }
 
-    void register_grapher(tl::request const &request, chronolog::GrapherRegistrationMsg const & registrationMsg)
+    void register_grapher(tl::request const& request, chronolog::GrapherRegistrationMsg const& registrationMsg)
     {
         int return_code = 0;
         std::stringstream ss;
@@ -70,23 +71,24 @@ private:
         request.respond(return_code);
     }
 
-    void unregister_grapher(tl::request const &request, chronolog::GrapherIdCard const &id_card)
+    void unregister_grapher(tl::request const& request, chronolog::GrapherIdCard const& id_card)
     {
         int return_code = 0;
         return_code = theKeeperProcessRegistry.unregisterGrapherProcess(id_card);
         request.respond(return_code);
     }
 
-    void handle_grapher_stats_msg(chronolog::GrapherStatsMsg const & stats_msg)
+    void handle_grapher_stats_msg(chronolog::GrapherStatsMsg const& stats_msg)
     {
         std::stringstream ss;
         ss << stats_msg.getGrapherIdCard();
-        LOG_DEBUG("[RegistryService] Grapher Stats: GrapherIdCard: {}, ActiveStoryCount: {}", ss.str()
-             , stats_msg.getActiveStoryCount());
+        LOG_DEBUG("[RegistryService] Grapher Stats: GrapherIdCard: {}, ActiveStoryCount: {}",
+                  ss.str(),
+                  stats_msg.getActiveStoryCount());
         theKeeperProcessRegistry.updateGrapherProcessStats(stats_msg);
     }
 
-    void register_player(tl::request const &request, chronolog::PlayerRegistrationMsg const & registrationMsg)
+    void register_player(tl::request const& request, chronolog::PlayerRegistrationMsg const& registrationMsg)
     {
         int return_code = 0;
         std::stringstream ss;
@@ -96,7 +98,7 @@ private:
         request.respond(return_code);
     }
 
-    void unregister_player(tl::request const &request, chronolog::PlayerIdCard const &id_card)
+    void unregister_player(tl::request const& request, chronolog::PlayerIdCard const& id_card)
     {
         int return_code = 0;
         LOG_INFO("[RegistryService] unregister_player: {}", chronolog::to_string(id_card));
@@ -104,18 +106,18 @@ private:
         request.respond(return_code);
     }
 
-    void handle_player_stats_msg(chronolog::PlayerStatsMsg const & stats_msg)
+    void handle_player_stats_msg(chronolog::PlayerStatsMsg const& stats_msg)
     {
         std::stringstream ss;
         ss << stats_msg.getPlayerIdCard();
-       // LOG_DEBUG("[KeeperRegistryService] Player Stats: PlayerIdCard: {}", chrono::to_string(stats_msg));
+        // LOG_DEBUG("[KeeperRegistryService] Player Stats: PlayerIdCard: {}", chrono::to_string(stats_msg));
         theKeeperProcessRegistry.updatePlayerProcessStats(stats_msg);
     }
 
 
-    KeeperRegistryService(tl::engine &tl_engine, uint16_t service_provider_id, KeeperRegistry &keeperRegistry)
-            : tl::provider <KeeperRegistryService>(tl_engine, service_provider_id), theKeeperProcessRegistry(
-            keeperRegistry)
+    KeeperRegistryService(tl::engine& tl_engine, uint16_t service_provider_id, KeeperRegistry& keeperRegistry)
+        : tl::provider<KeeperRegistryService>(tl_engine, service_provider_id)
+        , theKeeperProcessRegistry(keeperRegistry)
     {
         define("register_keeper", &KeeperRegistryService::register_keeper);
         define("unregister_keeper", &KeeperRegistryService::unregister_keeper);
@@ -127,28 +129,23 @@ private:
         define("unregister_player", &KeeperRegistryService::unregister_player);
         define("handle_player_stats_msg", &KeeperRegistryService::handle_player_stats_msg, tl::ignore_return_value());
         //setup finalization callback in case this ser vice provider is still alive when the engine is finalized
-        get_engine().push_finalize_callback(this, [p = this]()
-        { delete p; });
+        get_engine().push_finalize_callback(this, [p = this]() { delete p; });
     }
 
-    KeeperRegistryService(KeeperRegistryService const &) = delete;
+    KeeperRegistryService(KeeperRegistryService const&) = delete;
 
-    KeeperRegistryService &operator=(KeeperRegistryService const &) = delete;
+    KeeperRegistryService& operator=(KeeperRegistryService const&) = delete;
 
 
 public:
-
     static KeeperRegistryService*
-    CreateKeeperRegistryService(tl::engine &tl_engine, uint16_t service_provider_id, KeeperRegistry &keeperRegistry)
+    CreateKeeperRegistryService(tl::engine& tl_engine, uint16_t service_provider_id, KeeperRegistry& keeperRegistry)
     {
         return new KeeperRegistryService(tl_engine, service_provider_id, keeperRegistry);
     }
 
-    ~KeeperRegistryService()
-    {
-        get_engine().pop_finalize_callback(this);
-    }
+    ~KeeperRegistryService() { get_engine().pop_finalize_callback(this); }
 };
-}// namespace chronolog
+} // namespace chronolog
 
 #endif

--- a/ChronoVisor/include/KeeperRegistryService.h
+++ b/ChronoVisor/include/KeeperRegistryService.h
@@ -2,6 +2,8 @@
 #define KEEPER_REGISTRY_SERVICE_H
 
 #include <iostream>
+#include <sstream>
+
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>
 

--- a/ChronoVisor/include/Story.h
+++ b/ChronoVisor/include/Story.h
@@ -5,12 +5,16 @@
 #ifndef CHRONOLOG_STORY_H
 #define CHRONOLOG_STORY_H
 
-#include <unordered_map>
-#include <map>
 #include <atomic>
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
 #include <Event.h>
 #include <city.h>
-#include <mutex>
 #include <chronolog_errcode.h>
 #include <chrono_monitor.h>
 

--- a/ChronoVisor/include/Story.h
+++ b/ChronoVisor/include/Story.h
@@ -22,17 +22,23 @@
 
 enum StoryIndexingGranularity
 {
-    story_gran_ns = 0, story_gran_us = 1, story_gran_ms = 2, story_gran_sec = 3
+    story_gran_ns = 0,
+    story_gran_us = 1,
+    story_gran_ms = 2,
+    story_gran_sec = 3
 };
 
 enum StoryType
 {
-    story_type_standard = 0, story_type_priority = 1
+    story_type_standard = 0,
+    story_type_priority = 1
 };
 
 enum StoryTieringPolicy
 {
-    story_tiering_normal = 0, story_tiering_hot = 1, story_tiering_cold = 2
+    story_tiering_normal = 0,
+    story_tiering_hot = 1,
+    story_tiering_cold = 2
 };
 
 typedef struct StoryAttrs_
@@ -64,54 +70,43 @@ public:
         stats_.count = 0;
     }
 
-    const std::string &getName() const
-    { return name_; }
+    const std::string& getName() const { return name_; }
 
-    uint64_t getSid() const
-    { return sid_; }
+    uint64_t getSid() const { return sid_; }
 
-    uint64_t getCid() const
-    { return cid_; }
+    uint64_t getCid() const { return cid_; }
 
-    const StoryStats &getStats() const
-    { return stats_; }
+    const StoryStats& getStats() const { return stats_; }
 
-    const std::unordered_map <std::string, std::string> &getProperty() const
-    { return propertyList_; }
+    const std::unordered_map<std::string, std::string>& getProperty() const { return propertyList_; }
 
-    const std::unordered_map <std::string, Event> &getEventMap() const
-    { return eventMap_; }
+    const std::unordered_map<std::string, Event>& getEventMap() const { return eventMap_; }
 
-    void setName(const std::string &name)
-    { name_ = name; }
+    void setName(const std::string& name) { name_ = name; }
 
-    void setSid(uint64_t sid)
-    { sid_ = sid; }
+    void setSid(uint64_t sid) { sid_ = sid; }
 
-    void setCid(uint64_t cid)
-    { cid_ = cid; }
+    void setCid(uint64_t cid) { cid_ = cid; }
 
-    void setStats(const StoryStats &stats)
-    { stats_ = stats; }
+    void setStats(const StoryStats& stats) { stats_ = stats; }
 
-    std::unordered_map <chronolog::ClientId, ClientInfo*> &getAcquirerMap()
-    {
-        return acquirerClientMap_;
-    }
+    std::unordered_map<chronolog::ClientId, ClientInfo*>& getAcquirerMap() { return acquirerClientMap_; }
 
-    void addAcquirerClient(chronolog::ClientId const &client_id, ClientInfo*clientInfo)
+    void addAcquirerClient(chronolog::ClientId const& client_id, ClientInfo* clientInfo)
     {
         if(nullptr == clientInfo)
-        { return; }
+        {
+            return;
+        }
 
-        std::lock_guard <std::mutex> acquirerClientListLock(acquirerClientMapMutex_);
+        std::lock_guard<std::mutex> acquirerClientListLock(acquirerClientMapMutex_);
         acquirerClientMap_.emplace(client_id, clientInfo);
         LOG_DEBUG("[Story] Acquirer ClientID={} is added to StoryName={}", client_id, name_.c_str());
     }
 
-    int removeAcquirerClient(chronolog::ClientId const &client_id)
+    int removeAcquirerClient(chronolog::ClientId const& client_id)
     {
-        std::lock_guard <std::mutex> acquirerClientListLock(acquirerClientMapMutex_);
+        std::lock_guard<std::mutex> acquirerClientListLock(acquirerClientMapMutex_);
         if(isAcquiredByClient(client_id))
         {
             acquirerClientMap_.erase(client_id);
@@ -125,7 +120,7 @@ public:
         }
     }
 
-    bool isAcquiredByClient(chronolog::ClientId const &client_id)
+    bool isAcquiredByClient(chronolog::ClientId const& client_id)
     {
         if(acquirerClientMap_.find(client_id) != acquirerClientMap_.end())
         {
@@ -137,16 +132,12 @@ public:
         }
     }
 
-    void setProperty(const std::map <std::string, std::string> &attrs)
+    void setProperty(const std::map<std::string, std::string>& attrs)
     {
-        for(auto const &entry: attrs)
-        {
-            propertyList_.emplace(entry.first, entry.second);
-        }
+        for(auto const& entry: attrs) { propertyList_.emplace(entry.first, entry.second); }
     }
 
-    void setEventMap(const std::unordered_map <std::string, Event> &eventMap)
-    { eventMap_ = eventMap; }
+    void setEventMap(const std::unordered_map<std::string, Event>& eventMap) { eventMap_ = eventMap; }
 
     uint64_t incrementAcquisitionCount()
     {
@@ -160,10 +151,9 @@ public:
         return stats_.count;
     }
 
-    uint64_t getAcquisitionCount() const
-    { return stats_.count; }
+    uint64_t getAcquisitionCount() const { return stats_.count; }
 
-    friend std::ostream &operator<<(std::ostream &os, const Story &story);
+    friend std::ostream& operator<<(std::ostream& os, const Story& story);
 
 private:
     std::string name_;
@@ -171,13 +161,13 @@ private:
     uint64_t cid_{};
     StoryAttrs attrs_{};
     StoryStats stats_{};
-    std::unordered_map <chronolog::ClientId, ClientInfo*> acquirerClientMap_;
+    std::unordered_map<chronolog::ClientId, ClientInfo*> acquirerClientMap_;
     std::mutex acquirerClientMapMutex_;
-    std::unordered_map <std::string, std::string> propertyList_;
-    std::unordered_map <std::string, Event> eventMap_;
+    std::unordered_map<std::string, std::string> propertyList_;
+    std::unordered_map<std::string, Event> eventMap_;
 };
 
-inline std::ostream &operator<<(std::ostream &os, const Story &story)
+inline std::ostream& operator<<(std::ostream& os, const Story& story)
 {
     os << "name: " << story.name_ << ", " << "sid: " << story.sid_ << ", " << "access count: " << story.stats_.count;
     return os;

--- a/ChronoVisor/include/VisorClientPortal.h
+++ b/ChronoVisor/include/VisorClientPortal.h
@@ -7,8 +7,8 @@
 
 #include <thallium.hpp>
 
-#include "chronolog_types.h"
-#include "ConfigurationManager.h"
+#include <chronolog_types.h>
+#include <ConfigurationManager.h>
 
 #include "ClientRegistryManager.h"
 #include "ChronicleMetaDirectory.h"

--- a/ChronoVisor/include/VisorClientPortal.h
+++ b/ChronoVisor/include/VisorClientPortal.h
@@ -28,7 +28,9 @@ class VisorClientPortal
 
     enum ClientPortalState
     {
-        UNKNOWN = 0, INITIALIZED = 1, RUNNING = 2, // RegistryService and ClientPortalService are up and running
+        UNKNOWN = 0,
+        INITIALIZED = 1,
+        RUNNING = 2,      // RegistryService and ClientPortalService are up and running
         SHUTTING_DOWN = 3 // Shutting down services
     };
 
@@ -38,63 +40,67 @@ public:
 
     ~VisorClientPortal();
 
-    int StartServices(VisorConfiguration const &, KeeperRegistry*);
+    int StartServices(VisorConfiguration const&, KeeperRegistry*);
 
     void ShutdownServices();
 
-    int ClientConnect(uint32_t client_account, uint32_t client_host_ip, uint32_t client_pid, ClientId &
-                      , uint64_t &clock_offset);
+    int ClientConnect(uint32_t client_account,
+                      uint32_t client_host_ip,
+                      uint32_t client_pid,
+                      ClientId&,
+                      uint64_t& clock_offset);
 
-    int ClientDisconnect(ClientId const &client_id);
+    int ClientDisconnect(ClientId const& client_id);
 
-    int CreateChronicle(ClientId const &name, ChronicleName const &
-                        , const std::map <std::string, std::string> &attrs, int &flags);
+    int CreateChronicle(ClientId const& name,
+                        ChronicleName const&,
+                        const std::map<std::string, std::string>& attrs,
+                        int& flags);
 
-    int DestroyChronicle(ClientId const &client_id, ChronicleName const &chronicle_name);
+    int DestroyChronicle(ClientId const& client_id, ChronicleName const& chronicle_name);
 
-    int DestroyStory(ClientId const &client_id, std::string const &chronicle_name, std::string const &story_name);
+    int DestroyStory(ClientId const& client_id, std::string const& chronicle_name, std::string const& story_name);
 
-    AcquireStoryResponseMsg AcquireStory(ClientId const &client_id,
-            std::string const &chronicle_name, std::string const &story_name
-            , const std::map <std::string, std::string> &attrs, int &flags);
+    AcquireStoryResponseMsg AcquireStory(ClientId const& client_id,
+                                         std::string const& chronicle_name,
+                                         std::string const& story_name,
+                                         const std::map<std::string, std::string>& attrs,
+                                         int& flags);
 
-    int ReleaseStory(ClientId const &client_id, std::string const &chronicle_name, std::string const &story_name);
+    int ReleaseStory(ClientId const& client_id, std::string const& chronicle_name, std::string const& story_name);
 
-/*int ReleaseStory( ClientId const&client_id, StoryId const&);
+    /*int ReleaseStory( ClientId const&client_id, StoryId const&);
 int DestroyStory( ClientId const&client_id, StoryId const&);
 */
     int
-    GetChronicleAttr(ClientId const &, std::string const &chronicle_name, std::string const &key, std::string &value);
+    GetChronicleAttr(ClientId const&, std::string const& chronicle_name, std::string const& key, std::string& value);
 
     int
-    EditChronicleAttr(ClientId const &, std::string const &chronicle, std::string const &key, std::string const &value);
+    EditChronicleAttr(ClientId const&, std::string const& chronicle, std::string const& key, std::string const& value);
 
-    int ShowChronicles(ClientId const &client_id, std::vector <std::string> &);
+    int ShowChronicles(ClientId const& client_id, std::vector<std::string>&);
 
-    int ShowStories(ClientId const &client_id, std::string const &chronicle_name, std::vector <std::string> &);
+    int ShowStories(ClientId const& client_id, std::string const& chronicle_name, std::vector<std::string>&);
 
 
 private:
-
     // role based authentication dummies return true for any client_id for the time being
     // TODO: will be implemented when we add ClientAuthentication module
     bool is_client_authenticated(uint32_t client_account);
 
-    bool chronicle_action_is_authorized(ClientId const &, ChronicleName const &);
+    bool chronicle_action_is_authorized(ClientId const&, ChronicleName const&);
 
-    bool story_action_is_authorized(ClientId const &, ChronicleName const &, StoryName const &);
+    bool story_action_is_authorized(ClientId const&, ChronicleName const&, StoryName const&);
 
-    //ChronoLog::ConfigurationManager & visorConfiguration; 
+    //ChronoLog::ConfigurationManager & visorConfiguration;
     ClientPortalState clientPortalState;
-    thallium::engine*clientPortalEngine;
-    ClientPortalService*clientPortalService;
-    chronolog::KeeperRegistry*theKeeperRegistry;
+    thallium::engine* clientPortalEngine;
+    ClientPortalService* clientPortalService;
+    chronolog::KeeperRegistry* theKeeperRegistry;
     ClientRegistryManager clientManager;
     ChronicleMetaDirectory chronicleMetaDirectory;
-
-
 };
 
-}
+} // namespace chronolog
 
 #endif

--- a/ChronoVisor/src/ChronicleMetaDirectory.cpp
+++ b/ChronoVisor/src/ChronicleMetaDirectory.cpp
@@ -1,8 +1,13 @@
 #include <chrono>
 #include <unistd.h>
 #include <mutex>
+#include <string>
+#include <map>
+#include <vector>
 #include <typedefs.h>
 
+#include <chrono_monitor.h>
+#include <chronolog_errcode.h>
 #include <ClientRegistryManager.h>
 #include <ChronicleMetaDirectory.h>
 #include <city.h>

--- a/ChronoVisor/src/ChronicleMetaDirectory.cpp
+++ b/ChronoVisor/src/ChronicleMetaDirectory.cpp
@@ -16,15 +16,13 @@ namespace chl = chronolog;
 
 ChronicleMetaDirectory::ChronicleMetaDirectory()
 {
-    LOG_DEBUG("[ChronicleMetaDirectory] Constructor is called. Object created at {} in thread PID={}"
-         , static_cast<const void*>(this), getpid());
-    chronicleMap_ = new std::unordered_map <uint64_t, Chronicle*>();
+    LOG_DEBUG("[ChronicleMetaDirectory] Constructor is called. Object created at {} in thread PID={}",
+              static_cast<const void*>(this),
+              getpid());
+    chronicleMap_ = new std::unordered_map<uint64_t, Chronicle*>();
 }
 
-ChronicleMetaDirectory::~ChronicleMetaDirectory()
-{
-    delete chronicleMap_;
-}
+ChronicleMetaDirectory::~ChronicleMetaDirectory() { delete chronicleMap_; }
 
 /**
  * Create a Chronicle
@@ -34,16 +32,17 @@ ChronicleMetaDirectory::~ChronicleMetaDirectory()
  *         chronolog::CL_ERR_CHRONICLE_EXISTS if a Chronicle with the same name already exists \n
  *         chronolog::CL_ERR_UNKNOWN otherwise
  */
-int ChronicleMetaDirectory::create_chronicle(const std::string &name
-                                             , const std::map <std::string, std::string> &attrs)
+int ChronicleMetaDirectory::create_chronicle(const std::string& name, const std::map<std::string, std::string>& attrs)
 {
     LOG_DEBUG("[ChronicleMetaDirectory] Creating Chronicle Name={}", name.c_str());
     for(auto iter = attrs.begin(); iter != attrs.end(); ++iter)
     {
-        LOG_DEBUG("[ChronicleMetaDirectory] Attribute of Chronicle {}: {}={}", name.c_str(), iter->first.c_str()
-             , iter->second.c_str());
+        LOG_DEBUG("[ChronicleMetaDirectory] Attribute of Chronicle {}: {}={}",
+                  name.c_str(),
+                  iter->first.c_str(),
+                  iter->second.c_str());
     }
-    std::lock_guard <std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
+    std::lock_guard<std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
     /* Check if Chronicle already exists, fail if true */
     uint64_t cid;
     cid = CityHash64(name.c_str(), name.length());
@@ -53,7 +52,7 @@ int ChronicleMetaDirectory::create_chronicle(const std::string &name
         LOG_WARNING("[ChronicleMetaDirectory] A Chronicle with the same ChronicleName={} already exists", name.c_str());
         return chronolog::CL_ERR_CHRONICLE_EXISTS;
     }
-    auto*pChronicle = new Chronicle();
+    auto* pChronicle = new Chronicle();
     pChronicle->setName(name);
     pChronicle->setCid(cid);
     auto res = chronicleMap_->emplace(cid, pChronicle);
@@ -79,10 +78,10 @@ int ChronicleMetaDirectory::create_chronicle(const std::string &name
  *         chronolog::CL_ERR_ACQUIRED if the Chronicle is acquired by others and cannot be destroyed \n
  *         chronolog::CL_ERR_UNKNOWN otherwise
  */
-int ChronicleMetaDirectory::destroy_chronicle(const std::string &name)
+int ChronicleMetaDirectory::destroy_chronicle(const std::string& name)
 {
     LOG_DEBUG("[ChronicleMetaDirectory] Destroying ChronicleName={}", name.c_str());
-    std::lock_guard <std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
+    std::lock_guard<std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
     /* First check if Chronicle exists, fail if false */
     uint64_t cid;
     cid = CityHash64(name.c_str(), name.length());
@@ -90,19 +89,22 @@ int ChronicleMetaDirectory::destroy_chronicle(const std::string &name)
     if(chronicleMapRecord != chronicleMap_->end())
     {
         /* Check if Chronicle is acquired by checking if each of its Story is acquired, fail if true */
-        Chronicle*pChronicle = chronicleMapRecord->second;
+        Chronicle* pChronicle = chronicleMapRecord->second;
         auto storyMap = pChronicle->getStoryMap();
         int ret = chronolog::CL_SUCCESS;
         for(auto storyMapRecord: storyMap)
         {
-            Story*pStory = storyMapRecord.second;
+            Story* pStory = storyMapRecord.second;
             if(!pStory->getAcquirerMap().empty())
             {
                 ret = chronolog::CL_ERR_ACQUIRED;
-                for(const auto &acquirerMapRecord: pStory->getAcquirerMap())
+                for(const auto& acquirerMapRecord: pStory->getAcquirerMap())
                 {
-                    LOG_DEBUG("[ChronicleMetaDirectory] StoryID={} in Chronicle Name={} is still acquired by ClientID={}"
-                         , pStory->getSid(), name.c_str(), acquirerMapRecord.first);
+                    LOG_DEBUG(
+                            "[ChronicleMetaDirectory] StoryID={} in Chronicle Name={} is still acquired by ClientID={}",
+                            pStory->getSid(),
+                            name.c_str(),
+                            acquirerMapRecord.first);
                 }
             }
         }
@@ -112,8 +114,9 @@ int ChronicleMetaDirectory::destroy_chronicle(const std::string &name)
         }
         if(pChronicle->getAcquisitionCount() != 0)
         {
-            LOG_ERROR("[ChronicleMetaDirectory] Something is wrong, no Story is being acquired, but ChronicleName={}'s AcquisitionCount is not 0"
-                 , name.c_str());
+            LOG_ERROR("[ChronicleMetaDirectory] Something is wrong, no Story is being acquired, but ChronicleName={}'s "
+                      "AcquisitionCount is not 0",
+                      name.c_str());
             return chronolog::CL_ERR_UNKNOWN;
         }
         /* No Stories in Chronicle is acquired, ready to destroy */
@@ -148,18 +151,19 @@ int ChronicleMetaDirectory::destroy_chronicle(const std::string &name)
  *         chronolog::CL_ERR_NOT_EXIST if the Chronicle does not exist \n
  *         chronolog::CL_ERR_UNKNOWN otherwise
  */
-int ChronicleMetaDirectory::destroy_story(std::string const &chronicle_name, const std::string &story_name)
+int ChronicleMetaDirectory::destroy_story(std::string const& chronicle_name, const std::string& story_name)
 {
-    LOG_DEBUG("[ChronicleMetaDirectory] Destroying StoryName={} in ChronicleName={}", story_name.c_str()
-         , chronicle_name.c_str());
-    std::lock_guard <std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
+    LOG_DEBUG("[ChronicleMetaDirectory] Destroying StoryName={} in ChronicleName={}",
+              story_name.c_str(),
+              chronicle_name.c_str());
+    std::lock_guard<std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
     /* First check if Chronicle exists, fail if false */
     uint64_t cid;
     cid = CityHash64(chronicle_name.c_str(), chronicle_name.length());
     auto chronicleMapRecord = chronicleMap_->find(cid);
     if(chronicleMapRecord != chronicleMap_->end())
     {
-        Chronicle*pChronicle = chronicleMap_->find(cid)->second;
+        Chronicle* pChronicle = chronicleMap_->find(cid)->second;
         /* Then check if Story exists, fail if false */
         uint64_t sid = pChronicle->getStoryId(story_name);
         if(sid == 0)
@@ -168,13 +172,15 @@ int ChronicleMetaDirectory::destroy_story(std::string const &chronicle_name, con
             return chronolog::CL_ERR_NOT_EXIST;
         }
         /* Then check if Story is acquired, fail if true */
-        Story*pStory = pChronicle->getStoryMap().at(sid);
+        Story* pStory = pChronicle->getStoryMap().at(sid);
         if(!pStory->getAcquirerMap().empty())
         {
-            for(const auto &acquirerMapRecord: pStory->getAcquirerMap())
+            for(const auto& acquirerMapRecord: pStory->getAcquirerMap())
             {
-                LOG_DEBUG("[ChronicleMetaDirectory] StoryID={} in ChronicleName={} is still acquired by client_id={}"
-                     , pStory->getSid(), chronicle_name.c_str(), acquirerMapRecord.first);
+                LOG_DEBUG("[ChronicleMetaDirectory] StoryID={} in ChronicleName={} is still acquired by client_id={}",
+                          pStory->getSid(),
+                          chronicle_name.c_str(),
+                          acquirerMapRecord.first);
             }
             return chronolog::CL_ERR_ACQUIRED;
         }
@@ -182,8 +188,9 @@ int ChronicleMetaDirectory::destroy_story(std::string const &chronicle_name, con
         CL_Status res = pChronicle->removeStory(chronicle_name, story_name);
         if(res != chronolog::CL_SUCCESS)
         {
-            LOG_ERROR("[ChronicleMetaDirectory] Fail to remove StoryName={} in ChronicleName={}", story_name.c_str()
-                 , chronicle_name.c_str());
+            LOG_ERROR("[ChronicleMetaDirectory] Fail to remove StoryName={} in ChronicleName={}",
+                      story_name.c_str(),
+                      chronicle_name.c_str());
         }
         return res;
     }
@@ -205,15 +212,20 @@ int ChronicleMetaDirectory::destroy_story(std::string const &chronicle_name, con
  *         chronolog::CL_ERR_NOT_EXIST if the Chronicle does not exist \n
  *         chronolog::CL_ERR_UNKNOWN otherwise
  */
-int ChronicleMetaDirectory::acquire_story(chl::ClientId const &client_id, const std::string &chronicle_name
-                                          , const std::string &story_name
-                                          , const std::map <std::string, std::string> &attrs, int &flags
-                                          , StoryId &story_id)
+int ChronicleMetaDirectory::acquire_story(chl::ClientId const& client_id,
+                                          const std::string& chronicle_name,
+                                          const std::string& story_name,
+                                          const std::map<std::string, std::string>& attrs,
+                                          int& flags,
+                                          StoryId& story_id)
 {
-    LOG_DEBUG("[ChronicleMetaDirectory] ClientID={} acquiring StoryName={} in ChronicleName={} with Flags={}", client_id
-         , story_name.c_str(), chronicle_name.c_str(), flags);
+    LOG_DEBUG("[ChronicleMetaDirectory] ClientID={} acquiring StoryName={} in ChronicleName={} with Flags={}",
+              client_id,
+              story_name.c_str(),
+              chronicle_name.c_str(),
+              flags);
 
-    std::lock_guard <std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
+    std::lock_guard<std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
     /* First check if Chronicle exists, fail if false */
     uint64_t cid;
     cid = CityHash64(chronicle_name.c_str(), chronicle_name.length());
@@ -223,21 +235,22 @@ int ChronicleMetaDirectory::acquire_story(chl::ClientId const &client_id, const 
         LOG_WARNING("[ChronicleMetaDirectory] ChronicleName={} does not exist", chronicle_name.c_str());
         return chronolog::CL_ERR_NOT_EXIST;
     }
-    Chronicle*pChronicle = chronicleMapRecord->second;
+    Chronicle* pChronicle = chronicleMapRecord->second;
     /* Then check if Story already_acquired_by_this_client, fail if false */
     auto ret = pChronicle->addStory(story_name, attrs);
     if(ret.first != chronolog::CL_SUCCESS)
     {
         return ret.first;
     }
-    Story*pStory = ret.second;
+    Story* pStory = ret.second;
     /* Last check if this client has acquired this Story already, do nothing and return success if true */
     auto acquirerMap = pStory->getAcquirerMap();
     auto acquirerMapRecord = acquirerMap.find(client_id);
     if(acquirerMapRecord != acquirerMap.end())
     {
-        LOG_DEBUG("[ChronicleMetaDirectory] StoryName={} has already been acquired by ClientID={}", story_name.c_str()
-             , client_id);
+        LOG_DEBUG("[ChronicleMetaDirectory] StoryName={} has already been acquired by ClientID={}",
+                  story_name.c_str(),
+                  client_id);
         /* All checks passed, manipulate metadata */
         return chronolog::CL_ERR_ACQUIRED;
     }
@@ -266,12 +279,16 @@ int ChronicleMetaDirectory::acquire_story(chl::ClientId const &client_id, const 
  *         chronolog::CL_ERR_UNKNOWN otherwise
  */
 //TO_DO return acquisition_count after the story has been released
-int ChronicleMetaDirectory::release_story(chl::ClientId const &client_id, const std::string &chronicle_name
-                                          , const std::string &story_name, StoryId &story_id)
+int ChronicleMetaDirectory::release_story(chl::ClientId const& client_id,
+                                          const std::string& chronicle_name,
+                                          const std::string& story_name,
+                                          StoryId& story_id)
 {
-    LOG_DEBUG("[ChronicleMetaDirectory] ClientID={} releasing StoryName={} in ChronicleName={}", client_id
-         , story_name.c_str(), chronicle_name.c_str());
-    std::lock_guard <std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
+    LOG_DEBUG("[ChronicleMetaDirectory] ClientID={} releasing StoryName={} in ChronicleName={}",
+              client_id,
+              story_name.c_str(),
+              chronicle_name.c_str());
+    std::lock_guard<std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
     /* First check if Chronicle exists, fail if false */
     uint64_t cid;
     cid = CityHash64(chronicle_name.c_str(), chronicle_name.length());
@@ -279,14 +296,14 @@ int ChronicleMetaDirectory::release_story(chl::ClientId const &client_id, const 
     auto chronicleRecord = chronicleMap_->find(cid);
     if(chronicleRecord != chronicleMap_->end())
     {
-        Chronicle*pChronicle = chronicleRecord->second;
+        Chronicle* pChronicle = chronicleRecord->second;
         /* Then check if Story exists, fail if false */
         uint64_t sid = pChronicle->getStoryId(story_name);
         if(sid == 0)
         {
             return chronolog::CL_ERR_NOT_EXIST;
         }
-        Story*pStory = pChronicle->getStoryMap().find(sid)->second;
+        Story* pStory = pChronicle->getStoryMap().find(sid)->second;
         /* Check if this client actually acquired this Story before, fail if false */
         auto acquirerMap = pChronicle->getStoryMap().at(sid)->getAcquirerMap();
         auto acquirerMapRecord = acquirerMap.find(client_id);
@@ -307,25 +324,26 @@ int ChronicleMetaDirectory::release_story(chl::ClientId const &client_id, const 
         }
         else
         {
-            LOG_DEBUG("[ChronicleMetaDirectory] StoryName={} is not acquired by ClientID={}, cannot release"
-                 , story_name.c_str(), client_id);
+            LOG_DEBUG("[ChronicleMetaDirectory] StoryName={} is not acquired by ClientID={}, cannot release",
+                      story_name.c_str(),
+                      client_id);
             ret = chronolog::CL_ERR_NOT_ACQUIRED;
         }
     }
     return ret;
 }
 
-int ChronicleMetaDirectory::get_chronicle_attr(std::string const &name, const std::string &key, std::string &value)
+int ChronicleMetaDirectory::get_chronicle_attr(std::string const& name, const std::string& key, std::string& value)
 {
     LOG_DEBUG("[ChronicleMetaDirectory] Getting attributes Key={} from ChronicleName={}", key.c_str(), name.c_str());
-    std::lock_guard <std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
+    std::lock_guard<std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
     /* First check if Chronicle exists, fail if false */
     uint64_t cid;
     cid = CityHash64(name.c_str(), name.length());
     auto chronicleMapRecord = chronicleMap_->find(cid);
     if(chronicleMapRecord != chronicleMap_->end())
     {
-        Chronicle*pChronicle = chronicleMap_->find(cid)->second;
+        Chronicle* pChronicle = chronicleMap_->find(cid)->second;
         if(pChronicle)
         {
             /* Then check if property exists, fail if false */
@@ -337,8 +355,9 @@ int ChronicleMetaDirectory::get_chronicle_attr(std::string const &name, const st
             }
             else
             {
-                LOG_WARNING("[ChronicleMetaDirectory] Property Key={} does not exist in ChronicleName={}", key.c_str()
-                     , name.c_str());
+                LOG_WARNING("[ChronicleMetaDirectory] Property Key={} does not exist in ChronicleName={}",
+                            key.c_str(),
+                            name.c_str());
                 return chronolog::CL_ERR_NOT_EXIST;
             }
         }
@@ -355,19 +374,22 @@ int ChronicleMetaDirectory::get_chronicle_attr(std::string const &name, const st
     }
 }
 
-int
-ChronicleMetaDirectory::edit_chronicle_attr(std::string const &name, const std::string &key, const std::string &value)
+int ChronicleMetaDirectory::edit_chronicle_attr(std::string const& name,
+                                                const std::string& key,
+                                                const std::string& value)
 {
-    LOG_DEBUG("[ChronicleMetaDirectory] Editing attribute Key={}, Value={} from ChronicleName={}", key.c_str(), value.c_str()
-         , name.c_str());
-    std::lock_guard <std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
+    LOG_DEBUG("[ChronicleMetaDirectory] Editing attribute Key={}, Value={} from ChronicleName={}",
+              key.c_str(),
+              value.c_str(),
+              name.c_str());
+    std::lock_guard<std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
     /* First check if Chronicle exists, fail if false */
     uint64_t cid;
     cid = CityHash64(name.c_str(), name.length());
     auto chronicleMapRecord = chronicleMap_->find(cid);
     if(chronicleMapRecord != chronicleMap_->end())
     {
-        Chronicle*pChronicle = chronicleMap_->find(cid)->second;
+        Chronicle* pChronicle = chronicleMap_->find(cid)->second;
         if(pChronicle)
         {
             /* Then check if property exists, fail if false */
@@ -381,15 +403,17 @@ ChronicleMetaDirectory::edit_chronicle_attr(std::string const &name, const std::
                 }
                 else
                 {
-                    LOG_ERROR("[ChronicleMetaDirectory] Something is wrong, fail to insert property Key={}, Value={}"
-                         , key.c_str(), value.c_str());
+                    LOG_ERROR("[ChronicleMetaDirectory] Something is wrong, fail to insert property Key={}, Value={}",
+                              key.c_str(),
+                              value.c_str());
                     return chronolog::CL_ERR_UNKNOWN;
                 }
             }
             else
             {
-                LOG_WARNING("[ChronicleMetaDirectory] Property Key={} does not exist in ChronicleName={}", key.c_str()
-                     , name.c_str());
+                LOG_WARNING("[ChronicleMetaDirectory] Property Key={} does not exist in ChronicleName={}",
+                            key.c_str(),
+                            name.c_str());
                 return chronolog::CL_ERR_NOT_EXIST;
             }
         }
@@ -411,15 +435,12 @@ ChronicleMetaDirectory::edit_chronicle_attr(std::string const &name, const std::
  * @param client_id: Client ID
  * @return a vector of the names of all Chronicles
  */
-int ChronicleMetaDirectory::show_chronicles(std::vector <std::string> &chronicle_names)
+int ChronicleMetaDirectory::show_chronicles(std::vector<std::string>& chronicle_names)
 {
     chronicle_names.clear();
 
-    std::lock_guard <std::mutex> lock(g_chronicleMetaDirectoryMutex_);
-    for(auto &[key, value]: *chronicleMap_)
-    {
-        chronicle_names.emplace_back(value->getName());
-    }
+    std::lock_guard<std::mutex> lock(g_chronicleMetaDirectoryMutex_);
+    for(auto& [key, value]: *chronicleMap_) { chronicle_names.emplace_back(value->getName()); }
     return chronolog::CL_SUCCESS;
 }
 
@@ -431,11 +452,11 @@ int ChronicleMetaDirectory::show_chronicles(std::vector <std::string> &chronicle
  *         empty vector if Chronicle does not exist
  */
 
-int ChronicleMetaDirectory::show_stories(const std::string &chronicle_name, std::vector <std::string> &story_names)
+int ChronicleMetaDirectory::show_stories(const std::string& chronicle_name, std::vector<std::string>& story_names)
 {
     story_names.clear();
 
-    std::lock_guard <std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
+    std::lock_guard<std::mutex> chronicleMapLock(g_chronicleMetaDirectoryMutex_);
 
     /* First check if Chronicle exists, fail if false */
 
@@ -443,12 +464,14 @@ int ChronicleMetaDirectory::show_stories(const std::string &chronicle_name, std:
     cid = CityHash64(chronicle_name.c_str(), chronicle_name.length());
     auto chronicleMapRecord = chronicleMap_->find(cid);
     if(chronicleMapRecord == chronicleMap_->end())
-    { return chronolog::CL_ERR_NOT_EXIST; }
+    {
+        return chronolog::CL_ERR_NOT_EXIST;
+    }
 
-    Chronicle*pChronicle = chronicleMap_->find(cid)->second;
+    Chronicle* pChronicle = chronicleMap_->find(cid)->second;
 
     LOG_DEBUG("[ChronicleMetaDirectory] Chronicle at {}", static_cast<void*>(&(*pChronicle)));
-    for(auto &[key, value]: pChronicle->getStoryMap())
+    for(auto& [key, value]: pChronicle->getStoryMap())
     {
         std::string story_name = value->getName();
         story_names.emplace_back(story_name);

--- a/ChronoVisor/src/ClientInfo.cpp
+++ b/ChronoVisor/src/ClientInfo.cpp
@@ -7,14 +7,11 @@
 
 #include <ClientInfo.h>
 
-std::ostream &operator<<(std::ostream &out, const ClientInfo &r)
+std::ostream& operator<<(std::ostream& out, const ClientInfo& r)
 {
     std::stringstream ss;
     auto it = r.acquiredStoryList_.begin();
     ss << it->first;
-    for(++it; it != r.acquiredStoryList_.end(); ++it)
-    {
-        ss << ", " << it->first;
-    }
+    for(++it; it != r.acquiredStoryList_.end(); ++it) { ss << ", " << it->first; }
     return out << r.addr_ << ":" << r.port_ << ", acquiredStories: " << ss.str();
 }

--- a/ChronoVisor/src/ClientInfo.cpp
+++ b/ChronoVisor/src/ClientInfo.cpp
@@ -2,6 +2,9 @@
 // Created by kfeng on 1/2/23.
 //
 
+#include <sstream>
+#include <iostream>
+
 #include <ClientInfo.h>
 
 std::ostream &operator<<(std::ostream &out, const ClientInfo &r)

--- a/ChronoVisor/src/ClientRegistryManager.cpp
+++ b/ChronoVisor/src/ClientRegistryManager.cpp
@@ -19,34 +19,37 @@ ClientRegistryManager::ClientRegistryManager()
 {
     std::stringstream ss;
     ss << this;
-    LOG_DEBUG("[ClientRegistryManager] Constructor is called. Object created at {} in thread PID={}", ss.str(), getpid());
-    clientRegistry_ = new std::unordered_map <chronolog::ClientId, ClientInfo>();
+    LOG_DEBUG("[ClientRegistryManager] Constructor is called. Object created at {} in thread PID={}",
+              ss.str(),
+              getpid());
+    clientRegistry_ = new std::unordered_map<chronolog::ClientId, ClientInfo>();
     std::stringstream s1;
     s1 << clientRegistry_;
-    LOG_DEBUG("[ClientRegistryManager] Client Registry created at {} has {} entries", s1.str(), clientRegistry_->size());
+    LOG_DEBUG("[ClientRegistryManager] Client Registry created at {} has {} entries",
+              s1.str(),
+              clientRegistry_->size());
 }
 
-ClientRegistryManager::~ClientRegistryManager()
-{
-    delete clientRegistry_;
-}
+ClientRegistryManager::~ClientRegistryManager() { delete clientRegistry_; }
 
-ClientInfo*ClientRegistryManager::get_client_info(chl::ClientId const &client_id)
+ClientInfo* ClientRegistryManager::get_client_info(chl::ClientId const& client_id)
 {
-    std::lock_guard <std::mutex> clientRegistryLock(g_clientRegistryMutex_);
+    std::lock_guard<std::mutex> clientRegistryLock(g_clientRegistryMutex_);
     auto clientRegistryRecord = clientRegistry_->find(client_id);
     if(clientRegistryRecord != clientRegistry_->end())
     {
         return &(clientRegistryRecord->second);
     }
     else
-    { return nullptr; }
+    {
+        return nullptr;
+    }
 }
 //////////////////////
 
-int ClientRegistryManager::add_story_acquisition(chl::ClientId const &client_id, uint64_t &sid, Story*pStory)
+int ClientRegistryManager::add_story_acquisition(chl::ClientId const& client_id, uint64_t& sid, Story* pStory)
 {
-    std::lock_guard <std::mutex> clientRegistryLock(g_clientRegistryMutex_);
+    std::lock_guard<std::mutex> clientRegistryLock(g_clientRegistryMutex_);
     auto clientRegistryRecord = clientRegistry_->find(client_id);
     if(clientRegistryRecord != clientRegistry_->end())
     {
@@ -62,13 +65,16 @@ int ClientRegistryManager::add_story_acquisition(chl::ClientId const &client_id,
             auto res = clientRegistry_->insert_or_assign(client_id, clientInfo);
             if(res.second)
             {
-                LOG_DEBUG("[ClientRegistryManager] Added a new entry for ClientID={} acquiring StoryID={}", client_id, sid);
+                LOG_DEBUG("[ClientRegistryManager] Added a new entry for ClientID={} acquiring StoryID={}",
+                          client_id,
+                          sid);
                 return chronolog::CL_SUCCESS;
             }
             else
             {
-                LOG_DEBUG("[ClientRegistryManager] Updated an existing entry for ClientID={} acquiring StoryID={}", client_id
-                     , sid);
+                LOG_DEBUG("[ClientRegistryManager] Updated an existing entry for ClientID={} acquiring StoryID={}",
+                          client_id,
+                          sid);
                 return chronolog::CL_ERR_UNKNOWN;
             }
         }
@@ -82,9 +88,9 @@ int ClientRegistryManager::add_story_acquisition(chl::ClientId const &client_id,
 
 //////////////////////
 
-int ClientRegistryManager::remove_story_acquisition(chl::ClientId const &client_id, uint64_t &sid)
+int ClientRegistryManager::remove_story_acquisition(chl::ClientId const& client_id, uint64_t& sid)
 {
-    std::lock_guard <std::mutex> clientRegistryLock(g_clientRegistryMutex_);
+    std::lock_guard<std::mutex> clientRegistryLock(g_clientRegistryMutex_);
     auto clientRegistryRecord = clientRegistry_->find(client_id);
     if(clientRegistryRecord != clientRegistry_->end())
     {
@@ -94,23 +100,28 @@ int ClientRegistryManager::remove_story_acquisition(chl::ClientId const &client_
             auto nErased = clientRegistryRecord->second.acquiredStoryList_.erase(sid);
             if(nErased == 1)
             {
-                LOG_DEBUG("[ClientRegistryManager] Removed StoryID={} from AcquiredStoryList for ClientID={}", sid
-                     , client_id);
-                LOG_DEBUG("[ClientRegistryManager] Acquired Story List of ClientID={} has {} entries left", client_id
-                     , clientRegistryRecord->second.acquiredStoryList_.size());
+                LOG_DEBUG("[ClientRegistryManager] Removed StoryID={} from AcquiredStoryList for ClientID={}",
+                          sid,
+                          client_id);
+                LOG_DEBUG("[ClientRegistryManager] Acquired Story List of ClientID={} has {} entries left",
+                          client_id,
+                          clientRegistryRecord->second.acquiredStoryList_.size());
                 return chronolog::CL_SUCCESS;
             }
             else
             {
-                LOG_DEBUG("[ClientRegistryManager] Failed to remove StoryID={} from AcquiredStoryList for ClientID={}", sid
-                     , client_id);
+                LOG_DEBUG("[ClientRegistryManager] Failed to remove StoryID={} from AcquiredStoryList for ClientID={}",
+                          sid,
+                          client_id);
                 return chronolog::CL_ERR_UNKNOWN;
             }
         }
         else
         {
-            LOG_WARNING("[ClientRegistryManager] StoryID={} is not acquired by ClientID={}, cannot remove from AcquiredStoryList for it"
-                 , sid, client_id);
+            LOG_WARNING("[ClientRegistryManager] StoryID={} is not acquired by ClientID={}, cannot remove from "
+                        "AcquiredStoryList for it",
+                        sid,
+                        client_id);
             return chronolog::CL_ERR_NOT_ACQUIRED;
         }
     }
@@ -121,18 +132,22 @@ int ClientRegistryManager::remove_story_acquisition(chl::ClientId const &client_
     }
 }
 
-int ClientRegistryManager::add_client_record(chl::ClientId const &client_id, const ClientInfo &record)
+int ClientRegistryManager::add_client_record(chl::ClientId const& client_id, const ClientInfo& record)
 {
-    LOG_DEBUG("[ClientRegistryManager] ClientRecord added in ClientRegistryManager at {}", static_cast<const void*>(this));
-    LOG_DEBUG("[ClientRegistryManager] Client Registry at {} has {} entries stored", static_cast<void*>(clientRegistry_)
-         , clientRegistry_->size());
-    std::lock_guard <std::mutex> lock(g_clientRegistryMutex_);
+    LOG_DEBUG("[ClientRegistryManager] ClientRecord added in ClientRegistryManager at {}",
+              static_cast<const void*>(this));
+    LOG_DEBUG("[ClientRegistryManager] Client Registry at {} has {} entries stored",
+              static_cast<void*>(clientRegistry_),
+              clientRegistry_->size());
+    std::lock_guard<std::mutex> lock(g_clientRegistryMutex_);
     if(clientRegistry_->insert_or_assign(client_id, record).second)
     {
-        LOG_DEBUG("[ClientRegistryManager] An entry for ClientID={} has been added to Client Registry at {}", client_id
-             , static_cast<void*>(clientRegistry_));
-        LOG_DEBUG("[ClientRegistryManager] Client Registry at {} has {} entries stored", static_cast<void*>(clientRegistry_)
-             , clientRegistry_->size());
+        LOG_DEBUG("[ClientRegistryManager] An entry for ClientID={} has been added to Client Registry at {}",
+                  client_id,
+                  static_cast<void*>(clientRegistry_));
+        LOG_DEBUG("[ClientRegistryManager] Client Registry at {} has {} entries stored",
+                  static_cast<void*>(clientRegistry_),
+                  clientRegistry_->size());
         return chronolog::CL_SUCCESS;
     }
     else
@@ -142,20 +157,23 @@ int ClientRegistryManager::add_client_record(chl::ClientId const &client_id, con
     }
 }
 
-int ClientRegistryManager::remove_client_record(const chronolog::ClientId &client_id)
+int ClientRegistryManager::remove_client_record(const chronolog::ClientId& client_id)
 {
-    LOG_DEBUG("[ClientRegistryManager] Remove client record in ClientRegistryManager at {}", static_cast<const void*>(this));
-    LOG_DEBUG("[ClientRegistryManager] Client Registry at {} has {} entries", static_cast<void*>(clientRegistry_)
-         , clientRegistry_->size());
-    std::lock_guard <std::mutex> lock(g_clientRegistryMutex_);
+    LOG_DEBUG("[ClientRegistryManager] Remove client record in ClientRegistryManager at {}",
+              static_cast<const void*>(this));
+    LOG_DEBUG("[ClientRegistryManager] Client Registry at {} has {} entries",
+              static_cast<void*>(clientRegistry_),
+              clientRegistry_->size());
+    std::lock_guard<std::mutex> lock(g_clientRegistryMutex_);
     auto clientRegistryRecord = clientRegistry_->find(client_id);
     if(clientRegistryRecord != clientRegistry_->end())
     {
         auto clientInfo = clientRegistryRecord->second;
         if(!clientInfo.acquiredStoryList_.empty())
         {
-            LOG_WARNING("[ClientRegistryManager] ClientID={} still has {} stories acquired, entry cannot be removed", client_id
-                 , clientInfo.acquiredStoryList_.size());
+            LOG_WARNING("[ClientRegistryManager] ClientID={} still has {} stories acquired, entry cannot be removed",
+                        client_id,
+                        clientInfo.acquiredStoryList_.size());
             return chronolog::CL_ERR_ACQUIRED;
         }
     }
@@ -166,8 +184,9 @@ int ClientRegistryManager::remove_client_record(const chronolog::ClientId &clien
     }
     if(clientRegistry_->erase(client_id))
     {
-        LOG_DEBUG("[ClientRegistryManager] Entry for ClientID={} has been removed from clientRegistry_ at {}", client_id
-             , static_cast<void*>(clientRegistry_));
+        LOG_DEBUG("[ClientRegistryManager] Entry for ClientID={} has been removed from clientRegistry_ at {}",
+                  client_id,
+                  static_cast<void*>(clientRegistry_));
         return chronolog::CL_SUCCESS;
     }
     else

--- a/ChronoVisor/src/ClientRegistryManager.cpp
+++ b/ChronoVisor/src/ClientRegistryManager.cpp
@@ -4,6 +4,7 @@
 
 #include <unistd.h>
 #include <mutex>
+#include <sstream>
 
 #include <ClientRegistryManager.h>
 #include <chronolog_errcode.h>

--- a/ChronoVisor/src/KeeperRegistry.cpp
+++ b/ChronoVisor/src/KeeperRegistry.cpp
@@ -1,4 +1,7 @@
 #include <iostream>
+#include <algorithm>
+#include <ctime>
+#include <cstdlib>
 #include <thallium.hpp>
 
 #include <KeeperRegistry.h>

--- a/ChronoVisor/src/KeeperRegistry.cpp
+++ b/ChronoVisor/src/KeeperRegistry.cpp
@@ -17,13 +17,15 @@ namespace chl = chronolog;
 namespace chronolog
 {
 
-int KeeperRegistry::InitializeRegistryService(VisorConfiguration const & VISOR_CONF)
+int KeeperRegistry::InitializeRegistryService(VisorConfiguration const& VISOR_CONF)
 {
     int status = chronolog::CL_ERR_UNKNOWN;
-    std::lock_guard <std::mutex> lock(registryLock);
+    std::lock_guard<std::mutex> lock(registryLock);
 
     if(registryState != UNKNOWN)
-    { return chronolog::CL_SUCCESS; }
+    {
+        return chronolog::CL_SUCCESS;
+    }
 
     try
     {
@@ -41,7 +43,8 @@ int KeeperRegistry::InitializeRegistryService(VisorConfiguration const & VISOR_C
             LOG_CRITICAL("[ChronoProcessRegistry] Failed to initialize margo_instance");
             return -1;
         }
-        LOG_INFO("[ChronoProcessRegistry] margo_instance initialized with NA_STRING {}", KEEPER_REGISTRY_SERVICE_NA_STRING);
+        LOG_INFO("[ChronoProcessRegistry] margo_instance initialized with NA_STRING {}",
+                 KEEPER_REGISTRY_SERVICE_NA_STRING);
 
         registryEngine = new tl::engine(margo_id);
 
@@ -64,13 +67,12 @@ int KeeperRegistry::InitializeRegistryService(VisorConfiguration const & VISOR_C
         registryState = INITIALIZED;
         status = chronolog::CL_SUCCESS;
     }
-    catch(tl::exception const &ex)
+    catch(tl::exception const& ex)
     {
         LOG_ERROR("[ChronoProcessRegistry] Failed to start");
     }
 
     return status;
-
 }
 
 KeeperRegistry::KeeperRegistry()
@@ -84,7 +86,7 @@ KeeperRegistry::KeeperRegistry()
     // TODO: reseach the seeding of Mersense Twister int number generator
 
     size_t new_seed = std::chrono::high_resolution_clock::to_time_t(std::chrono::high_resolution_clock::now());
-    mt_random.seed(new_seed);//initial seed for the 32 int Mersene Twister generator
+    mt_random.seed(new_seed); //initial seed for the 32 int Mersene Twister generator
 }
 
 /////////////////
@@ -93,7 +95,7 @@ int KeeperRegistry::ShutdownRegistryService()
 {
 
 
-    std::lock_guard <std::mutex> lock(registryLock);
+    std::lock_guard<std::mutex> lock(registryLock);
 
     if(is_shutting_down())
     {
@@ -127,7 +129,10 @@ int KeeperRegistry::ShutdownRegistryService()
                 if(grapher_process->active)
                 {
                     LOG_INFO("[ChronoProcessRegistry] Sending shutdown to grapher {}", id_string.str());
-                    if(grapher_process->adminClient != nullptr) { grapher_process->adminClient->shutdown_collection(); }
+                    if(grapher_process->adminClient != nullptr)
+                    {
+                        grapher_process->adminClient->shutdown_collection();
+                    }
 
                     // start delayed destruction for the lingering Adminclient to be safe...
                     recording_group.startDelayedGrapherExit(*grapher_process, delayedExitTime);
@@ -160,18 +165,21 @@ int KeeperRegistry::ShutdownRegistryService()
                     (*process_iter).second.keeperAdminClient->shutdown_collection();
 
                     LOG_INFO("[ChronoProcessRegistry] shutdown: starting delayedExit for keeper {} delayedExitTime={}",
-                             id_string.str(), std::ctime(&delayedExitTime));
+                             id_string.str(),
+                             std::ctime(&delayedExitTime));
                     recording_group.startDelayedKeeperExit((*process_iter).second, delayedExitTime);
                 }
                 else
                 {
-                    LOG_INFO("[ChronoProcessRegistry] shutdown: clear delayedAdminClient for keeper {}", id_string.str());
+                    LOG_INFO("[ChronoProcessRegistry] shutdown: clear delayedAdminClient for keeper {}",
+                             id_string.str());
                     recording_group.clearDelayedExitKeeper((*process_iter).second, current_time);
                 }
 
                 if((*process_iter).second.delayedExitClients.empty())
                 {
-                    LOG_INFO("[ChronoProcessRegistry] shutdown : destroys old keeperProcessEntry for {}", id_string.str());
+                    LOG_INFO("[ChronoProcessRegistry] shutdown : destroys old keeperProcessEntry for {}",
+                             id_string.str());
                     process_iter = recording_group.keeperProcesses.erase(process_iter);
                 }
                 else
@@ -194,12 +202,17 @@ int KeeperRegistry::ShutdownRegistryService()
             }
         }
 
-        if(!recordingGroups.empty()) { sleep(1); }
+        if(!recordingGroups.empty())
+        {
+            sleep(1);
+        }
     }
 
 
     if(nullptr != keeperRegistryService)
-    { delete keeperRegistryService; }
+    {
+        delete keeperRegistryService;
+    }
     return chronolog::CL_SUCCESS;
 }
 
@@ -212,16 +225,20 @@ KeeperRegistry::~KeeperRegistry()
 /////////////////
 
 
-int KeeperRegistry::registerKeeperProcess(KeeperRegistrationMsg const &keeper_reg_msg)
+int KeeperRegistry::registerKeeperProcess(KeeperRegistrationMsg const& keeper_reg_msg)
 {
 
     if(is_shutting_down())
-    { return chronolog::CL_ERR_UNKNOWN; }
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
-    std::lock_guard <std::mutex> lock(registryLock);
+    std::lock_guard<std::mutex> lock(registryLock);
     //re-check state after ther lock is aquired
     if(is_shutting_down())
-    { return chronolog::CL_ERR_UNKNOWN; }
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
     KeeperIdCard keeper_id_card = keeper_reg_msg.getKeeperIdCard();
     ServiceId admin_service_id = keeper_reg_msg.getAdminServiceId();
@@ -230,22 +247,27 @@ int KeeperRegistry::registerKeeperProcess(KeeperRegistrationMsg const &keeper_re
     auto group_iter = recordingGroups.find(keeper_id_card.getGroupId());
     if(group_iter == recordingGroups.end())
     {
-        auto insert_return = recordingGroups.insert(std::pair<RecordingGroupId, RecordingGroup>(
-                keeper_id_card.getGroupId(), RecordingGroup(keeper_id_card.getGroupId())));
+        auto insert_return = recordingGroups.insert(
+                std::pair<RecordingGroupId, RecordingGroup>(keeper_id_card.getGroupId(),
+                                                            RecordingGroup(keeper_id_card.getGroupId())));
         if(false == insert_return.second)
         {
             LOG_ERROR("[ChronoProcessRegistry] keeper registration failed to find RecordingGroup {}",
                       keeper_id_card.getGroupId());
             return chronolog::CL_ERR_UNKNOWN;
         }
-        else { group_iter = insert_return.first; }
+        else
+        {
+            group_iter = insert_return.first;
+        }
     }
 
     RecordingGroup& recording_group = (*group_iter).second;
 
     // unlikely but possible that the Registry still retains the record of the previous re-incarnation of hte Keeper process
     // running on the same host... check for this case and clean up the leftover record...
-    auto keeper_process_iter = recording_group.keeperProcesses.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
+    auto keeper_process_iter =
+            recording_group.keeperProcesses.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
 
     if(keeper_process_iter != recording_group.keeperProcesses.end())
     {
@@ -257,7 +279,9 @@ int KeeperRegistry::registerKeeperProcess(KeeperRegistrationMsg const &keeper_re
             std::time_t delayedExitTime = std::chrono::high_resolution_clock::to_time_t(
                     std::chrono::high_resolution_clock::now() + std::chrono::seconds(delayedDataAdminExitSeconds));
             LOG_WARNING("[ChronoProcessRegistry] registerKeeperProcess: found old instance of dataAdminclient for {} "
-                        "delayedExitTime={}", to_string(keeper_id_card), std::ctime(&delayedExitTime));
+                        "delayedExitTime={}",
+                        to_string(keeper_id_card),
+                        std::ctime(&delayedExitTime));
             ;
 
             recording_group.startDelayedKeeperExit((*keeper_process_iter).second, delayedExitTime);
@@ -266,18 +290,22 @@ int KeeperRegistry::registerKeeperProcess(KeeperRegistrationMsg const &keeper_re
         {
             std::time_t current_time =
                     std::chrono::high_resolution_clock::to_time_t(std::chrono::high_resolution_clock::now());
-            LOG_INFO("[ChronoProcessRegistry] registerKeeperProcess tries to clear dataAdmindClient for {}", to_string(keeper_id_card));
+            LOG_INFO("[ChronoProcessRegistry] registerKeeperProcess tries to clear dataAdmindClient for {}",
+                     to_string(keeper_id_card));
             recording_group.clearDelayedExitKeeper((*keeper_process_iter).second, current_time);
         }
 
         if((*keeper_process_iter).second.delayedExitClients.empty())
         {
-            LOG_INFO("[ChronoProcessRegistry] registerKeeperProcess has destroyed old entry for keeper {}", to_string(keeper_id_card));
+            LOG_INFO("[ChronoProcessRegistry] registerKeeperProcess has destroyed old entry for keeper {}",
+                     to_string(keeper_id_card));
             recording_group.keeperProcesses.erase(keeper_process_iter);
         }
         else
         {
-            LOG_INFO("[ChronoProcessRegistry] registration for Keeper {} cant's proceed as previous AdminClient is not yet dismantled", to_string(keeper_id_card));
+            LOG_INFO("[ChronoProcessRegistry] registration for Keeper {} cant's proceed as previous AdminClient is not "
+                     "yet dismantled",
+                     to_string(keeper_id_card));
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
@@ -287,13 +315,15 @@ int KeeperRegistry::registerKeeperProcess(KeeperRegistrationMsg const &keeper_re
     std::string service_na_string;
     admin_service_id.get_service_as_string(service_na_string);
 
-    DataStoreAdminClient*collectionClient = DataStoreAdminClient::CreateDataStoreAdminClient(*registryEngine
-                                                                                             , service_na_string
-                                                                                             , admin_service_id.getProviderId());
+    DataStoreAdminClient* collectionClient =
+            DataStoreAdminClient::CreateDataStoreAdminClient(*registryEngine,
+                                                             service_na_string,
+                                                             admin_service_id.getProviderId());
     if(nullptr == collectionClient)
     {
-        LOG_ERROR("[ChronoProcessRegistry] Register Keeper: {} failed to create DataStoreAdminClient for {}"
-             , to_string(keeper_id_card), to_string(admin_service_id));
+        LOG_ERROR("[ChronoProcessRegistry] Register Keeper: {} failed to create DataStoreAdminClient for {}",
+                  to_string(keeper_id_card),
+                  to_string(admin_service_id));
         return chronolog::CL_ERR_UNKNOWN;
     }
 
@@ -304,7 +334,7 @@ int KeeperRegistry::registerKeeperProcess(KeeperRegistrationMsg const &keeper_re
                     KeeperProcessEntry(keeper_id_card, admin_service_id)));
     if(false == insert_return.second)
     {
-        LOG_ERROR("[ChronoProcessRegistry] registration failed for Keeper {}",to_string(keeper_id_card));
+        LOG_ERROR("[ChronoProcessRegistry] registration failed for Keeper {}", to_string(keeper_id_card));
         delete collectionClient;
         return chronolog::CL_ERR_UNKNOWN;
     }
@@ -313,49 +343,64 @@ int KeeperRegistry::registerKeeperProcess(KeeperRegistrationMsg const &keeper_re
     (*insert_return.first).second.active = true;
     recording_group.activeKeeperCount += 1;
 
-    LOG_INFO("[ChronoProcessRegistry] Register Keeper: {} created DataStoreAdminClient for {}"
-         , to_string(keeper_id_card), to_string(admin_service_id));
+    LOG_INFO("[ChronoProcessRegistry] Register Keeper: {} created DataStoreAdminClient for {}",
+             to_string(keeper_id_card),
+             to_string(admin_service_id));
 
-    LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} has {} keepers", recording_group.groupId,
+    LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} has {} keepers",
+             recording_group.groupId,
              recording_group.keeperProcesses.size());
 
     // check if this is the first keeper for the recording group and the group is ready to be part of
     //  the activeGroups rotation
-    
+
     if(recording_group.isActive() && recording_group.activeKeeperCount == 1)
     {
         activeGroups.push_back(&recording_group);
         size_t new_seed = std::chrono::high_resolution_clock::to_time_t(std::chrono::high_resolution_clock::now());
-        mt_random.seed(new_seed);//re-seed the mersene_twister_generator
+        mt_random.seed(new_seed); //re-seed the mersene_twister_generator
         group_id_distribution =
-                std::uniform_int_distribution<size_t>(0, activeGroups.size() - 1);//reset the distribution range
+                std::uniform_int_distribution<size_t>(0, activeGroups.size() - 1); //reset the distribution range
     }
 
-    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ", activeGroups.size(), recordingGroups.size());
-    if(activeGroups.size() > 0) { registryState = RUNNING; }
+    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ",
+             activeGroups.size(),
+             recordingGroups.size());
+    if(activeGroups.size() > 0)
+    {
+        registryState = RUNNING;
+    }
     return chronolog::CL_SUCCESS;
 }
 /////////////////
 
-int KeeperRegistry::unregisterKeeperProcess(KeeperIdCard const &keeper_id_card)
+int KeeperRegistry::unregisterKeeperProcess(KeeperIdCard const& keeper_id_card)
 {
     if(is_shutting_down())
-    { return chronolog::CL_ERR_UNKNOWN; }
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
     std::lock_guard<std::mutex> lock(registryLock);
     //check again after the lock is acquired
     if(is_shutting_down())
-    { return chronolog::CL_ERR_UNKNOWN; }
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
     auto group_iter = recordingGroups.find(keeper_id_card.getGroupId());
-    if(group_iter == recordingGroups.end()) { return chronolog::CL_SUCCESS; }
+    if(group_iter == recordingGroups.end())
+    {
+        return chronolog::CL_SUCCESS;
+    }
 
     RecordingGroup& recording_group = (*group_iter).second;
 
-    auto keeper_process_iter = recording_group.keeperProcesses.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
-            
+    auto keeper_process_iter =
+            recording_group.keeperProcesses.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
+
     if(keeper_process_iter == recording_group.keeperProcesses.end())
-    { 
+    {
         //we don't have a record of this keeper, we have nothing to do
         return chronolog::CL_SUCCESS;
     }
@@ -367,11 +412,13 @@ int KeeperRegistry::unregisterKeeperProcess(KeeperIdCard const &keeper_id_card)
         {
             activeGroups.erase(std::remove(activeGroups.begin(), activeGroups.end(), &recording_group));
             if(activeGroups.size() > 0)
-            {//reset the group distribution
-                size_t new_seed = std::chrono::high_resolution_clock::to_time_t(std::chrono::high_resolution_clock::now());
-                mt_random.seed(new_seed);//re-seed the mersene_twister_generator
+            { //reset the group distribution
+                size_t new_seed =
+                        std::chrono::high_resolution_clock::to_time_t(std::chrono::high_resolution_clock::now());
+                mt_random.seed(new_seed); //re-seed the mersene_twister_generator
                 group_id_distribution =
-                    std::uniform_int_distribution<size_t>(0, activeGroups.size() - 1);//reset the distribution range
+                        std::uniform_int_distribution<size_t>(0,
+                                                              activeGroups.size() - 1); //reset the distribution range
             }
         }
 
@@ -385,38 +432,49 @@ int KeeperRegistry::unregisterKeeperProcess(KeeperIdCard const &keeper_id_card)
         recording_group.startDelayedKeeperExit((*keeper_process_iter).second, delayedExitTime);
     }
 
-    LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} has {} keepers", recording_group.groupId,
+    LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} has {} keepers",
+             recording_group.groupId,
              recording_group.keeperProcesses.size());
 
-    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ", activeGroups.size(), recordingGroups.size());
-    
+    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ",
+             activeGroups.size(),
+             recordingGroups.size());
+
     // update registryState if needed
-    if(!is_shutting_down() && activeGroups.size() == 0) { registryState = INITIALIZED; }
+    if(!is_shutting_down() && activeGroups.size() == 0)
+    {
+        registryState = INITIALIZED;
+    }
 
     return chronolog::CL_SUCCESS;
 }
 /////////////////
 
-void KeeperRegistry::updateKeeperProcessStats(KeeperStatsMsg const &keeperStatsMsg)
+void KeeperRegistry::updateKeeperProcessStats(KeeperStatsMsg const& keeperStatsMsg)
 {
     // NOTE: we don't lock registryLock while updating the keeperProcess stats
     // delayed destruction of keeperProcessEntry protects us from the case when
     // stats message is received from the KeeperProcess that has unregistered
     // on the other thread
     if(is_shutting_down())
-    { return; }
+    {
+        return;
+    }
 
     KeeperIdCard keeper_id_card = keeperStatsMsg.getKeeperIdCard();
 
     LOG_DEBUG("[ChronoProcessRegistry] Received KeeperStatsMsg from {}", chl::to_string(keeper_id_card));
 
     auto group_iter = recordingGroups.find(keeper_id_card.getGroupId());
-    if(group_iter == recordingGroups.end()) { return; }
+    if(group_iter == recordingGroups.end())
+    {
+        return;
+    }
 
-    auto keeper_process_iter = 
-        (*group_iter).second.keeperProcesses.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
+    auto keeper_process_iter =
+            (*group_iter).second.keeperProcesses.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
     if(keeper_process_iter == (*group_iter).second.keeperProcesses.end() || !((*keeper_process_iter).second.active))
-    {// however unlikely it is that the stats msg would be delivered for the keeper that's already unregistered
+    { // however unlikely it is that the stats msg would be delivered for the keeper that's already unregistered
         // we should probably log a warning here...
         return;
     }
@@ -452,10 +510,15 @@ std::vector<KeeperIdCard>& RecordingGroup::getActiveKeepers(std::vector<KeeperId
               (current_time >= (*iter).second.delayedExitClients.front().first))
         {
             auto dataStoreClientPair = (*iter).second.delayedExitClients.front();
-            LOG_INFO("[ChronoProcessRegistry] getActiveKeepers() destroys dataAdminClient for keeper {} current_time={} delayedExitTime={}", 
-                    (*iter).second.idCardString, ctime(&current_time), ctime(&(*iter).second.delayedExitClients.front
-                    ().first));
-            if(dataStoreClientPair.second != nullptr) { delete dataStoreClientPair.second; }
+            LOG_INFO("[ChronoProcessRegistry] getActiveKeepers() destroys dataAdminClient for keeper {} "
+                     "current_time={} delayedExitTime={}",
+                     (*iter).second.idCardString,
+                     ctime(&current_time),
+                     ctime(&(*iter).second.delayedExitClients.front().first));
+            if(dataStoreClientPair.second != nullptr)
+            {
+                delete dataStoreClientPair.second;
+            }
             (*iter).second.delayedExitClients.pop_front();
         }
 
@@ -468,14 +531,18 @@ std::vector<KeeperIdCard>& RecordingGroup::getActiveKeepers(std::vector<KeeperId
         else if((*iter).second.delayedExitClients.empty())
         {
             // it's safe to erase the entry for unregistered keeper process
-            LOG_INFO("[ChronoProcessRegistry] getActiveKeepers() destroys keeperProcessEntry for keeper {} current_time={}",
-                     (*iter).second.idCardString, std::ctime(&current_time));
+            LOG_INFO("[ChronoProcessRegistry] getActiveKeepers() destroys keeperProcessEntry for keeper {} "
+                     "current_time={}",
+                     (*iter).second.idCardString,
+                     std::ctime(&current_time));
             iter = keeperProcesses.erase(iter);
         }
         else
-        { 
-            LOG_INFO("ChronoProcessRegistry] getActiveKeepers still keeps keeperProcessEntry for keeper {} current_time={}",
-                     (*iter).second.idCardString, std::ctime(&current_time));
+        {
+            LOG_INFO("ChronoProcessRegistry] getActiveKeepers still keeps keeperProcessEntry for keeper {} "
+                     "current_time={}",
+                     (*iter).second.idCardString,
+                     std::ctime(&current_time));
             ++iter;
         }
     }
@@ -483,10 +550,11 @@ std::vector<KeeperIdCard>& RecordingGroup::getActiveKeepers(std::vector<KeeperId
     return keeper_id_cards;
 }
 /////////////////
-int KeeperRegistry::notifyRecordingGroupOfStoryRecordingStart(ChronicleName const& chronicle, StoryName const &story
-                                                              , StoryId const &story_id
-                                                              , std::vector <KeeperIdCard> &vectorOfKeepers
-                                , ServiceId & player_service_id)
+int KeeperRegistry::notifyRecordingGroupOfStoryRecordingStart(ChronicleName const& chronicle,
+                                                              StoryName const& story,
+                                                              StoryId const& story_id,
+                                                              std::vector<KeeperIdCard>& vectorOfKeepers,
+                                                              ServiceId& player_service_id)
 {
     vectorOfKeepers.clear();
 
@@ -498,7 +566,8 @@ int KeeperRegistry::notifyRecordingGroupOfStoryRecordingStart(ChronicleName cons
         std::lock_guard<std::mutex> lock(registryLock);
         if(!is_running())
         {
-            LOG_ERROR("[ChronoProcessRegistry] Registry has no active RecordingGroups to start recording story {}", story_id);
+            LOG_ERROR("[ChronoProcessRegistry] Registry has no active RecordingGroups to start recording story {}",
+                      story_id);
             return chronolog::CL_ERR_NO_KEEPERS;
         }
 
@@ -513,11 +582,13 @@ int KeeperRegistry::notifyRecordingGroupOfStoryRecordingStart(ChronicleName cons
             //and implement group re-assignment procedure when we have recording processes dynamically coming and going..
 
             recording_group = (*story_iter).second;
-            recording_group->getActiveKeepers(vectorOfKeepers); 
-    
+            recording_group->getActiveKeepers(vectorOfKeepers);
+
             //no need for notification , group processes are already recording this story
-            LOG_DEBUG("[ChronoProcessRegistry] RecordingGroup {} is already recording story {}", recording_group->groupId,story_id);
-            
+            LOG_DEBUG("[ChronoProcessRegistry] RecordingGroup {} is already recording story {}",
+                      recording_group->groupId,
+                      story_id);
+
             return chronolog::CL_SUCCESS;
         }
 
@@ -530,55 +601,77 @@ int KeeperRegistry::notifyRecordingGroupOfStoryRecordingStart(ChronicleName cons
     }
 
     LOG_DEBUG("[ChronoProcessRegistry] selected RecordingGroup {} for story {}", recording_group->groupId, story_id);
-    
+
     uint64_t story_start_time = std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
     // the registryLock is released by this point..
     // notify Grapher and notifyKeepers functions use delayedExit logic to protect
     // the rpc code from DataAdminClients being destroyed while notification is in progress..
     int rpc_return = notifyGrapherOfStoryRecordingStart(*recording_group, chronicle, story, story_id, story_start_time);
-    
-    if( rpc_return != chronolog::CL_SUCCESS)
+
+    if(rpc_return != chronolog::CL_SUCCESS)
     {
-        LOG_WARNING("[ChronoProcessRegistry]  RecordingGroup {} failed to notify Grapher of Story {} Start : err_code {}", recording_group->groupId, story_id, rpc_return);
+        LOG_WARNING(
+                "[ChronoProcessRegistry]  RecordingGroup {} failed to notify Grapher of Story {} Start : err_code {}",
+                recording_group->groupId,
+                story_id,
+                rpc_return);
         return rpc_return;
     }
 
-    LOG_DEBUG("[ChronoProcessRegistry]  RecordingGroup {}  notified Grapher  of Story {} Start", recording_group->groupId, story_id);
+    LOG_DEBUG("[ChronoProcessRegistry]  RecordingGroup {}  notified Grapher  of Story {} Start",
+              recording_group->groupId,
+              story_id);
 
     recording_group->getActiveKeepers(vectorOfKeepers);
-    rpc_return = notifyKeepersOfStoryRecordingStart(*recording_group, vectorOfKeepers, chronicle, story, story_id,
-                                                        story_start_time);
-    if( rpc_return != chronolog::CL_SUCCESS)
+    rpc_return = notifyKeepersOfStoryRecordingStart(*recording_group,
+                                                    vectorOfKeepers,
+                                                    chronicle,
+                                                    story,
+                                                    story_id,
+                                                    story_start_time);
+    if(rpc_return != chronolog::CL_SUCCESS)
     {
-        LOG_WARNING("[ChronoProcessRegistry]  RecordingGroup {} failed to notify Keepers of Story {} Start : err_code {}", 
-            recording_group->groupId, story_id, rpc_return);
+        LOG_WARNING(
+                "[ChronoProcessRegistry]  RecordingGroup {} failed to notify Keepers of Story {} Start : err_code {}",
+                recording_group->groupId,
+                story_id,
+                rpc_return);
         vectorOfKeepers.clear();
         return rpc_return;
     }
 
-    LOG_DEBUG("[ChronoProcessRegistry]  RecordingGroup {}  notified  Keepers of story {} Start", recording_group->groupId, story_id);
+    LOG_DEBUG("[ChronoProcessRegistry]  RecordingGroup {}  notified  Keepers of story {} Start",
+              recording_group->groupId,
+              story_id);
 
     if(recording_group->playerProcess != nullptr)
     {
         player_service_id = recording_group->playerProcess->idCard.getPlaybackServiceId();
     }
 
-    LOG_INFO("[ChronoProcessRegistry]  RecordingGroup {}  notified  of story {} Start : group has {} keepers and player {}", 
-        recording_group->groupId, story_id, vectorOfKeepers.size(), chl::to_string(player_service_id));
+    LOG_INFO("[ChronoProcessRegistry]  RecordingGroup {}  notified  of story {} Start : group has {} keepers and "
+             "player {}",
+             recording_group->groupId,
+             story_id,
+             vectorOfKeepers.size(),
+             chl::to_string(player_service_id));
     return rpc_return;
 }
 
 ////////////////
-int KeeperRegistry::notifyGrapherOfStoryRecordingStart(RecordingGroup &recordingGroup, ChronicleName const &chronicle
-                                                       , StoryName const &story, StoryId const &storyId
-                                                       , uint64_t story_start_time)
+int KeeperRegistry::notifyGrapherOfStoryRecordingStart(RecordingGroup& recordingGroup,
+                                                       ChronicleName const& chronicle,
+                                                       StoryName const& story,
+                                                       StoryId const& storyId,
+                                                       uint64_t story_start_time)
 {
     int return_code = chronolog::CL_ERR_UNKNOWN;
 
     if(!is_running())
     {
-        LOG_ERROR("[ChronoProcessRegistry] Registry has no active RecordingGroups to start recording story {}", storyId);
+        LOG_ERROR("[ChronoProcessRegistry] Registry has no active RecordingGroups to start recording story {}",
+                  storyId);
         return chronolog::CL_ERR_UNKNOWN;
     }
 
@@ -603,24 +696,31 @@ int KeeperRegistry::notifyGrapherOfStoryRecordingStart(RecordingGroup &recording
         }
     }
 
-    if(dataAdminClient == nullptr) { return return_code; }
+    if(dataAdminClient == nullptr)
+    {
+        return return_code;
+    }
 
     try
     {
         return_code = dataAdminClient->send_start_story_recording(chronicle, story, storyId, story_start_time);
         if(return_code != chronolog::CL_SUCCESS)
         {
-            LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to {}", recordingGroup.grapherProcess->idCardString);
+            LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to {}",
+                        recordingGroup.grapherProcess->idCardString);
         }
         else
         {
             LOG_INFO("[ChronoProcessRegistry] Registry notified {} to start recording StoryID={} with StartTime={}",
-                     recordingGroup.grapherProcess->idCardString, storyId, story_start_time);
+                     recordingGroup.grapherProcess->idCardString,
+                     storyId,
+                     story_start_time);
         }
     }
     catch(thallium::exception const& ex)
     {
-        LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to grapher {}", recordingGroup.grapherProcess->idCardString);
+        LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to grapher {}",
+                    recordingGroup.grapherProcess->idCardString);
     }
 
     return return_code;
@@ -633,7 +733,8 @@ int KeeperRegistry::notifyGrapherOfStoryRecordingStop(RecordingGroup& recordingG
 
     if(!is_running())
     {
-        LOG_ERROR("[ChronoProcessRegistry] Registry has no active RecordingGroups to start recording story {}", storyId);
+        LOG_ERROR("[ChronoProcessRegistry] Registry has no active RecordingGroups to start recording story {}",
+                  storyId);
         return chronolog::CL_ERR_NO_KEEPERS;
     }
 
@@ -661,7 +762,10 @@ int KeeperRegistry::notifyGrapherOfStoryRecordingStop(RecordingGroup& recordingG
         }
     }
 
-    if(dataAdminClient == nullptr) { return return_code; }
+    if(dataAdminClient == nullptr)
+    {
+        return return_code;
+    }
 
     try
     {
@@ -672,7 +776,8 @@ int KeeperRegistry::notifyGrapherOfStoryRecordingStop(RecordingGroup& recordingG
         }
         else
         {
-            LOG_INFO("[ChronoProcessRegistry] Registry notified grapher {} to stop recording StoryID={} ", id_string.str(),
+            LOG_INFO("[ChronoProcessRegistry] Registry notified grapher {} to stop recording StoryID={} ",
+                     id_string.str(),
                      storyId);
         }
     }
@@ -685,17 +790,20 @@ int KeeperRegistry::notifyGrapherOfStoryRecordingStop(RecordingGroup& recordingG
 }
 /////////////////////
 
-int KeeperRegistry::notifyKeepersOfStoryRecordingStart(RecordingGroup& recordingGroup
-                                                       , std::vector <KeeperIdCard> &vectorOfKeepers
-                                                       , ChronicleName const &chronicle, StoryName const &story
-                                                       , StoryId const &storyId, uint64_t story_start_time)
+int KeeperRegistry::notifyKeepersOfStoryRecordingStart(RecordingGroup& recordingGroup,
+                                                       std::vector<KeeperIdCard>& vectorOfKeepers,
+                                                       ChronicleName const& chronicle,
+                                                       StoryName const& story,
+                                                       StoryId const& storyId,
+                                                       uint64_t story_start_time)
 {
 
     // if there are no activeGroups ready for recording
     // we are out of luck...
     if(!is_running())
     {
-        LOG_ERROR("[ChronoProcessRegistry] Registry has no active RecordingGroups to start recording story {}", storyId);
+        LOG_ERROR("[ChronoProcessRegistry] Registry has no active RecordingGroups to start recording story {}",
+                  storyId);
         return chronolog::CL_ERR_NO_KEEPERS;
     }
 
@@ -713,8 +821,9 @@ int KeeperRegistry::notifyKeepersOfStoryRecordingStart(RecordingGroup& recording
             // (see unregisterKeeperProcess()) to protect us from the unfortunate case of keeperProcessEntry.dataAdminClient object being deleted
             // while this thread is waiting for rpc response
             std::lock_guard<std::mutex> lock(registryLock);
-            auto keeper_process_iter = keeper_processes.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
-                    
+            auto keeper_process_iter =
+                    keeper_processes.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
+
             if((keeper_process_iter != keeper_processes.end() && (*keeper_process_iter).second.active) &&
                ((*keeper_process_iter).second.keeperAdminClient != nullptr))
             {
@@ -722,7 +831,8 @@ int KeeperRegistry::notifyKeepersOfStoryRecordingStart(RecordingGroup& recording
             }
             else
             {
-                LOG_WARNING("[ChronoProcessRegistry] Keeper {} is not available for notification", to_string(keeper_id_card));
+                LOG_WARNING("[ChronoProcessRegistry] Keeper {} is not available for notification",
+                            to_string(keeper_id_card));
                 continue;
             }
         }
@@ -732,18 +842,22 @@ int KeeperRegistry::notifyKeepersOfStoryRecordingStart(RecordingGroup& recording
             int rpc_return = dataAdminClient->send_start_story_recording(chronicle, story, storyId, story_start_time);
             if(rpc_return != chronolog::CL_SUCCESS)
             {
-                LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to keeper {}", to_string(keeper_id_card));
+                LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to keeper {}",
+                            to_string(keeper_id_card));
             }
             else
             {
                 LOG_INFO("[ChronoProcessRegistry] Registry notified {} to start recording StoryID={} with StartTime={}",
-                         to_string(keeper_id_card), storyId, story_start_time);
+                         to_string(keeper_id_card),
+                         storyId,
+                         story_start_time);
                 vectorOfKeepers.push_back(keeper_id_card);
             }
         }
         catch(thallium::exception const& ex)
         {
-            LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to keeper {}", to_string(keeper_id_card));
+            LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to keeper {}",
+                        to_string(keeper_id_card));
         }
     }
 
@@ -768,7 +882,8 @@ int KeeperRegistry::notifyRecordingGroupOfStoryRecordingStop(StoryId const& stor
         std::lock_guard<std::mutex> lock(registryLock);
         if(!is_running())
         {
-            LOG_ERROR("[ChronoProcessRegistry] Registry has no active RecordingGroups to start recording story {}", story_id);
+            LOG_ERROR("[ChronoProcessRegistry] Registry has no active RecordingGroups to start recording story {}",
+                      story_id);
             return chronolog::CL_ERR_NO_KEEPERS;
         }
 
@@ -782,7 +897,10 @@ int KeeperRegistry::notifyRecordingGroupOfStoryRecordingStop(StoryId const& stor
         }
 
         recording_group = (*story_iter).second;
-        if(recording_group != nullptr) { recording_group->getActiveKeepers(vectorOfKeepers); }
+        if(recording_group != nullptr)
+        {
+            recording_group->getActiveKeepers(vectorOfKeepers);
+        }
 
         activeStories.erase(story_iter);
     }
@@ -794,7 +912,7 @@ int KeeperRegistry::notifyRecordingGroupOfStoryRecordingStop(StoryId const& stor
         // the rpc code from DataAdminClients being destroyed while notification is in progress..
 
         notifyKeepersOfStoryRecordingStop(*recording_group, vectorOfKeepers, story_id);
-     
+
         notifyGrapherOfStoryRecordingStop(*recording_group, story_id);
     }
 
@@ -822,7 +940,8 @@ int KeeperRegistry::notifyKeepersOfStoryRecordingStop(RecordingGroup& recordingG
             // (see unregisterKeeperProcess()) to protect us from the unfortunate case of keeperProcessEntry.dataAdminClient object being deleted
             // while this thread is waiting for rpc response
             std::lock_guard<std::mutex> lock(registryLock);
-            auto keeper_process_iter = keeper_processes.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
+            auto keeper_process_iter =
+                    keeper_processes.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
             if((keeper_process_iter != keeper_processes.end() && (*keeper_process_iter).second.active) &&
                ((*keeper_process_iter).second.keeperAdminClient != nullptr))
             {
@@ -830,7 +949,8 @@ int KeeperRegistry::notifyKeepersOfStoryRecordingStop(RecordingGroup& recordingG
             }
             else
             {
-                LOG_WARNING("[ChronoProcessRegistry] Keeper {} is not available for notification", to_string(keeper_id_card));
+                LOG_WARNING("[ChronoProcessRegistry] Keeper {} is not available for notification",
+                            to_string(keeper_id_card));
                 continue;
             }
         }
@@ -839,16 +959,20 @@ int KeeperRegistry::notifyKeepersOfStoryRecordingStop(RecordingGroup& recordingG
             int rpc_return = dataAdminClient->send_stop_story_recording(storyId);
             if(rpc_return != chronolog::CL_SUCCESS)
             {
-                LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to keeper {}", to_string(keeper_id_card));
+                LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to keeper {}",
+                            to_string(keeper_id_card));
             }
             else
             {
-                LOG_INFO("[ChronoProcessRegistry] Registry notified  {} to stop recording story {}", to_string(keeper_id_card), storyId);
+                LOG_INFO("[ChronoProcessRegistry] Registry notified  {} to stop recording story {}",
+                         to_string(keeper_id_card),
+                         storyId);
             }
         }
         catch(thallium::exception const& ex)
         {
-            LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to keeper {}", to_string(keeper_id_card));
+            LOG_WARNING("[ChronoProcessRegistry] Registry failed RPC notification to keeper {}",
+                        to_string(keeper_id_card));
         }
     }
 
@@ -857,9 +981,12 @@ int KeeperRegistry::notifyKeepersOfStoryRecordingStop(RecordingGroup& recordingG
 
 ////////////////////////////
 
-int KeeperRegistry::registerGrapherProcess(GrapherRegistrationMsg const & reg_msg)
+int KeeperRegistry::registerGrapherProcess(GrapherRegistrationMsg const& reg_msg)
 {
-    if(is_shutting_down()) { return chronolog::CL_ERR_UNKNOWN; }
+    if(is_shutting_down())
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
     GrapherIdCard grapher_id_card = reg_msg.getGrapherIdCard();
     RecordingGroupId group_id = grapher_id_card.getGroupId();
@@ -867,7 +994,10 @@ int KeeperRegistry::registerGrapherProcess(GrapherRegistrationMsg const & reg_ms
 
     std::lock_guard<std::mutex> lock(registryLock);
     //re-check state after ther lock is aquired
-    if(is_shutting_down()) { return chronolog::CL_ERR_UNKNOWN; }
+    if(is_shutting_down())
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
     //find the group that grapher belongs to in the registry
     auto group_iter = recordingGroups.find(group_id);
@@ -880,7 +1010,10 @@ int KeeperRegistry::registerGrapherProcess(GrapherRegistrationMsg const & reg_ms
             LOG_ERROR("[ChronoProcessRegistry] keeper registration failed to find RecordingGroup {}", group_id);
             return chronolog::CL_ERR_UNKNOWN;
         }
-        else { group_iter = insert_return.first; }
+        else
+        {
+            group_iter = insert_return.first;
+        }
     }
 
     RecordingGroup& recording_group = ((*group_iter).second);
@@ -914,14 +1047,17 @@ int KeeperRegistry::registerGrapherProcess(GrapherRegistrationMsg const & reg_ms
 
         if(grapher_process->delayedExitGrapherClients.empty())
         {
-            LOG_INFO("[ChronoProcessRegistry] registerGrapherProcess has destroyed old entry for grapher {}", chl::to_string(grapher_id_card));
+            LOG_INFO("[ChronoProcessRegistry] registerGrapherProcess has destroyed old entry for grapher {}",
+                     chl::to_string(grapher_id_card));
             delete grapher_process;
             recording_group.grapherProcess = nullptr;
         }
         else
         {
-            LOG_INFO("[ChronoProcessRegistry] registration for Grapher{} cant's proceed as previous grapherClient isn't yet "
-                     "dismantled", chl::to_string(grapher_id_card));
+            LOG_INFO("[ChronoProcessRegistry] registration for Grapher{} cant's proceed as previous grapherClient "
+                     "isn't yet "
+                     "dismantled",
+                     chl::to_string(grapher_id_card));
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
@@ -931,12 +1067,16 @@ int KeeperRegistry::registerGrapherProcess(GrapherRegistrationMsg const & reg_ms
     std::string service_na_string;
     admin_service_id.get_service_as_string(service_na_string);
 
-    DataStoreAdminClient* collectionClient = DataStoreAdminClient::CreateDataStoreAdminClient(
-            *registryEngine, service_na_string, admin_service_id.getProviderId());
+    DataStoreAdminClient* collectionClient =
+            DataStoreAdminClient::CreateDataStoreAdminClient(*registryEngine,
+                                                             service_na_string,
+                                                             admin_service_id.getProviderId());
     if(nullptr == collectionClient)
     {
-        LOG_ERROR("[ChronoProcessRegistry] Register Grapher {} failed to create DataStoreAdminClient for {}: provider_id={}",
-                  chl::to_string(grapher_id_card), chl::to_string(admin_service_id));
+        LOG_ERROR("[ChronoProcessRegistry] Register Grapher {} failed to create DataStoreAdminClient for {}: "
+                  "provider_id={}",
+                  chl::to_string(grapher_id_card),
+                  chl::to_string(admin_service_id));
         return chronolog::CL_ERR_UNKNOWN;
     }
 
@@ -946,9 +1086,11 @@ int KeeperRegistry::registerGrapherProcess(GrapherRegistrationMsg const & reg_ms
     recording_group.grapherProcess->active = true;
 
     LOG_INFO("[ChronoProcessRegistry] Register grapher {} created DataStoreAdminClient for {}",
-                  chl::to_string(grapher_id_card), chl::to_string(admin_service_id));
+             chl::to_string(grapher_id_card),
+             chl::to_string(admin_service_id));
 
-    LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} has a grappher and  {} keepers", recording_group.groupId,
+    LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} has a grappher and  {} keepers",
+             recording_group.groupId,
              recording_group.keeperProcesses.size());
 
     // now that communnication with the Grapher is established and we are still holding registryLock
@@ -956,19 +1098,21 @@ int KeeperRegistry::registerGrapherProcess(GrapherRegistrationMsg const & reg_ms
     if(recording_group.isActive())
     {
         activeGroups.push_back(&recording_group);
-        
+
         //reset the group distribution
         size_t new_seed = std::chrono::high_resolution_clock::to_time_t(std::chrono::high_resolution_clock::now());
-        mt_random.seed(new_seed);//re-seed the mersene_twister_generator
+        mt_random.seed(new_seed); //re-seed the mersene_twister_generator
         group_id_distribution = std::uniform_int_distribution<size_t>(0, activeGroups.size() - 1);
     }
 
-    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ", activeGroups.size(), recordingGroups.size());
+    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ",
+             activeGroups.size(),
+             recordingGroups.size());
     // we still holding registryLock
     // update registryState if needed
-    if(activeGroups.size() > 0) 
-    { 
-        registryState = RUNNING; 
+    if(activeGroups.size() > 0)
+    {
+        registryState = RUNNING;
     }
     return chronolog::CL_SUCCESS;
 }
@@ -978,39 +1122,53 @@ int KeeperRegistry::unregisterGrapherProcess(GrapherIdCard const& grapher_id_car
 {
     std::lock_guard<std::mutex> lock(registryLock);
     //check again after the lock is acquired
-    if(is_shutting_down()) { return chronolog::CL_ERR_UNKNOWN; }
+    if(is_shutting_down())
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
     auto group_iter = recordingGroups.find(grapher_id_card.getGroupId());
-    if(group_iter == recordingGroups.end()) { return chronolog::CL_SUCCESS; }
+    if(group_iter == recordingGroups.end())
+    {
+        return chronolog::CL_SUCCESS;
+    }
 
     RecordingGroup& recording_group = ((*group_iter).second);
 
-    // we are about to unregister the grapher so the group can't perform recording duties 
+    // we are about to unregister the grapher so the group can't perform recording duties
     // if it were an active recordingGroup before remove it from rotation
     if(recording_group.isActive())
     {
         auto active_group_iter = activeGroups.begin();
-        while (active_group_iter != activeGroups.end())
+        while(active_group_iter != activeGroups.end())
         {
-            if((*active_group_iter) != &recording_group) 
-            { ++active_group_iter;}
+            if((*active_group_iter) != &recording_group)
+            {
+                ++active_group_iter;
+            }
             else
-            { break; }
+            {
+                break;
+            }
         }
 
         if(active_group_iter != activeGroups.end())
         {
             //INNA: what do we do with any active Stories that this group were recordng? force release them and notify clients?
             // wait for the new grapher?
-            LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} is not active; activeGroups.size{}", recording_group.groupId,activeGroups.size());
+            LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} is not active; activeGroups.size{}",
+                     recording_group.groupId,
+                     activeGroups.size());
             activeGroups.erase(active_group_iter);
             if(activeGroups.size() > 0)
             {
                 //reset the group distribution
-                size_t new_seed = std::chrono::high_resolution_clock::to_time_t(std::chrono::high_resolution_clock::now());
-                mt_random.seed(new_seed);//re-seed the mersene_twister_generator
+                size_t new_seed =
+                        std::chrono::high_resolution_clock::to_time_t(std::chrono::high_resolution_clock::now());
+                mt_random.seed(new_seed); //re-seed the mersene_twister_generator
                 group_id_distribution =
-                    std::uniform_int_distribution<size_t>(0, activeGroups.size() - 1);//reset the distribution range
+                        std::uniform_int_distribution<size_t>(0,
+                                                              activeGroups.size() - 1); //reset the distribution range
             }
         }
     }
@@ -1023,7 +1181,8 @@ int KeeperRegistry::unregisterGrapherProcess(GrapherIdCard const& grapher_id_car
 
         std::time_t delayedExitTime = std::chrono::high_resolution_clock::to_time_t(
                 std::chrono::high_resolution_clock::now() + std::chrono::seconds(delayedDataAdminExitSeconds));
-        LOG_INFO("[ChronoProcessRegistry] starting delayedExit for grapher {} delayedExitTime={}", recording_group.grapherProcess->idCardString,
+        LOG_INFO("[ChronoProcessRegistry] starting delayedExit for grapher {} delayedExitTime={}",
+                 recording_group.grapherProcess->idCardString,
                  std::ctime(&delayedExitTime));
 
         recording_group.startDelayedGrapherExit(*(recording_group.grapherProcess), delayedExitTime);
@@ -1031,27 +1190,35 @@ int KeeperRegistry::unregisterGrapherProcess(GrapherIdCard const& grapher_id_car
 
     // now that we are still holding registryLock
     // update registryState if needed
-    LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} has no grapher and  {} keepers", recording_group.groupId,
+    LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} has no grapher and  {} keepers",
+             recording_group.groupId,
              recording_group.keeperProcesses.size());
-        
-    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ", activeGroups.size(), recordingGroups.size());
-    
+
+    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ",
+             activeGroups.size(),
+             recordingGroups.size());
+
     // update registryState in case this was the last active recordingGroup
-    if(activeGroups.size() == 0) { registryState = INITIALIZED; }
+    if(activeGroups.size() == 0)
+    {
+        registryState = INITIALIZED;
+    }
 
     return chronolog::CL_SUCCESS;
 }
 
-}//namespace chronolog
+} //namespace chronolog
 
-void chl::KeeperRegistry::updateGrapherProcessStats(chl::GrapherStatsMsg const &statsMsg)
+void chl::KeeperRegistry::updateGrapherProcessStats(chl::GrapherStatsMsg const& statsMsg)
 {
     // NOTE: we don't lock registryLock while updating the keeperProcess stats
     // delayed destruction of keeperProcessEntry protects us from the case when
     // stats message is received from the KeeperProcess that has unregistered
     // on the other thread
     if(is_shutting_down())
-    { return; }
+    {
+        return;
+    }
 
 #ifdef DEBUG
     std::string id_string;
@@ -1060,8 +1227,10 @@ void chl::KeeperRegistry::updateGrapherProcessStats(chl::GrapherStatsMsg const &
 #endif
 
     auto group_iter = recordingGroups.find(statsMsg.getGrapherIdCard().getGroupId());
-    if(group_iter == recordingGroups.end()) 
-    { return; }
+    if(group_iter == recordingGroups.end())
+    {
+        return;
+    }
 
     RecordingGroup& recording_group = ((*group_iter).second);
     if(recording_group.grapherProcess != nullptr && recording_group.grapherProcess->active)
@@ -1069,36 +1238,43 @@ void chl::KeeperRegistry::updateGrapherProcessStats(chl::GrapherStatsMsg const &
         // there's no need to update stats of inactive process
         recording_group.grapherProcess->lastStatsTime = std::chrono::steady_clock::now().time_since_epoch().count();
         recording_group.grapherProcess->activeStoryCount = statsMsg.getActiveStoryCount();
-
     }
 }
 
 /////////////////
 
-int chl::KeeperRegistry::registerPlayerProcess(chl::PlayerRegistrationMsg const & reg_msg)
+int chl::KeeperRegistry::registerPlayerProcess(chl::PlayerRegistrationMsg const& reg_msg)
 {
-    if(is_shutting_down()) { return chronolog::CL_ERR_UNKNOWN; }
+    if(is_shutting_down())
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
     chl::PlayerIdCard id_card = reg_msg.getPlayerIdCard();
     chl::RecordingGroupId group_id = id_card.getGroupId();
     chl::ServiceId admin_service_id = reg_msg.getAdminServiceId();
 
     std::lock_guard<std::mutex> lock(registryLock);
-    if(is_shutting_down()) 
-    { return chronolog::CL_ERR_UNKNOWN; }
+    if(is_shutting_down())
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
-    //find the recording group that new player process belongs to or create one 
+    //find the recording group that new player process belongs to or create one
     auto group_iter = recordingGroups.find(group_id);
     if(group_iter == recordingGroups.end())
     {
-        auto insert_return =
-                recordingGroups.insert(std::pair<chl::RecordingGroupId, chl::RecordingGroup>(group_id, chl::RecordingGroup(group_id)));
+        auto insert_return = recordingGroups.insert(
+                std::pair<chl::RecordingGroupId, chl::RecordingGroup>(group_id, chl::RecordingGroup(group_id)));
         if(false == insert_return.second)
         {
             LOG_ERROR("[ChronoProcessRegistry] player registration failed to find RecordingGroup {}", group_id);
             return chronolog::CL_ERR_UNKNOWN;
         }
-        else { group_iter = insert_return.first; }
+        else
+        {
+            group_iter = insert_return.first;
+        }
     }
 
     chl::RecordingGroup& recording_group = ((*group_iter).second);
@@ -1130,15 +1306,18 @@ int chl::KeeperRegistry::registerPlayerProcess(chl::PlayerRegistrationMsg const 
 
         if(player_process->delayedExitPlayerClients.empty())
         {
-            LOG_INFO("[ChronoProcessRegistry] registerplayerProcess has destroyed old entry for player {}", chl::to_string(id_card));
+            LOG_INFO("[ChronoProcessRegistry] registerplayerProcess has destroyed old entry for player {}",
+                     chl::to_string(id_card));
             delete player_process;
             recording_group.playerProcess = nullptr;
         }
         else
         {
-            LOG_INFO("[ChronoProcessRegistry] registration for Player{} cant's proceed as previous playerClient isn't yet "
-                     "dismantled", chl::to_string(id_card));
-                     
+            LOG_INFO("[ChronoProcessRegistry] registration for Player{} cant's proceed as previous playerClient isn't "
+                     "yet "
+                     "dismantled",
+                     chl::to_string(id_card));
+
             return chronolog::CL_ERR_UNKNOWN;
         }
     }
@@ -1147,14 +1326,17 @@ int chl::KeeperRegistry::registerPlayerProcess(chl::PlayerRegistrationMsg const 
     std::string service_na_string;
     admin_service_id.get_service_as_string(service_na_string);
 
-    LOG_DEBUG("[ChronoProcessRegistry] creating AdminClient for service_na_string {}",service_na_string);
+    LOG_DEBUG("[ChronoProcessRegistry] creating AdminClient for service_na_string {}", service_na_string);
 
-    chl::DataStoreAdminClient* collectionClient = chl::DataStoreAdminClient::CreateDataStoreAdminClient(
-            *registryEngine, service_na_string, admin_service_id.getProviderId());
+    chl::DataStoreAdminClient* collectionClient =
+            chl::DataStoreAdminClient::CreateDataStoreAdminClient(*registryEngine,
+                                                                  service_na_string,
+                                                                  admin_service_id.getProviderId());
     if(nullptr == collectionClient)
     {
         LOG_ERROR("[ChronoProcessRegistry] Register Player {} failed to create DataStoreAdminClient for {}",
-                  chl::to_string(id_card), chl::to_string(admin_service_id));
+                  chl::to_string(id_card),
+                  chl::to_string(admin_service_id));
         return chronolog::CL_ERR_UNKNOWN;
     }
 
@@ -1164,17 +1346,20 @@ int chl::KeeperRegistry::registerPlayerProcess(chl::PlayerRegistrationMsg const 
     recording_group.playerProcess->active = true;
 
     LOG_INFO("[ChronoProcessRegistry] Register Player {} created DataStoreAdminClient for {}",
-             chl::to_string(id_card), chl::to_string(admin_service_id));
+             chl::to_string(id_card),
+             chl::to_string(admin_service_id));
 
     // now that communnication with the Player is established and we are still holding registryLock
     // check if the group is ready for active group rotation
 
-    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ", activeGroups.size(), recordingGroups.size());
+    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ",
+             activeGroups.size(),
+             recordingGroups.size());
     // we still holding registryLock
     // update registryState if needed
-    if(activeGroups.size() > 0) 
-    { 
-        registryState = RUNNING; 
+    if(activeGroups.size() > 0)
+    {
+        registryState = RUNNING;
     }
     return chronolog::CL_SUCCESS;
 }
@@ -1183,15 +1368,20 @@ int chl::KeeperRegistry::registerPlayerProcess(chl::PlayerRegistrationMsg const 
 int chl::KeeperRegistry::unregisterPlayerProcess(chl::PlayerIdCard const& id_card)
 {
     std::lock_guard<std::mutex> lock(registryLock);
-    if(is_shutting_down()) { return chronolog::CL_ERR_UNKNOWN; }
+    if(is_shutting_down())
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
     auto group_iter = recordingGroups.find(id_card.getGroupId());
-    if(group_iter == recordingGroups.end()) 
-    { return chronolog::CL_SUCCESS; }
+    if(group_iter == recordingGroups.end())
+    {
+        return chronolog::CL_SUCCESS;
+    }
 
     RecordingGroup& recording_group = ((*group_iter).second);
 
-    // we are about to unregister the player so the group can't perform playback duties 
+    // we are about to unregister the player so the group can't perform playback duties
 
     // TODO: handle the case by notifying the clients that playback service is not available...
 
@@ -1204,7 +1394,8 @@ int chl::KeeperRegistry::unregisterPlayerProcess(chl::PlayerIdCard const& id_car
 
         std::time_t delayedExitTime = std::chrono::high_resolution_clock::to_time_t(
                 std::chrono::high_resolution_clock::now() + std::chrono::seconds(delayedDataAdminExitSeconds));
-        LOG_INFO("[ChronoProcessRegistry] starting delayedExit for player {} delayedExitTime={}", recording_group.playerProcess->idCardString,
+        LOG_INFO("[ChronoProcessRegistry] starting delayedExit for player {} delayedExitTime={}",
+                 recording_group.playerProcess->idCardString,
                  std::ctime(&delayedExitTime));
 
         recording_group.startDelayedPlayerExit(*(recording_group.playerProcess), delayedExitTime);
@@ -1213,24 +1404,30 @@ int chl::KeeperRegistry::unregisterPlayerProcess(chl::PlayerIdCard const& id_car
     // now that we are still holding registryLock
     // update registryState if needed
     LOG_INFO("[ChronoProcessRegistry] RecordingGroup {} has no chrono_player ", recording_group.groupId);
-        
-    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ", activeGroups.size(), recordingGroups.size());
-    
+
+    LOG_INFO("[ChronoProcessRegistry]  has {} activeGroups; {} RecordingGroups ",
+             activeGroups.size(),
+             recordingGroups.size());
+
     // update registryState in case this was the last active recordingGroup
     if(activeGroups.size() == 0)
-    { registryState = INITIALIZED; }
+    {
+        registryState = INITIALIZED;
+    }
 
     return chronolog::CL_SUCCESS;
 }
 
-void chl::KeeperRegistry::updatePlayerProcessStats(chl::PlayerStatsMsg const &statsMsg)
+void chl::KeeperRegistry::updatePlayerProcessStats(chl::PlayerStatsMsg const& statsMsg)
 {
     // NOTE: we don't lock registryLock while updating the keeperProcess stats
     // delayed destruction of keeperProcessEntry protects us from the case when
     // stats message is received from the KeeperProcess that has unregistered
     // on the other thread
     if(is_shutting_down())
-    { return; }
+    {
+        return;
+    }
 
 #ifdef DEBUG
     std::string id_string;
@@ -1240,16 +1437,16 @@ void chl::KeeperRegistry::updatePlayerProcessStats(chl::PlayerStatsMsg const &st
 
     auto group_iter = recordingGroups.find(statsMsg.getPlayerIdCard().getGroupId());
     if(group_iter == recordingGroups.end())
-    { return; }
+    {
+        return;
+    }
 
     RecordingGroup& recording_group = ((*group_iter).second);
     if(recording_group.playerProcess != nullptr && recording_group.playerProcess->active)
     {
         // there's no need to update stats of inactive process
         recording_group.playerProcess->lastStatsTime = std::chrono::steady_clock::now().time_since_epoch().count();
-
     }
-
 }
 
 
@@ -1258,9 +1455,9 @@ void chl::KeeperRegistry::updatePlayerProcessStats(chl::PlayerStatsMsg const &st
 bool chl::RecordingGroup::isActive() const
 {
     //TODO: we might add a check for time since the last stats message received from
-    // the processes listed as active 
+    // the processes listed as active
 
-    if(grapherProcess != nullptr && grapherProcess->active && activeKeeperCount >0)
+    if(grapherProcess != nullptr && grapherProcess->active && activeKeeperCount > 0)
     {
         LOG_DEBUG("[ChronoProcessRegistry RecordingGroup {} is active", groupId);
         return true;
@@ -1277,7 +1474,9 @@ void chl::RecordingGroup::startDelayedGrapherExit(chl::GrapherProcessEntry& grap
 {
     grapher_process.active = false;
 
-    LOG_INFO("[ChronoProcessRegistry] recording_group {} starts delayedExit for {}", groupId, grapher_process.idCardString);
+    LOG_INFO("[ChronoProcessRegistry] recording_group {} starts delayedExit for {}",
+             groupId,
+             grapher_process.idCardString);
     if(grapher_process.adminClient != nullptr)
     {
         grapher_process.delayedExitGrapherClients.push_back(
@@ -1291,20 +1490,25 @@ void chl::RecordingGroup::clearDelayedExitGrapher(chl::GrapherProcessEntry& grap
     while(!grapher_process.delayedExitGrapherClients.empty() &&
           (current_time >= grapher_process.delayedExitGrapherClients.front().first))
     {
-        LOG_INFO("[ChronoProcessRegistry] recording_Group {}, destroys delayed dataAdmindClient for {}", groupId,
-                  grapher_process.idCardString);
+        LOG_INFO("[ChronoProcessRegistry] recording_Group {}, destroys delayed dataAdmindClient for {}",
+                 groupId,
+                 grapher_process.idCardString);
         auto dataStoreClientPair = grapher_process.delayedExitGrapherClients.front();
-        if(dataStoreClientPair.second != nullptr) { delete dataStoreClientPair.second; }
+        if(dataStoreClientPair.second != nullptr)
+        {
+            delete dataStoreClientPair.second;
+        }
         grapher_process.delayedExitGrapherClients.pop_front();
     }
 }
 
-void chl::RecordingGroup::startDelayedPlayerExit(chl::PlayerProcessEntry& player_process,
-                                                  std::time_t delayedExitTime)
+void chl::RecordingGroup::startDelayedPlayerExit(chl::PlayerProcessEntry& player_process, std::time_t delayedExitTime)
 {
     player_process.active = false;
 
-    LOG_INFO("[ChronoProcessRegistry] recording_group {} starts delayedExit for {}", groupId, player_process.idCardString);
+    LOG_INFO("[ChronoProcessRegistry] recording_group {} starts delayedExit for {}",
+             groupId,
+             player_process.idCardString);
     if(player_process.adminClient != nullptr)
     {
         player_process.delayedExitPlayerClients.push_back(
@@ -1318,10 +1522,14 @@ void chl::RecordingGroup::clearDelayedExitPlayer(chl::PlayerProcessEntry& player
     while(!player_process.delayedExitPlayerClients.empty() &&
           (current_time >= player_process.delayedExitPlayerClients.front().first))
     {
-        LOG_INFO("[ChronoProcessRegistry] recording_Group {}, destroys delayed dataAdmindClient for {}", groupId,
-                  player_process.idCardString);
+        LOG_INFO("[ChronoProcessRegistry] recording_Group {}, destroys delayed dataAdmindClient for {}",
+                 groupId,
+                 player_process.idCardString);
         auto dataStoreClientPair = player_process.delayedExitPlayerClients.front();
-        if(dataStoreClientPair.second != nullptr) { delete dataStoreClientPair.second; }
+        if(dataStoreClientPair.second != nullptr)
+        {
+            delete dataStoreClientPair.second;
+        }
         player_process.delayedExitPlayerClients.pop_front();
     }
 }
@@ -1337,7 +1545,9 @@ void chl::RecordingGroup::startDelayedKeeperExit(chl::KeeperProcessEntry& keeper
     keeper_process.active = false;
     activeKeeperCount -= 1;
 
-    LOG_INFO("[ChronoProcessRegistry] recording_group {} starts delayedExit for {}", groupId, keeper_process.idCardString);
+    LOG_INFO("[ChronoProcessRegistry] recording_group {} starts delayedExit for {}",
+             groupId,
+             keeper_process.idCardString);
     if(keeper_process.keeperAdminClient != nullptr)
     {
         keeper_process.delayedExitClients.push_back(
@@ -1351,9 +1561,14 @@ void chl::RecordingGroup::clearDelayedExitKeeper(chl::KeeperProcessEntry& keeper
     while(!keeper_process.delayedExitClients.empty() &&
           (current_time >= keeper_process.delayedExitClients.front().first))
     {
-        LOG_INFO("[ChronoProcessRegistry] recording_group {} destroys delayed dataAdminClient for {}", groupId, keeper_process.idCardString);
+        LOG_INFO("[ChronoProcessRegistry] recording_group {} destroys delayed dataAdminClient for {}",
+                 groupId,
+                 keeper_process.idCardString);
         auto dataStoreClientPair = keeper_process.delayedExitClients.front();
-        if(dataStoreClientPair.second != nullptr) { delete dataStoreClientPair.second; }
+        if(dataStoreClientPair.second != nullptr)
+        {
+            delete dataStoreClientPair.second;
+        }
         keeper_process.delayedExitClients.pop_front();
     }
 }

--- a/ChronoVisor/src/VisorClientPortal.cpp
+++ b/ChronoVisor/src/VisorClientPortal.cpp
@@ -17,13 +17,16 @@ namespace tl = thallium;
 namespace chl = chronolog;
 
 /////////////////
-chronolog::VisorClientPortal::VisorClientPortal(): clientPortalState(chl::VisorClientPortal::UNKNOWN)
-                                                   , clientPortalEngine(nullptr), clientPortalService(nullptr)
-                                                   , theKeeperRegistry(nullptr)  //TODO: revisit later ...
+chronolog::VisorClientPortal::VisorClientPortal()
+    : clientPortalState(chl::VisorClientPortal::UNKNOWN)
+    , clientPortalEngine(nullptr)
+    , clientPortalService(nullptr)
+    , theKeeperRegistry(nullptr) //TODO: revisit later ...
 {
     // TODO: revisit the construction of registries ....
-    LOG_DEBUG("[VisorClientPortal] Constructor is called. Object created at {} in thread PID={}"
-         , static_cast<const void*>(this), getpid());
+    LOG_DEBUG("[VisorClientPortal] Constructor is called. Object created at {} in thread PID={}",
+              static_cast<const void*>(this),
+              getpid());
     //clientManager = ChronoLog::Singleton<ClientRegistryManager>::GetInstance();
     //chronicleMetaDirectory = ChronoLog::Singleton<ChronicleMetaDirectory>::GetInstance();
     clientManager.setChronicleMetaDirectory(&chronicleMetaDirectory);
@@ -31,14 +34,16 @@ chronolog::VisorClientPortal::VisorClientPortal(): clientPortalState(chl::VisorC
 }
 
 ////////////////
-int chronolog::VisorClientPortal::StartServices(chronolog::VisorConfiguration const & VISOR_CONF
-                                                , chl::KeeperRegistry*keeperRegistry)
+int chronolog::VisorClientPortal::StartServices(chronolog::VisorConfiguration const& VISOR_CONF,
+                                                chl::KeeperRegistry* keeperRegistry)
 {
     int return_status = chronolog::CL_ERR_UNKNOWN;
 
     // check if already started
     if(clientPortalState != UNKNOWN)
-    { return chronolog::CL_SUCCESS; }
+    {
+        return chronolog::CL_SUCCESS;
+    }
 
     // TODO : keeper registry can be a member ...
     theKeeperRegistry = keeperRegistry;
@@ -63,13 +68,12 @@ int chronolog::VisorClientPortal::StartServices(chronolog::VisorConfiguration co
         LOG_INFO("[VisorClientPortal] margo_instance initialized with NA_STRING {}", CLIENT_PORTAL_SERVICE_NA_STRING);
 
         clientPortalEngine = new tl::engine(margo_id);
-        clientPortalService = chl::ClientPortalService::CreateClientPortalService(*clientPortalEngine, provider_id
-                                                                                  , *this);
+        clientPortalService =
+                chl::ClientPortalService::CreateClientPortalService(*clientPortalEngine, provider_id, *this);
         clientPortalState = INITIALIZED;
         return_status = chronolog::CL_SUCCESS;
-
     }
-    catch(tl::exception const &ex)
+    catch(tl::exception const& ex)
     {
         LOG_ERROR("[VisorClientPortal] Failed to start ClientPortal services.");
     }
@@ -77,10 +81,7 @@ int chronolog::VisorClientPortal::StartServices(chronolog::VisorConfiguration co
     return return_status;
 }
 
-void chronolog::VisorClientPortal::ShutdownServices()
-{
-    clientPortalState = SHUTTING_DOWN;
-}
+void chronolog::VisorClientPortal::ShutdownServices() { clientPortalState = SHUTTING_DOWN; }
 
 /////////////////
 chronolog::VisorClientPortal::~VisorClientPortal()
@@ -90,19 +91,29 @@ chronolog::VisorClientPortal::~VisorClientPortal()
     ShutdownServices();
 
     if(clientPortalService != nullptr)
-    { delete clientPortalService; }
+    {
+        delete clientPortalService;
+    }
 
     if(clientPortalEngine != nullptr)
-    { delete clientPortalEngine; }
+    {
+        delete clientPortalEngine;
+    }
 }
 
 /**
  * Admin APIs
  */
-int chronolog::VisorClientPortal::ClientConnect(uint32_t client_euid, uint32_t client_host_id, uint32_t client_pid
-                                                , chl::ClientId &client_id, uint64_t &clock_offset)
+int chronolog::VisorClientPortal::ClientConnect(uint32_t client_euid,
+                                                uint32_t client_host_id,
+                                                uint32_t client_pid,
+                                                chl::ClientId& client_id,
+                                                uint64_t& clock_offset)
 {
-    LOG_INFO("New Client Connected. ClientEUID={}, ClientHostID={}, ClientPID={}", client_euid, client_host_id, client_pid);
+    LOG_INFO("New Client Connected. ClientEUID={}, ClientHostID={}, ClientPID={}",
+             client_euid,
+             client_host_id,
+             client_pid);
     ClientInfo record;
 
     if(!is_client_authenticated(client_euid))
@@ -115,13 +126,16 @@ int chronolog::VisorClientPortal::ClientConnect(uint32_t client_euid, uint32_t c
     std::string client_account_for_hash =
             std::to_string(client_euid) + std::to_string(client_host_id) + std::to_string(client_pid);
     uint64_t client_token = CityHash64(client_account_for_hash.c_str(), client_account_for_hash.size());
-    client_id = client_token;    //INNA: change this API...
-    LOG_INFO("[VisorClientPortal] Client arguments: account={} host_id={} pid={} -> client_token={}", client_euid
-         , client_host_id, client_pid, client_token);
+    client_id = client_token; //INNA: change this API...
+    LOG_INFO("[VisorClientPortal] Client arguments: account={} host_id={} pid={} -> client_token={}",
+             client_euid,
+             client_host_id,
+             client_pid,
+             client_token);
     return clientManager.add_client_record(client_token, record);
 }
 
-int chronolog::VisorClientPortal::ClientDisconnect(chronolog::ClientId const &client_id)
+int chronolog::VisorClientPortal::ClientDisconnect(chronolog::ClientId const& client_id)
 {
     LOG_INFO("Client Disconnected. ClientID={}", client_id);
     return clientManager.remove_client_record(client_id);
@@ -130,51 +144,68 @@ int chronolog::VisorClientPortal::ClientDisconnect(chronolog::ClientId const &cl
 /**
  * Metadata APIs
  */
-int chronolog::VisorClientPortal::CreateChronicle(chl::ClientId const &client_id, std::string const &chronicle_name
-                                                  , const std::map <std::string, std::string> &attrs
-                                                  , int &flags)
+int chronolog::VisorClientPortal::CreateChronicle(chl::ClientId const& client_id,
+                                                  std::string const& chronicle_name,
+                                                  const std::map<std::string, std::string>& attrs,
+                                                  int& flags)
 {
     if(chronicle_name.empty())
-    { return chronolog::CL_ERR_INVALID_ARG; }
+    {
+        return chronolog::CL_ERR_INVALID_ARG;
+    }
 
     if(!chronicle_action_is_authorized(client_id, chronicle_name))
-    { return chronolog::CL_ERR_NOT_AUTHORIZED; }
+    {
+        return chronolog::CL_ERR_NOT_AUTHORIZED;
+    }
 
     int return_code = chronicleMetaDirectory.create_chronicle(chronicle_name, attrs);
     if(return_code == chronolog::CL_SUCCESS)
     {
-        LOG_INFO("[VisorClientPortal] Chronicle created: PID={}, ClientID={}, Name={}", getpid(), client_id
-             , chronicle_name.c_str());
+        LOG_INFO("[VisorClientPortal] Chronicle created: PID={}, ClientID={}, Name={}",
+                 getpid(),
+                 client_id,
+                 chronicle_name.c_str());
     }
     return (return_code);
 }
 
-int
-chronolog::VisorClientPortal::DestroyChronicle(chl::ClientId const &client_id, chl::ChronicleName const &chronicle_name)
+int chronolog::VisorClientPortal::DestroyChronicle(chl::ClientId const& client_id,
+                                                   chl::ChronicleName const& chronicle_name)
 {
     if(chronicle_name.empty())
-    { return chronolog::CL_ERR_INVALID_ARG; }
+    {
+        return chronolog::CL_ERR_INVALID_ARG;
+    }
 
     if(!chronicle_action_is_authorized(client_id, chronicle_name))
-    { return chronolog::CL_ERR_NOT_AUTHORIZED; }
+    {
+        return chronolog::CL_ERR_NOT_AUTHORIZED;
+    }
 
     int return_code = chronicleMetaDirectory.destroy_chronicle(chronicle_name);
     if(return_code == chronolog::CL_SUCCESS)
     {
-        LOG_DEBUG("[VisorClientPortal] Chronicle destroyed: ClientID={}, ChronicleName={}", client_id
-             , chronicle_name.c_str());
+        LOG_DEBUG("[VisorClientPortal] Chronicle destroyed: ClientID={}, ChronicleName={}",
+                  client_id,
+                  chronicle_name.c_str());
     }
     return (return_code);
 }
 
 
-int chronolog::VisorClientPortal::DestroyStory(chl::ClientId const &client_id, std::string const &chronicle_name
-                                               , std::string const &story_name)
+int chronolog::VisorClientPortal::DestroyStory(chl::ClientId const& client_id,
+                                               std::string const& chronicle_name,
+                                               std::string const& story_name)
 {
-    LOG_INFO("[VisorClientPortal] Story destroyed: PID={}, ChronicleName={}, StoryName={}", getpid(), chronicle_name.c_str()
-         , story_name.c_str());
+    LOG_INFO("[VisorClientPortal] Story destroyed: PID={}, ChronicleName={}, StoryName={}",
+             getpid(),
+             chronicle_name.c_str(),
+             story_name.c_str());
     if(!story_action_is_authorized(client_id, chronicle_name, story_name))
-    { return chronolog::CL_ERR_NOT_AUTHORIZED; }
+    {
+        return chronolog::CL_ERR_NOT_AUTHORIZED;
+    }
 
     if(!chronicle_name.empty() && !story_name.empty())
     {
@@ -188,28 +219,35 @@ int chronolog::VisorClientPortal::DestroyStory(chl::ClientId const &client_id, s
 
 ///////////////////
 
-chl::AcquireStoryResponseMsg
-chronolog::VisorClientPortal::AcquireStory(chl::ClientId const &client_id, std::string const &chronicle_name
-                                           , std::string const &story_name
-                                           , const std::map <std::string, std::string> &attrs, int &flags)
+chl::AcquireStoryResponseMsg chronolog::VisorClientPortal::AcquireStory(chl::ClientId const& client_id,
+                                                                        std::string const& chronicle_name,
+                                                                        std::string const& story_name,
+                                                                        const std::map<std::string, std::string>& attrs,
+                                                                        int& flags)
 {
     chronolog::StoryId story_id{0};
-    std::vector <chronolog::KeeperIdCard> recording_keepers;
+    std::vector<chronolog::KeeperIdCard> recording_keepers;
     chl::ServiceId player; //ServiceID of ChronoPlayer providing playback service for this story
 
     if(!theKeeperRegistry->is_running())
-    { return chronolog::AcquireStoryResponseMsg(chronolog::CL_ERR_NO_KEEPERS, story_id, recording_keepers); }
+    {
+        return chronolog::AcquireStoryResponseMsg(chronolog::CL_ERR_NO_KEEPERS, story_id, recording_keepers);
+    }
 
     if(chronicle_name.empty() || story_name.empty())
-    { return chronolog::AcquireStoryResponseMsg(chronolog::CL_ERR_INVALID_ARG, story_id, recording_keepers); }
+    {
+        return chronolog::AcquireStoryResponseMsg(chronolog::CL_ERR_INVALID_ARG, story_id, recording_keepers);
+    }
 
     if(!story_action_is_authorized(client_id, chronicle_name, story_name))
-    { return chronolog::AcquireStoryResponseMsg(chronolog::CL_ERR_NOT_AUTHORIZED, story_id, recording_keepers); }
+    {
+        return chronolog::AcquireStoryResponseMsg(chronolog::CL_ERR_NOT_AUTHORIZED, story_id, recording_keepers);
+    }
 
     int ret = chronolog::CL_ERR_UNKNOWN;
 
     ret = chronicleMetaDirectory.acquire_story(client_id, chronicle_name, story_name, attrs, flags, story_id);
-                                              
+
     if(ret != chronolog::CL_SUCCESS)
     {
         // return the error with the empty recording_keepers vector
@@ -217,16 +255,23 @@ chronolog::VisorClientPortal::AcquireStory(chl::ClientId const &client_id, std::
     }
     else
     {
-        LOG_INFO("[VisorClientPortal] Story acquired: PID={}, ClientID={}, ChronicleName={}, StoryName={}, Flags={}"
-             , getpid(), client_id, chronicle_name.c_str(), story_name.c_str(), flags);
+        LOG_INFO("[VisorClientPortal] Story acquired: PID={}, ClientID={}, ChronicleName={}, StoryName={}, Flags={}",
+                 getpid(),
+                 client_id,
+                 chronicle_name.c_str(),
+                 story_name.c_str(),
+                 flags);
     }
 
     // if this is the first client to acquire this story we need to choose an active recording group
     // for the new story and notify the recording Keepers & Graphers
     // so that they are ready to start recording this story
 
-    if(chronolog::CL_SUCCESS != theKeeperRegistry->notifyRecordingGroupOfStoryRecordingStart(
-                                        chronicle_name, story_name, story_id, recording_keepers, player))
+    if(chronolog::CL_SUCCESS != theKeeperRegistry->notifyRecordingGroupOfStoryRecordingStart(chronicle_name,
+                                                                                             story_name,
+                                                                                             story_id,
+                                                                                             recording_keepers,
+                                                                                             player))
     {
         // RPC notification to the keepers might have failed, release the newly acquired story
         chronicleMetaDirectory.release_story(client_id, chronicle_name, story_name, story_id);
@@ -239,19 +284,26 @@ chronolog::VisorClientPortal::AcquireStory(chl::ClientId const &client_id, std::
 }
 
 
-int chronolog::VisorClientPortal::ReleaseStory(chl::ClientId const &client_id, std::string const &chronicle_name
-                                               , std::string const &story_name)
+int chronolog::VisorClientPortal::ReleaseStory(chl::ClientId const& client_id,
+                                               std::string const& chronicle_name,
+                                               std::string const& story_name)
 {
-    LOG_INFO("[VisorClientPortal] Story released: PID={}, ChronicleName={}, StoryName={}", getpid(), chronicle_name.c_str()
-         , story_name.c_str());
+    LOG_INFO("[VisorClientPortal] Story released: PID={}, ChronicleName={}, StoryName={}",
+             getpid(),
+             chronicle_name.c_str(),
+             story_name.c_str());
 
     if(!story_action_is_authorized(client_id, chronicle_name, story_name))
-    { return chronolog::CL_ERR_NOT_AUTHORIZED; }
+    {
+        return chronolog::CL_ERR_NOT_AUTHORIZED;
+    }
 
     StoryId story_id(0);
     auto return_code = chronicleMetaDirectory.release_story(client_id, chronicle_name, story_name, story_id);
     if(chronolog::CL_SUCCESS != return_code)
-    { return return_code; }
+    {
+        return return_code;
+    }
 
     theKeeperRegistry->notifyRecordingGroupOfStoryRecordingStop(story_id);
 
@@ -260,13 +312,19 @@ int chronolog::VisorClientPortal::ReleaseStory(chl::ClientId const &client_id, s
 
 //////////////
 
-int chronolog::VisorClientPortal::GetChronicleAttr(chl::ClientId const &client_id, std::string const &chronicle_name
-                                                   , const std::string &key, std::string &value)
+int chronolog::VisorClientPortal::GetChronicleAttr(chl::ClientId const& client_id,
+                                                   std::string const& chronicle_name,
+                                                   const std::string& key,
+                                                   std::string& value)
 {
-    LOG_DEBUG("[VisorClientPortal] Get Chronicle Attributes: PID={}, Name={}, Key={}", getpid(), chronicle_name.c_str()
-         , key.c_str());
+    LOG_DEBUG("[VisorClientPortal] Get Chronicle Attributes: PID={}, Name={}, Key={}",
+              getpid(),
+              chronicle_name.c_str(),
+              key.c_str());
     if(chronicle_name.empty() || key.empty())
-    { return chronolog::CL_ERR_INVALID_ARG; }
+    {
+        return chronolog::CL_ERR_INVALID_ARG;
+    }
 
     // TODO: add authorization check : if ( chronicle_action_is_authorized())
     return chronicleMetaDirectory.get_chronicle_attr(chronicle_name, key, value);
@@ -274,19 +332,26 @@ int chronolog::VisorClientPortal::GetChronicleAttr(chl::ClientId const &client_i
 
 //////////////
 
-int chronolog::VisorClientPortal::EditChronicleAttr(chl::ClientId const &client_id, std::string const &chronicle
-                                                    , std::string const &key, std::string const &value)
+int chronolog::VisorClientPortal::EditChronicleAttr(chl::ClientId const& client_id,
+                                                    std::string const& chronicle,
+                                                    std::string const& key,
+                                                    std::string const& value)
 {
-    LOG_DEBUG("[VisorClientPortal] Edit Chronicle Attributes: PID={}, Name={}, Key={}, Value={}", getpid(), chronicle.c_str()
-         , key.c_str(), value.c_str());
+    LOG_DEBUG("[VisorClientPortal] Edit Chronicle Attributes: PID={}, Name={}, Key={}, Value={}",
+              getpid(),
+              chronicle.c_str(),
+              key.c_str(),
+              value.c_str());
     if(chronicle.empty() || key.empty() || value.empty())
-    { return chronolog::CL_ERR_INVALID_ARG; }
+    {
+        return chronolog::CL_ERR_INVALID_ARG;
+    }
 
     // TODO: add authorization check : if ( chronicle_action_is_authorized())
     return chronicleMetaDirectory.edit_chronicle_attr(chronicle, key, value);
 }
 
-int chronolog::VisorClientPortal::ShowChronicles(chl::ClientId const &client_id, std::vector <std::string> &chronicles)
+int chronolog::VisorClientPortal::ShowChronicles(chl::ClientId const& client_id, std::vector<std::string>& chronicles)
 {
     LOG_DEBUG("[VisorClientPortal] Show Chronicles: PID={}, ClientID={}", getpid(), client_id);
 
@@ -296,13 +361,16 @@ int chronolog::VisorClientPortal::ShowChronicles(chl::ClientId const &client_id,
     return chronolog::CL_SUCCESS;
 }
 
-int chronolog::VisorClientPortal::ShowStories(chl::ClientId const &client_id, std::string const &chronicle_name
-                                              , std::vector <std::string> &stories)
+int chronolog::VisorClientPortal::ShowStories(chl::ClientId const& client_id,
+                                              std::string const& chronicle_name,
+                                              std::vector<std::string>& stories)
 {
     LOG_DEBUG("[VisorClientPortal] Show Stories: PID={}, ChronicleName={}", getpid(), chronicle_name.c_str());
 
     if(!chronicle_action_is_authorized(client_id, chronicle_name))
-    { return chronolog::CL_ERR_UNKNOWN; }
+    {
+        return chronolog::CL_ERR_UNKNOWN;
+    }
 
     chronicleMetaDirectory.show_stories(chronicle_name, stories);
 
@@ -365,23 +433,20 @@ int chronolog::VisorClientPortal::LocalEditChronicleAttr( chronolog::ClientId co
 */
 /////////////////
 
-bool chronolog::VisorClientPortal::is_client_authenticated(uint32_t client_account)
-{
-    return true;
-}
+bool chronolog::VisorClientPortal::is_client_authenticated(uint32_t client_account) { return true; }
 
 ///////////////
 
-bool
-chronolog::VisorClientPortal::chronicle_action_is_authorized(chl::ClientId const &client_id, chl::ChronicleName const &)
+bool chronolog::VisorClientPortal::chronicle_action_is_authorized(chl::ClientId const& client_id,
+                                                                  chl::ChronicleName const&)
 {
     return true;
 }
 ////////////////
 
-bool chronolog::VisorClientPortal::story_action_is_authorized(chronolog::ClientId const &client_id
-                                                              , chl::ChronicleName const &chronicle
-                                                              , chl::StoryName const &story_name)
+bool chronolog::VisorClientPortal::story_action_is_authorized(chronolog::ClientId const& client_id,
+                                                              chl::ChronicleName const& chronicle,
+                                                              chl::StoryName const& story_name)
 {
     return true;
 }

--- a/ChronoVisor/src/VisorClientPortal.cpp
+++ b/ChronoVisor/src/VisorClientPortal.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <sstream>
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/ChronoVisor/src/chronovisor_instance.cpp
+++ b/ChronoVisor/src/chronovisor_instance.cpp
@@ -1,5 +1,8 @@
 #include <signal.h>
 #include <unistd.h>
+#include <iostream>
+#include <cstdlib>
+#include <string>
 
 #include <cmd_arg_parse.h>
 #include <KeeperRegistry.h>

--- a/ChronoVisor/src/chronovisor_instance.cpp
+++ b/ChronoVisor/src/chronovisor_instance.cpp
@@ -19,7 +19,7 @@ void sigterm_handler(int)
 
 
 ///////////////////////////////////////////////
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     signal(SIGTERM, sigterm_handler);
 
@@ -46,20 +46,20 @@ int main(int argc, char**argv)
 
     std::cout << "VISOR_CONFIGURATION " << VISOR_CONF.to_String() << std::endl;
 
-    int result = chronolog::chrono_monitor::initialize( VISOR_CONF.VISOR_LOG_CONF.LOGTYPE
-                                                       , VISOR_CONF.VISOR_LOG_CONF.LOGFILE
-                                                       , VISOR_CONF.VISOR_LOG_CONF.LOGLEVEL
-                                                       , VISOR_CONF.VISOR_LOG_CONF.LOGNAME
-                                                       , VISOR_CONF.VISOR_LOG_CONF.LOGFILESIZE
-                                                       , VISOR_CONF.VISOR_LOG_CONF.LOGFILENUM
-                                                       , VISOR_CONF.VISOR_LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize(VISOR_CONF.VISOR_LOG_CONF.LOGTYPE,
+                                                       VISOR_CONF.VISOR_LOG_CONF.LOGFILE,
+                                                       VISOR_CONF.VISOR_LOG_CONF.LOGLEVEL,
+                                                       VISOR_CONF.VISOR_LOG_CONF.LOGNAME,
+                                                       VISOR_CONF.VISOR_LOG_CONF.LOGFILESIZE,
+                                                       VISOR_CONF.VISOR_LOG_CONF.LOGFILENUM,
+                                                       VISOR_CONF.VISOR_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
     }
     LOG_INFO("[chronovisor_instance] Running Chronovisor Server.");
 
-   LOG_INFO("chronovisor_instance] VISOR CONFIGURATION {}", VISOR_CONF.to_String());
+    LOG_INFO("chronovisor_instance] VISOR CONFIGURATION {}", VISOR_CONF.to_String());
 
     chronolog::VisorClientPortal theChronoVisorPortal;
     chronolog::KeeperRegistry keeperRegistry;
@@ -68,13 +68,10 @@ int main(int argc, char**argv)
 
     theChronoVisorPortal.StartServices(VISOR_CONF, &keeperRegistry);
 
-    // If services do not start successfully there should a graceful exit(-1) here 
+    // If services do not start successfully there should a graceful exit(-1) here
     /////
     LOG_INFO("[chronovisor_instance] ChronoVisor Running...");
-    while(keep_running)
-    {
-        sleep(10);
-    }
+    while(keep_running) { sleep(10); }
 
     theChronoVisorPortal.ShutdownServices();
     keeperRegistry.ShutdownRegistryService();

--- a/Client/cpp/include/ClientConfiguration.h
+++ b/Client/cpp/include/ClientConfiguration.h
@@ -7,23 +7,27 @@
 #include <json-c/json.h>
 #include <spdlog/common.h>
 
-namespace chronolog {
+namespace chronolog
+{
 
-struct ClientPortalServiceConf {
+struct ClientPortalServiceConf
+{
     std::string PROTO_CONF = "ofi+sockets";
     std::string IP = "127.0.0.1";
     uint16_t PORT = 5555;
     uint16_t PROVIDER_ID = 55;
 };
 
-struct ClientQueryServiceConf {
+struct ClientQueryServiceConf
+{
     std::string PROTO_CONF = "ofi+sockets";
     std::string IP = "127.0.0.1";
     uint16_t PORT = 5557;
     uint16_t PROVIDER_ID = 57;
 };
 
-struct ClientLogConf {
+struct ClientLogConf
+{
     std::string LOGTYPE = "file";
     std::string LOGFILE = "chrono_client.log";
     spdlog::level::level_enum LOGLEVEL = spdlog::level::debug;
@@ -33,7 +37,8 @@ struct ClientLogConf {
     spdlog::level::level_enum FLUSHLEVEL = spdlog::level::warn;
 };
 
-class ClientConfiguration {
+class ClientConfiguration
+{
 public:
     ClientPortalServiceConf PORTAL_CONF;
     ClientQueryServiceConf QUERY_CONF;

--- a/Client/cpp/include/ClientConfiguration.h
+++ b/Client/cpp/include/ClientConfiguration.h
@@ -1,9 +1,11 @@
 #ifndef CHRONOLOG_CLIENT_CONFIGURATION_H
 #define CHRONOLOG_CLIENT_CONFIGURATION_H
 
+#include <ostream>
 #include <string>
-#include <spdlog/common.h>
+
 #include <json-c/json.h>
+#include <spdlog/common.h>
 
 namespace chronolog {
 

--- a/Client/cpp/include/chrono_monitor.h
+++ b/Client/cpp/include/chrono_monitor.h
@@ -70,7 +70,6 @@ namespace chronolog
 class chrono_monitor
 {
 public:
-
     /**
      * @brief Initializes the logger with the specified configuration.
      *
@@ -89,10 +88,13 @@ public:
      * @return             Returns 0 if the logger was initialized successfully,
      *                     and returns 1 if there was an error during initialization.
      */
-    static int initialize(const std::string &logType, const std::string &location, spdlog::level::level_enum logLevel
-                          , const std::string &loggerName, const std::size_t &logFileSize = 104857600
-                          , const std::size_t &logFileNum = 3
-                          , spdlog::level::level_enum flushLevel = spdlog::level::warn);
+    static int initialize(const std::string& logType,
+                          const std::string& location,
+                          spdlog::level::level_enum logLevel,
+                          const std::string& loggerName,
+                          const std::size_t& logFileSize = 104857600,
+                          const std::size_t& logFileNum = 3,
+                          spdlog::level::level_enum flushLevel = spdlog::level::warn);
 
 
     /**
@@ -103,12 +105,12 @@ public:
      *
      * @return Reference to spdlog::logger instance.
      */
-    static spdlog::logger &getInstance();
+    static spdlog::logger& getInstance();
 
     // Delete copy constructor and assignment operator
-    chrono_monitor(const chrono_monitor &) = delete;
+    chrono_monitor(const chrono_monitor&) = delete;
 
-    chrono_monitor &operator=(const chrono_monitor &) = delete;
+    chrono_monitor& operator=(const chrono_monitor&) = delete;
 
     ~chrono_monitor() = default;
 
@@ -121,7 +123,7 @@ private:
      *
      * This static member holds the instance of the spdlog logger used by the Logger class.
      */
-    static std::shared_ptr <spdlog::logger> logger;
+    static std::shared_ptr<spdlog::logger> logger;
 
     /**
      * @brief Mutex for thread safety.

--- a/Client/cpp/include/chrono_monitor.h
+++ b/Client/cpp/include/chrono_monitor.h
@@ -1,8 +1,11 @@
 #ifndef CHRONOLOG_CHRONO_MONITOR_H
 #define CHRONOLOG_CHRONO_MONITOR_H
 
-#include <spdlog/spdlog.h>
+#include <memory>
 #include <mutex>
+#include <string>
+
+#include <spdlog/spdlog.h>
 
 namespace chronolog
 {

--- a/Client/cpp/include/cmd_arg_parse.h
+++ b/Client/cpp/include/cmd_arg_parse.h
@@ -10,14 +10,15 @@
 #include <iostream>
 #include <string>
 
-std::string parse_conf_path_arg(int argc, char**argv)
+std::string parse_conf_path_arg(int argc, char** argv)
 {
     int opt;
-    char*config_file = nullptr;
+    char* config_file = nullptr;
 
     // Define the long options and their corresponding short options
-    struct option long_options[] = {{  "config", required_argument, 0, 'c'}
-                                    , {0       , 0                , 0, 0} // Terminate the options array
+    struct option long_options[] = {
+            {"config", required_argument, 0, 'c'},
+            {0, 0, 0, 0} // Terminate the options array
     };
 
     // Parse the command-line options
@@ -30,9 +31,9 @@ std::string parse_conf_path_arg(int argc, char**argv)
                 break;
             case '?':
                 // Invalid option or missing argument
-                std::cout
-                        << "[cmd_arg_parse] Invalid usage: Please provide a configuration file path using -c or --config option."
-                        << std::endl;
+                std::cout << "[cmd_arg_parse] Invalid usage: Please provide a configuration file path using -c or "
+                             "--config option."
+                          << std::endl;
                 exit(EXIT_FAILURE);
             default:
                 // Unknown option

--- a/Client/cpp/include/cmd_arg_parse.h
+++ b/Client/cpp/include/cmd_arg_parse.h
@@ -5,9 +5,10 @@
 #ifndef CHRONOLOG_CMD_ARG_PARSE_H
 #define CHRONOLOG_CMD_ARG_PARSE_H
 
+#include <cstdlib>
 #include <getopt.h>
-#include <string>
 #include <iostream>
+#include <string>
 
 std::string parse_conf_path_arg(int argc, char**argv)
 {

--- a/Client/cpp/src/ChronologClientImpl.cpp
+++ b/Client/cpp/src/ChronologClientImpl.cpp
@@ -17,69 +17,74 @@
 namespace chl = chronolog;
 
 std::mutex chronolog::ChronologClientImpl::chronologClientMutex;
-chronolog::ChronologClientImpl*chronolog::ChronologClientImpl::chronologClientImplInstance{nullptr};
+chronolog::ChronologClientImpl* chronolog::ChronologClientImpl::chronologClientImplInstance{nullptr};
 
-chronolog::ChronologClientImpl*chronolog::ChronologClientImpl::GetClientImplInstance(
-        chronolog::ClientPortalServiceConf const &visorClientPortalServiceConf,
+chronolog::ChronologClientImpl* chronolog::ChronologClientImpl::GetClientImplInstance(
+        chronolog::ClientPortalServiceConf const& visorClientPortalServiceConf,
         chronolog::ClientMode const& clientMode,
         chronolog::ClientQueryServiceConf const& clientQueryServiceConf)
 {
-    chrono_monitor::initialize("file", "/tmp/chrono_client.log", spdlog::level::info, "chrono_client", 1024000, 3
-                               , spdlog::level::warn);
+    chrono_monitor::initialize("file",
+                               "/tmp/chrono_client.log",
+                               spdlog::level::info,
+                               "chrono_client",
+                               1024000,
+                               3,
+                               spdlog::level::warn);
 
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     if(chronologClientImplInstance == nullptr)
     {
-        chronologClientImplInstance = new ChronologClientImpl(visorClientPortalServiceConf, clientMode,  clientQueryServiceConf);
+        chronologClientImplInstance =
+                new ChronologClientImpl(visorClientPortalServiceConf, clientMode, clientQueryServiceConf);
     }
 
     return chronologClientImplInstance;
 }
 
-chronolog::ChronologClientImpl::ChronologClientImpl(
-    chronolog::ClientPortalServiceConf const& clientPortalServiceConf,
-    chronolog::ClientMode const& clientMode,
-    chronolog::ClientQueryServiceConf const& clientQueryServiceConf)
-        : clientMode(clientMode)
-        , clientState(UNKNOWN)
-        , clientLogin("")
-        , hostId(0), pid(0), clientId(0)
-        , tlEngine(nullptr)
-        , rpcVisorClient(nullptr)
-        , storyteller(nullptr)
-        , storyReaderService(nullptr)
+chronolog::ChronologClientImpl::ChronologClientImpl(chronolog::ClientPortalServiceConf const& clientPortalServiceConf,
+                                                    chronolog::ClientMode const& clientMode,
+                                                    chronolog::ClientQueryServiceConf const& clientQueryServiceConf)
+    : clientMode(clientMode)
+    , clientState(UNKNOWN)
+    , clientLogin("")
+    , hostId(0)
+    , pid(0)
+    , clientId(0)
+    , tlEngine(nullptr)
+    , rpcVisorClient(nullptr)
+    , storyteller(nullptr)
+    , storyReaderService(nullptr)
 {
 
     defineClientIdentity();
-    
+
     if(WRITER_MODE == clientMode)
     {
         tlEngine = new thallium::engine(clientPortalServiceConf.PROTO_CONF, THALLIUM_CLIENT_MODE, true, 1);
     }
     else
     {
-        std::string QUERY_SERVICE_NA_STRING =
-            clientQueryServiceConf.PROTO_CONF
- + "://" + clientQueryServiceConf.IP + ":" +
-            std::to_string(clientQueryServiceConf.PORT);
+        std::string QUERY_SERVICE_NA_STRING = clientQueryServiceConf.PROTO_CONF + "://" + clientQueryServiceConf.IP +
+                                              ":" + std::to_string(clientQueryServiceConf.PORT);
 
         margo_instance_id margo_id = margo_init(QUERY_SERVICE_NA_STRING.c_str(), MARGO_SERVER_MODE, 1, 1);
         tlEngine = new tl::engine(margo_id);
 
-        storyReaderService= chl::ClientQueryService::CreateClientQueryService(*tlEngine, chronolog::ServiceId(clientQueryServiceConf.PROTO_CONF, 
-                                        clientQueryServiceConf.IP, clientQueryServiceConf.PORT, clientQueryServiceConf.PROVIDER_ID
-));
-
+        storyReaderService = chl::ClientQueryService::CreateClientQueryService(
+                *tlEngine,
+                chronolog::ServiceId(clientQueryServiceConf.PROTO_CONF,
+                                     clientQueryServiceConf.IP,
+                                     clientQueryServiceConf.PORT,
+                                     clientQueryServiceConf.PROVIDER_ID));
     }
 
-    std::string VISOR_NA_STRING =
-            clientPortalServiceConf.PROTO_CONF + "://" + clientPortalServiceConf.IP + ":" +
-            std::to_string(clientPortalServiceConf.PORT);
+    std::string VISOR_NA_STRING = clientPortalServiceConf.PROTO_CONF + "://" + clientPortalServiceConf.IP + ":" +
+                                  std::to_string(clientPortalServiceConf.PORT);
 
-    rpcVisorClient = chl::RpcVisorClient::CreateRpcVisorClient(*tlEngine, VISOR_NA_STRING
-                                                               , clientPortalServiceConf.PROVIDER_ID
-);
+    rpcVisorClient =
+            chl::RpcVisorClient::CreateRpcVisorClient(*tlEngine, VISOR_NA_STRING, clientPortalServiceConf.PROVIDER_ID);
 }
 
 ////////
@@ -97,32 +102,40 @@ void chronolog::ChronologClientImpl::defineClientIdentity()
     hostId = gethostid();
     //32bit process id
     pid = getpid();
-    LOG_INFO("[ChronologClientImpl] Client Identity - Login: {}, EUID: {}, HostID: {}, PID: {}", clientLogin, euid
-             , hostId, pid);
+    LOG_INFO("[ChronologClientImpl] Client Identity - Login: {}, EUID: {}, HostID: {}, PID: {}",
+             clientLogin,
+             euid,
+             hostId,
+             pid);
 }
 
 chronolog::ChronologClientImpl::~ChronologClientImpl()
 {
     if(storyteller != nullptr)
-    { delete storyteller; }
+    {
+        delete storyteller;
+    }
 
     if(rpcVisorClient != nullptr)
-    { delete rpcVisorClient; }
+    {
+        delete rpcVisorClient;
+    }
 
     if(storyReaderService)
-    { delete storyReaderService; }
+    {
+        delete storyReaderService;
+    }
 
     if(tlEngine != nullptr)
     {
         tlEngine->finalize();
         delete tlEngine;
     }
-
 }
 
 int chronolog::ChronologClientImpl::Connect()
 {
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
     // if already connected return success
     // if disconencting return failure....
     if((clientState != UNKNOWN) && (clientState != SHUTTING_DOWN))
@@ -148,18 +161,19 @@ int chronolog::ChronologClientImpl::Connect()
         {
             storyteller = new StorytellerClient(clockProxy, *tlEngine, clientId);
         }
-        //TODO: if we ever change the connection hashing algorithm we'd need to handle reconnection case with the new client_id 
+        //TODO: if we ever change the connection hashing algorithm we'd need to handle reconnection case with the new client_id
     }
     else
     {
-        LOG_ERROR("[ChronoLogClientImpl] Connection attempt to Visor failed with error code: {}", chronolog::to_string_client(return_code));
+        LOG_ERROR("[ChronoLogClientImpl] Connection attempt to Visor failed with error code: {}",
+                  chronolog::to_string_client(return_code));
     }
     return return_code;
 }
 
 int chronolog::ChronologClientImpl::Disconnect()
 {
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     if((clientState == UNKNOWN) || (clientState == SHUTTING_DOWN))
     {
@@ -175,14 +189,15 @@ int chronolog::ChronologClientImpl::Disconnect()
     }
     else
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to disconnect from Visor. Error code: {}", chronolog::to_string_client(return_code));
+        LOG_ERROR("[ChronoLogClientImpl] Failed to disconnect from Visor. Error code: {}",
+                  chronolog::to_string_client(return_code));
     }
     return return_code;
-
 }
 
-int chronolog::ChronologClientImpl::CreateChronicle(std::string const &chronicle_name
-                                                    , const std::map <std::string, std::string> &attrs, int &flags)
+int chronolog::ChronologClientImpl::CreateChronicle(std::string const& chronicle_name,
+                                                    const std::map<std::string, std::string>& attrs,
+                                                    int& flags)
 {
     if(chronicle_name.empty())
     {
@@ -190,12 +205,12 @@ int chronolog::ChronologClientImpl::CreateChronicle(std::string const &chronicle
         return chronolog::CL_ERR_INVALID_ARG;
     }
 
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     if((clientState == UNKNOWN) || (clientState == SHUTTING_DOWN))
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to create chronicle '{}': Client is not connected or is shutting down."
-                  , chronicle_name);
+        LOG_ERROR("[ChronoLogClientImpl] Failed to create chronicle '{}': Client is not connected or is shutting down.",
+                  chronicle_name);
         return chronolog::CL_ERR_NO_CONNECTION;
     }
 
@@ -209,20 +224,26 @@ int chronolog::ChronologClientImpl::CreateChronicle(std::string const &chronicle
     }
     else
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to create chronicle '{}'. Error code: {}", chronicle_name, chronolog::to_string_client(result));
+        LOG_ERROR("[ChronoLogClientImpl] Failed to create chronicle '{}'. Error code: {}",
+                  chronicle_name,
+                  chronolog::to_string_client(result));
     }
     return result;
 }
 
-int chronolog::ChronologClientImpl::DestroyChronicle(std::string const &chronicle_name)
+int chronolog::ChronologClientImpl::DestroyChronicle(std::string const& chronicle_name)
 {
     if(chronicle_name.empty())
-    { return chronolog::CL_ERR_INVALID_ARG; }
+    {
+        return chronolog::CL_ERR_INVALID_ARG;
+    }
 
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     if((clientState == UNKNOWN) || (clientState == SHUTTING_DOWN))
-    { return chronolog::CL_ERR_NO_CONNECTION; }
+    {
+        return chronolog::CL_ERR_NO_CONNECTION;
+    }
 
     int result = rpcVisorClient->DestroyChronicle(clientId, chronicle_name);
 
@@ -233,13 +254,15 @@ int chronolog::ChronologClientImpl::DestroyChronicle(std::string const &chronicl
     }
     else
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to destroy chronicle '{}'. Error code: {}", chronicle_name, chronolog::to_string_client(result));
+        LOG_ERROR("[ChronoLogClientImpl] Failed to destroy chronicle '{}'. Error code: {}",
+                  chronicle_name,
+                  chronolog::to_string_client(result));
     }
 
     return result;
 }
 
-int chronolog::ChronologClientImpl::DestroyStory(std::string const &chronicle_name, std::string const &story_name)
+int chronolog::ChronologClientImpl::DestroyStory(std::string const& chronicle_name, std::string const& story_name)
 {
     if(chronicle_name.empty() || story_name.empty())
     {
@@ -247,12 +270,13 @@ int chronolog::ChronologClientImpl::DestroyStory(std::string const &chronicle_na
         return chronolog::CL_ERR_INVALID_ARG;
     }
 
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     if((clientState == UNKNOWN) || (clientState == SHUTTING_DOWN))
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to destroy chronicle '{}': Client is not connected or is shutting down."
-                  , chronicle_name);
+        LOG_ERROR(
+                "[ChronoLogClientImpl] Failed to destroy chronicle '{}': Client is not connected or is shutting down.",
+                chronicle_name);
         return chronolog::CL_ERR_NO_CONNECTION;
     }
 
@@ -262,50 +286,58 @@ int chronolog::ChronologClientImpl::DestroyStory(std::string const &chronicle_na
     // Log the outcome of the destroy operation.
     if(result == chronolog::CL_SUCCESS)
     {
-        LOG_INFO("[ChronoLogClientImpl] Successfully destroyed Story '{}' from Chronicle '{}'.", story_name
-                 , chronicle_name);
+        LOG_INFO("[ChronoLogClientImpl] Successfully destroyed Story '{}' from Chronicle '{}'.",
+                 story_name,
+                 chronicle_name);
     }
     else
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to destroy Story '{}' from Chronicle '{}'. Error code: {}", story_name
-                  , chronicle_name, chronolog::to_string_client(result));
+        LOG_ERROR("[ChronoLogClientImpl] Failed to destroy Story '{}' from Chronicle '{}'. Error code: {}",
+                  story_name,
+                  chronicle_name,
+                  chronolog::to_string_client(result));
     }
     return result;
 }
 
-std::pair <int, chronolog::StoryHandle*>
-chronolog::ChronologClientImpl::AcquireStory(std::string const &chronicle_name, std::string const &story_name
-                                             , const std::map <std::string, std::string> &attrs, int &flags)
+std::pair<int, chronolog::StoryHandle*>
+chronolog::ChronologClientImpl::AcquireStory(std::string const& chronicle_name,
+                                             std::string const& story_name,
+                                             const std::map<std::string, std::string>& attrs,
+                                             int& flags)
 {
     // Log the attempt to acquire a story with specific details.
-    LOG_DEBUG("[ChronoLogClientImpl] Attempting to acquire story. ChronicleName={}, StoryName={}", chronicle_name
-              , story_name);
+    LOG_DEBUG("[ChronoLogClientImpl] Attempting to acquire story. ChronicleName={}, StoryName={}",
+              chronicle_name,
+              story_name);
 
     if(chronicle_name.empty() || story_name.empty())
     {
         LOG_ERROR("[ChronoLogClientImpl] Failed to acquire story: Missing essential parameters.");
-        return std::pair <int, chronolog::StoryHandle*>(chronolog::CL_ERR_INVALID_ARG, nullptr);
+        return std::pair<int, chronolog::StoryHandle*>(chronolog::CL_ERR_INVALID_ARG, nullptr);
     }
 
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     if((clientState == UNKNOWN) || (clientState == SHUTTING_DOWN))
     {
-        LOG_ERROR(
-                "[ChronoLogClientImpl] Failed to acquire story '{}' from chronicle '{}': Client is not connected or is shutting down."
-                , story_name, chronicle_name);
-        return std::pair <int, chronolog::StoryHandle*>(chronolog::CL_ERR_NO_CONNECTION, nullptr);
+        LOG_ERROR("[ChronoLogClientImpl] Failed to acquire story '{}' from chronicle '{}': Client is not connected or "
+                  "is shutting down.",
+                  story_name,
+                  chronicle_name);
+        return std::pair<int, chronolog::StoryHandle*>(chronolog::CL_ERR_NO_CONNECTION, nullptr);
     }
 
     // this function can be called from any client thread, so before sending an rpc request to the Visor
     // we check if the story acquisition request has been already granted to the process on some other thread
-    // 
-    chronolog::StoryHandle*storyHandle = storyteller->findStoryWritingHandle(chronicle_name, story_name);
+    //
+    chronolog::StoryHandle* storyHandle = storyteller->findStoryWritingHandle(chronicle_name, story_name);
     if(storyHandle != nullptr)
     {
-        LOG_INFO("[ChronoLogClientImpl] Story '{}' from chronicle '{}' is already acquired.", story_name
-                 , chronicle_name);
-        return std::pair <int, chronolog::StoryHandle*>(chronolog::CL_SUCCESS, storyHandle);
+        LOG_INFO("[ChronoLogClientImpl] Story '{}' from chronicle '{}' is already acquired.",
+                 story_name,
+                 chronicle_name);
+        return std::pair<int, chronolog::StoryHandle*>(chronolog::CL_SUCCESS, storyHandle);
     }
 
     // issue rpc request to the Visor
@@ -316,42 +348,47 @@ chronolog::ChronologClientImpl::AcquireStory(std::string const &chronicle_name, 
     LOG_DEBUG("[ChronoLogClientImpl] Response from AcquireStory RPC call: {}", ss.str());
     if(acquireStoryResponse.getErrorCode() != chronolog::CL_SUCCESS)
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to acquire story '{}' from chronicle '{}'. Error code: {}", story_name
-                  , chronicle_name, chronolog::to_string_client(acquireStoryResponse.getErrorCode()));
-        return std::pair <int, chronolog::StoryHandle*>(acquireStoryResponse.getErrorCode(), nullptr);
+        LOG_ERROR("[ChronoLogClientImpl] Failed to acquire story '{}' from chronicle '{}'. Error code: {}",
+                  story_name,
+                  chronicle_name,
+                  chronolog::to_string_client(acquireStoryResponse.getErrorCode()));
+        return std::pair<int, chronolog::StoryHandle*>(acquireStoryResponse.getErrorCode(), nullptr);
     }
 
-    //successfull AcquireStoryResponse carries Visor generated StoryId & vector<KeeperIdCard> 
+    //successfull AcquireStoryResponse carries Visor generated StoryId & vector<KeeperIdCard>
     // for the Keepers assigned to record the acquired story
 
-    storyHandle = storyteller->initializeStoryWritingHandle(chronicle_name, story_name
-                                                            , acquireStoryResponse.getStoryId()
-                                                            , acquireStoryResponse.getKeepers()
-                    , acquireStoryResponse.getPlayer());
+    storyHandle = storyteller->initializeStoryWritingHandle(chronicle_name,
+                                                            story_name,
+                                                            acquireStoryResponse.getStoryId(),
+                                                            acquireStoryResponse.getKeepers(),
+                                                            acquireStoryResponse.getPlayer());
 
     if((nullptr != storyReaderService) && acquireStoryResponse.getPlayer().is_valid())
     {
         //prepare ClientQueryService for reading this story
         storyReaderService->addStoryReader(chronicle_name, story_name, acquireStoryResponse.getPlayer());
     }
-    
+
     if(storyHandle == nullptr)
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to initialize story handle for '{}' in chronicle '{}'.", story_name
-                  , chronicle_name);
-        return std::pair <int, chronolog::StoryHandle*>(chronolog::CL_ERR_UNKNOWN, nullptr);
+        LOG_ERROR("[ChronoLogClientImpl] Failed to initialize story handle for '{}' in chronicle '{}'.",
+                  story_name,
+                  chronicle_name);
+        return std::pair<int, chronolog::StoryHandle*>(chronolog::CL_ERR_UNKNOWN, nullptr);
     }
     else
     {
-        LOG_INFO("[ChronoLogClientImpl] Successfully acquired story '{}' in chronicle '{}'.", story_name
-                 , chronicle_name);
-        return std::pair <int, chronolog::StoryHandle*>(chronolog::CL_SUCCESS, storyHandle);
+        LOG_INFO("[ChronoLogClientImpl] Successfully acquired story '{}' in chronicle '{}'.",
+                 story_name,
+                 chronicle_name);
+        return std::pair<int, chronolog::StoryHandle*>(chronolog::CL_SUCCESS, storyHandle);
     }
 }
 
 ///////
 
-int chronolog::ChronologClientImpl::ReleaseStory(std::string const &chronicle_name, std::string const &story_name)
+int chronolog::ChronologClientImpl::ReleaseStory(std::string const& chronicle_name, std::string const& story_name)
 {
     // there's no reason to waste an rpc call on empty strings...
     if(chronicle_name.empty() || story_name.empty())
@@ -360,35 +397,38 @@ int chronolog::ChronologClientImpl::ReleaseStory(std::string const &chronicle_na
                 "[ChronoLogClientImpl] Failed to release story: Both chronicle_name and story_name must be provided.");
         return chronolog::CL_ERR_INVALID_ARG;
     }
-    
+
     if(storyReaderService)
     {
         //disengage storyReader
         storyReaderService->removeStoryReader(chronicle_name, story_name);
     }
 
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     // if we storyteller has active WritingHandle for this story
     // it should be cleared regardless of the Visor connection state
 
     if(nullptr == storyteller || nullptr == storyteller->findStoryWritingHandle(chronicle_name, story_name))
     {
-        LOG_WARNING("[ChronoLogClientImpl] No active writing handle found for story '{}' in chronicle '{}'.", story_name
-                    , chronicle_name);
+        LOG_WARNING("[ChronoLogClientImpl] No active writing handle found for story '{}' in chronicle '{}'.",
+                    story_name,
+                    chronicle_name);
         return chronolog::CL_ERR_NOT_ACQUIRED;
     }
 
     storyteller->removeAcquiredStoryHandle(chronicle_name, story_name);
-    LOG_INFO("[ChronoLogClientImpl] Successfully released the story '{}' from chronicle '{}'.", story_name
-             , chronicle_name);
+    LOG_INFO("[ChronoLogClientImpl] Successfully released the story '{}' from chronicle '{}'.",
+             story_name,
+             chronicle_name);
     // if the client is still connected to the Visor
-    // send ReleaseStory request 
+    // send ReleaseStory request
     if((clientState == UNKNOWN) || (clientState == SHUTTING_DOWN))
     {
-        LOG_ERROR(
-                "[ChronoLogClientImpl] Cannot release story '{}' from chronicle '{}' due to client being in an unknown or shutting down state."
-                , story_name, chronicle_name);
+        LOG_ERROR("[ChronoLogClientImpl] Cannot release story '{}' from chronicle '{}' due to client being in an "
+                  "unknown or shutting down state.",
+                  story_name,
+                  chronicle_name);
         return chronolog::CL_ERR_NO_CONNECTION;
     }
 
@@ -396,23 +436,27 @@ int chronolog::ChronologClientImpl::ReleaseStory(std::string const &chronicle_na
     auto releaseStatus = rpcVisorClient->ReleaseStory(clientId, chronicle_name, story_name);
     if(releaseStatus != chronolog::CL_SUCCESS)
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to release story '{}' from chronicle '{}'. Error code: {}", story_name
-                  , chronicle_name, chronolog::to_string_client(releaseStatus));
+        LOG_ERROR("[ChronoLogClientImpl] Failed to release story '{}' from chronicle '{}'. Error code: {}",
+                  story_name,
+                  chronicle_name,
+                  chronolog::to_string_client(releaseStatus));
     }
     else
     {
-        LOG_INFO("[ChronoLogClientImpl] Successfully released story '{}' from chronicle '{}'.", story_name
-                 , chronicle_name);
+        LOG_INFO("[ChronoLogClientImpl] Successfully released story '{}' from chronicle '{}'.",
+                 story_name,
+                 chronicle_name);
     }
 
     return releaseStatus;
 }
 
-//TODO: client account must be passed into the rpc call 
-int chronolog::ChronologClientImpl::GetChronicleAttr(std::string const &chronicle_name, const std::string &key
-                                                     , std::string &value)
+//TODO: client account must be passed into the rpc call
+int chronolog::ChronologClientImpl::GetChronicleAttr(std::string const& chronicle_name,
+                                                     const std::string& key,
+                                                     std::string& value)
 {
-    value.clear();  // in case the error is returned , make sure value is an empty string
+    value.clear(); // in case the error is returned , make sure value is an empty string
 
     if(chronicle_name.empty() || key.empty())
     {
@@ -420,13 +464,13 @@ int chronolog::ChronologClientImpl::GetChronicleAttr(std::string const &chronicl
         return chronolog::CL_ERR_INVALID_ARG;
     }
 
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     if((clientState == UNKNOWN) || (clientState == SHUTTING_DOWN))
     {
-        LOG_ERROR(
-                "[ChronoLogClientImpl] Cannot fetch attribute for chronicle '{}': Client is in an unknown or shutting down state."
-                , chronicle_name);
+        LOG_ERROR("[ChronoLogClientImpl] Cannot fetch attribute for chronicle '{}': Client is in an unknown or "
+                  "shutting down state.",
+                  chronicle_name);
         return chronolog::CL_ERR_NO_CONNECTION;
     }
 
@@ -434,20 +478,25 @@ int chronolog::ChronologClientImpl::GetChronicleAttr(std::string const &chronicl
     int fetchStatus = rpcVisorClient->GetChronicleAttr(clientId, chronicle_name, key, value);
     if(fetchStatus != chronolog::CL_SUCCESS)
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to fetch attribute '{}' for chronicle '{}'. Error code: {}", key
-                  , chronicle_name, chronolog::to_string_client(fetchStatus));
+        LOG_ERROR("[ChronoLogClientImpl] Failed to fetch attribute '{}' for chronicle '{}'. Error code: {}",
+                  key,
+                  chronicle_name,
+                  chronolog::to_string_client(fetchStatus));
     }
     else
     {
-        LOG_INFO("[ChronoLogClientImpl] Successfully fetched attribute '{}' for chronicle '{}'. Value: '{}'", key
-                 , chronicle_name, value);
+        LOG_INFO("[ChronoLogClientImpl] Successfully fetched attribute '{}' for chronicle '{}'. Value: '{}'",
+                 key,
+                 chronicle_name,
+                 value);
     }
     return fetchStatus;
 }
 
-//TODO: client account must be passed into the rpc call 
-int chronolog::ChronologClientImpl::EditChronicleAttr(std::string const &chronicle_name, const std::string &key
-                                                      , std::string const &value)
+//TODO: client account must be passed into the rpc call
+int chronolog::ChronologClientImpl::EditChronicleAttr(std::string const& chronicle_name,
+                                                      const std::string& key,
+                                                      std::string const& value)
 {
     if(chronicle_name.empty() || key.empty() || value.empty())
     {
@@ -456,13 +505,13 @@ int chronolog::ChronologClientImpl::EditChronicleAttr(std::string const &chronic
         return chronolog::CL_ERR_INVALID_ARG;
     }
 
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     if((clientState == UNKNOWN) || (clientState == SHUTTING_DOWN))
     {
-        LOG_ERROR(
-                "[ChronoLogClientImpl] Cannot edit attribute for chronicle '{}': Client is in an unknown or shutting down state."
-                , chronicle_name);
+        LOG_ERROR("[ChronoLogClientImpl] Cannot edit attribute for chronicle '{}': Client is in an unknown or shutting "
+                  "down state.",
+                  chronicle_name);
         return chronolog::CL_ERR_NO_CONNECTION;
     }
 
@@ -470,20 +519,24 @@ int chronolog::ChronologClientImpl::EditChronicleAttr(std::string const &chronic
     int editStatus = rpcVisorClient->EditChronicleAttr(clientId, chronicle_name, key, value);
     if(editStatus != chronolog::CL_SUCCESS)
     {
-        LOG_ERROR("[ChronoLogClientImpl] Failed to edit attribute '{}' for chronicle '{}'. Error code: {}", key
-                  , chronicle_name, chronolog::to_string_client(editStatus));
+        LOG_ERROR("[ChronoLogClientImpl] Failed to edit attribute '{}' for chronicle '{}'. Error code: {}",
+                  key,
+                  chronicle_name,
+                  chronolog::to_string_client(editStatus));
     }
     else
     {
-        LOG_INFO("[ChronoLogClientImpl] Successfully edited attribute '{}' for chronicle '{}'. New value: '{}'", key
-                 , chronicle_name, value);
+        LOG_INFO("[ChronoLogClientImpl] Successfully edited attribute '{}' for chronicle '{}'. New value: '{}'",
+                 key,
+                 chronicle_name,
+                 value);
     }
     return editStatus;
 }
 
-std::vector <std::string> &chronolog::ChronologClientImpl::ShowChronicles(std::vector <std::string> &chronicles)
+std::vector<std::string>& chronolog::ChronologClientImpl::ShowChronicles(std::vector<std::string>& chronicles)
 {
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     if((clientState == UNKNOWN) || (clientState == SHUTTING_DOWN))
     {
@@ -506,8 +559,8 @@ std::vector <std::string> &chronolog::ChronologClientImpl::ShowChronicles(std::v
     return chronicles;
 }
 
-std::vector <std::string> &
-chronolog::ChronologClientImpl::ShowStories(std::string const &chronicle_name, std::vector <std::string> &stories)
+std::vector<std::string>& chronolog::ChronologClientImpl::ShowStories(std::string const& chronicle_name,
+                                                                      std::vector<std::string>& stories)
 {
     if(chronicle_name.empty())
     {
@@ -515,13 +568,13 @@ chronolog::ChronologClientImpl::ShowStories(std::string const &chronicle_name, s
         return stories;
     }
 
-    std::lock_guard <std::mutex> lock_client(chronologClientMutex);
+    std::lock_guard<std::mutex> lock_client(chronologClientMutex);
 
     if((clientState == UNKNOWN) || (clientState == SHUTTING_DOWN))
     {
-        LOG_ERROR(
-                "[ChronoLogClientImpl] Failed to fetch stories for chronicle '{}': Client is in an unknown or shutting down state."
-                , chronicle_name);
+        LOG_ERROR("[ChronoLogClientImpl] Failed to fetch stories for chronicle '{}': Client is in an unknown or "
+                  "shutting down state.",
+                  chronicle_name);
         return stories;
     }
 
@@ -531,8 +584,9 @@ chronolog::ChronologClientImpl::ShowStories(std::string const &chronicle_name, s
     // Log the number of stories fetched and return the list.
     if(!stories.empty())
     {
-        LOG_INFO("[ChronoLogClientImpl] Successfully fetched {} stories for chronicle '{}'.", stories.size()
-                 , chronicle_name);
+        LOG_INFO("[ChronoLogClientImpl] Successfully fetched {} stories for chronicle '{}'.",
+                 stories.size(),
+                 chronicle_name);
     }
     else
     {
@@ -542,9 +596,11 @@ chronolog::ChronologClientImpl::ShowStories(std::string const &chronicle_name, s
 }
 
 ////////////////////////////
-int 
-chronolog::ChronologClientImpl::replay_story( chronolog::ChronicleName const& chronicle, chronolog::StoryName const& story, uint64_t start, uint64_t end
-                , std::vector<chronolog::Event> & event_series)
+int chronolog::ChronologClientImpl::replay_story(chronolog::ChronicleName const& chronicle,
+                                                 chronolog::StoryName const& story,
+                                                 uint64_t start,
+                                                 uint64_t end,
+                                                 std::vector<chronolog::Event>& event_series)
 {
     // this functionality is only available if the client is running in READER_MODE
 

--- a/Client/cpp/src/ChronologClientImpl.cpp
+++ b/Client/cpp/src/ChronologClientImpl.cpp
@@ -1,7 +1,15 @@
-#include <unistd.h>
+#include <cstdlib>
+#include <iostream>
+#include <limits.h>
+#include <mutex>
+#include <sstream>
 #include <string>
+#include <unistd.h>
 
 #include <city.h>
+#include <margo.h>
+#include <spdlog/spdlog.h>
+#include <thallium.hpp>
 
 #include "ChronologClientImpl.h"
 #include "StorytellerClient.h"

--- a/Client/cpp/src/ChronologClientImpl.h
+++ b/Client/cpp/src/ChronologClientImpl.h
@@ -30,56 +30,60 @@ enum ClientMode
 
 enum ChronologClientState
 {
-    UNKNOWN = 0, CONNECTED = 1, READING = 2, WRITING = 3, SHUTTING_DOWN = 4
+    UNKNOWN = 0,
+    CONNECTED = 1,
+    READING = 2,
+    WRITING = 3,
+    SHUTTING_DOWN = 4
 };
 
 class ChronologClientImpl
 {
 public:
-
     // static mutex ensures that there'd be the single instance
     // of ChronologClientImpl ever created regardless of the
     // thread(s) GetClientImplInstance() is called from
     static std::mutex chronologClientMutex;
-    static ChronologClientImpl*chronologClientImplInstance;
+    static ChronologClientImpl* chronologClientImplInstance;
 
-    static ChronologClientImpl*
-    GetClientImplInstance(chronolog::ClientPortalServiceConf const &, ClientMode const& , chronolog::ClientQueryServiceConf const &);
+    static ChronologClientImpl* GetClientImplInstance(chronolog::ClientPortalServiceConf const&,
+                                                      ClientMode const&,
+                                                      chronolog::ClientQueryServiceConf const&);
 
     // the classs is non-copyable
-    ChronologClientImpl(ChronologClientImpl const &) = delete;
+    ChronologClientImpl(ChronologClientImpl const&) = delete;
 
-    ChronologClientImpl &operator=(ChronologClientImpl const &) = delete;
+    ChronologClientImpl& operator=(ChronologClientImpl const&) = delete;
 
     ~ChronologClientImpl();
 
     int Connect();
 
-    int Disconnect(); 
+    int Disconnect();
 
-    int CreateChronicle(std::string const &chronicle_name, const std::map <std::string, std::string> &attrs
-                        , int &flags);
+    int CreateChronicle(std::string const& chronicle_name, const std::map<std::string, std::string>& attrs, int& flags);
 
-    int DestroyChronicle(std::string const &chronicle_name); 
+    int DestroyChronicle(std::string const& chronicle_name);
 
-    std::pair <int, StoryHandle*> AcquireStory(std::string const &chronicle_name, std::string const &story_name
-                                               , const std::map <std::string, std::string> &attrs
-                                               , int &flags);
+    std::pair<int, StoryHandle*> AcquireStory(std::string const& chronicle_name,
+                                              std::string const& story_name,
+                                              const std::map<std::string, std::string>& attrs,
+                                              int& flags);
 
-    int ReleaseStory(std::string const &chronicle_name, std::string const &story_name); 
-    int DestroyStory(std::string const &chronicle_name, std::string const &story_name);
+    int ReleaseStory(std::string const& chronicle_name, std::string const& story_name);
+    int DestroyStory(std::string const& chronicle_name, std::string const& story_name);
 
-    int GetChronicleAttr(std::string const &chronicle_name, const std::string &key, std::string &value);
+    int GetChronicleAttr(std::string const& chronicle_name, const std::string& key, std::string& value);
 
-    int EditChronicleAttr(std::string const &chronicle_name, const std::string &key, const std::string &value);
+    int EditChronicleAttr(std::string const& chronicle_name, const std::string& key, const std::string& value);
 
-    std::vector <std::string> &ShowChronicles(std::vector <std::string> &);
-    std::vector <std::string> &ShowStories(const std::string &chronicle_name, std::vector <std::string> &);
+    std::vector<std::string>& ShowChronicles(std::vector<std::string>&);
+    std::vector<std::string>& ShowStories(const std::string& chronicle_name, std::vector<std::string>&);
 
-    int replay_story( ChronicleName const&, StoryName const&, uint64_t start, uint64_t end, std::vector<Event> & eventSeries);
+    int
+    replay_story(ChronicleName const&, StoryName const&, uint64_t start, uint64_t end, std::vector<Event>& eventSeries);
 
 private:
-
     ClientMode clientMode;
     ChronologClientState clientState;
     std::string clientLogin;
@@ -88,16 +92,15 @@ private:
     uint32_t pid;
     ClientId clientId;
     ChronologTimer clockProxy;
-    thallium::engine*tlEngine;
-    RpcVisorClient*rpcVisorClient;
-    StorytellerClient*storyteller;
-    ClientQueryService * storyReaderService;
+    thallium::engine* tlEngine;
+    RpcVisorClient* rpcVisorClient;
+    StorytellerClient* storyteller;
+    ClientQueryService* storyReaderService;
 
-    ChronologClientImpl(ClientPortalServiceConf const&, ClientMode const &, chronolog::ClientQueryServiceConf const&);
+    ChronologClientImpl(ClientPortalServiceConf const&, ClientMode const&, chronolog::ClientQueryServiceConf const&);
 
     void defineClientIdentity();
-
 };
 } //namespace chronolog
 
-#endif 
+#endif

--- a/Client/cpp/src/ChronologClientImpl.h
+++ b/Client/cpp/src/ChronologClientImpl.h
@@ -1,6 +1,15 @@
 #ifndef CHRONOLOG_CLIENT_IMPL_H
 #define CHRONOLOG_CLIENT_IMPL_H
 
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <thallium.hpp>
+
 #include <client_errcode.h>
 #include <ClientConfiguration.h>
 #include <chronolog_types.h>

--- a/Client/cpp/src/ClientConfiguration.cpp
+++ b/Client/cpp/src/ClientConfiguration.cpp
@@ -9,41 +9,51 @@
 
 #include <ClientConfiguration.h>
 
-namespace chronolog {
+namespace chronolog
+{
 
-bool ClientConfiguration::load_from_file(const std::string& path) {
+bool ClientConfiguration::load_from_file(const std::string& path)
+{
     json_object* root = json_object_from_file(path.c_str());
-    if (!root) {
+    if(!root)
+    {
         std::cerr << "[ClientConfiguration] Failed to read config file: " << path << std::endl;
         return false;
     }
 
     json_object* chrono_client;
-    if (!json_object_object_get_ex(root, "chrono_client", &chrono_client)) {
+    if(!json_object_object_get_ex(root, "chrono_client", &chrono_client))
+    {
         std::cerr << "[ClientConfiguration] Missing 'chrono_client' section." << std::endl;
         return false;
     }
 
     json_object* portal_service;
-    if (json_object_object_get_ex(chrono_client, "VisorClientPortalService", &portal_service)) {
+    if(json_object_object_get_ex(chrono_client, "VisorClientPortalService", &portal_service))
+    {
         json_object* rpc;
-        if (json_object_object_get_ex(portal_service, "rpc", &rpc)) {
+        if(json_object_object_get_ex(portal_service, "rpc", &rpc))
+        {
             parse_rpc(rpc, PORTAL_CONF.PROTO_CONF, PORTAL_CONF.IP, PORTAL_CONF.PORT, PORTAL_CONF.PROVIDER_ID);
         }
     }
 
     json_object* query_service;
-    if (json_object_object_get_ex(chrono_client, "ClientQueryService", &query_service)) {
+    if(json_object_object_get_ex(chrono_client, "ClientQueryService", &query_service))
+    {
         json_object* rpc;
-        if (json_object_object_get_ex(query_service, "rpc", &rpc)) {
+        if(json_object_object_get_ex(query_service, "rpc", &rpc))
+        {
             parse_rpc(rpc, QUERY_CONF.PROTO_CONF, QUERY_CONF.IP, QUERY_CONF.PORT, QUERY_CONF.PROVIDER_ID);
         }
     }
 
     json_object* monitoring;
-    if (json_object_object_get_ex(chrono_client, "Monitoring", &monitoring)) {
+    if(json_object_object_get_ex(chrono_client, "Monitoring", &monitoring))
+    {
         json_object* monitor;
-        if (json_object_object_get_ex(monitoring, "monitor", &monitor)) {
+        if(json_object_object_get_ex(monitoring, "monitor", &monitor))
+        {
             parse_log(monitor);
         }
     }
@@ -52,59 +62,74 @@ bool ClientConfiguration::load_from_file(const std::string& path) {
     return true;
 }
 
-void ClientConfiguration::parse_rpc(json_object* rpc_obj, std::string& proto, std::string& ip, uint16_t& port, uint16_t& provider_id) {
+void ClientConfiguration::parse_rpc(json_object* rpc_obj,
+                                    std::string& proto,
+                                    std::string& ip,
+                                    uint16_t& port,
+                                    uint16_t& provider_id)
+{
     json_object* value;
 
-    if (json_object_object_get_ex(rpc_obj, "protocol_conf", &value))
+    if(json_object_object_get_ex(rpc_obj, "protocol_conf", &value))
         proto = json_object_get_string(value);
 
-    if (json_object_object_get_ex(rpc_obj, "service_ip", &value))
+    if(json_object_object_get_ex(rpc_obj, "service_ip", &value))
         ip = json_object_get_string(value);
 
-    if (json_object_object_get_ex(rpc_obj, "service_base_port", &value))
+    if(json_object_object_get_ex(rpc_obj, "service_base_port", &value))
         port = static_cast<uint16_t>(json_object_get_int(value));
 
-    if (json_object_object_get_ex(rpc_obj, "service_provider_id", &value))
+    if(json_object_object_get_ex(rpc_obj, "service_provider_id", &value))
         provider_id = static_cast<uint16_t>(json_object_get_int(value));
 }
 
-void ClientConfiguration::parse_log(json_object* log_obj) {
+void ClientConfiguration::parse_log(json_object* log_obj)
+{
     json_object* value;
 
-    if (json_object_object_get_ex(log_obj, "type", &value))
+    if(json_object_object_get_ex(log_obj, "type", &value))
         LOG_CONF.LOGTYPE = json_object_get_string(value);
 
-    if (json_object_object_get_ex(log_obj, "file", &value))
+    if(json_object_object_get_ex(log_obj, "file", &value))
         LOG_CONF.LOGFILE = json_object_get_string(value);
 
-    if (json_object_object_get_ex(log_obj, "level", &value))
+    if(json_object_object_get_ex(log_obj, "level", &value))
         LOG_CONF.LOGLEVEL = parse_log_level(json_object_get_string(value));
 
-    if (json_object_object_get_ex(log_obj, "name", &value))
+    if(json_object_object_get_ex(log_obj, "name", &value))
         LOG_CONF.LOGNAME = json_object_get_string(value);
 
-    if (json_object_object_get_ex(log_obj, "filesize", &value))
+    if(json_object_object_get_ex(log_obj, "filesize", &value))
         LOG_CONF.LOGFILESIZE = static_cast<size_t>(json_object_get_int(value));
 
-    if (json_object_object_get_ex(log_obj, "filenum", &value))
+    if(json_object_object_get_ex(log_obj, "filenum", &value))
         LOG_CONF.LOGFILENUM = static_cast<size_t>(json_object_get_int(value));
 
-    if (json_object_object_get_ex(log_obj, "flushlevel", &value))
+    if(json_object_object_get_ex(log_obj, "flushlevel", &value))
         LOG_CONF.FLUSHLEVEL = parse_log_level(json_object_get_string(value));
 }
 
-spdlog::level::level_enum ClientConfiguration::parse_log_level(const std::string& level_str) {
-    if (level_str == "trace") return spdlog::level::trace;
-    if (level_str == "debug") return spdlog::level::debug;
-    if (level_str == "info") return spdlog::level::info;
-    if (level_str == "warning") return spdlog::level::warn;
-    if (level_str == "error") return spdlog::level::err;
-    if (level_str == "critical") return spdlog::level::critical;
-    if (level_str == "off") return spdlog::level::off;
+spdlog::level::level_enum ClientConfiguration::parse_log_level(const std::string& level_str)
+{
+    if(level_str == "trace")
+        return spdlog::level::trace;
+    if(level_str == "debug")
+        return spdlog::level::debug;
+    if(level_str == "info")
+        return spdlog::level::info;
+    if(level_str == "warning")
+        return spdlog::level::warn;
+    if(level_str == "error")
+        return spdlog::level::err;
+    if(level_str == "critical")
+        return spdlog::level::critical;
+    if(level_str == "off")
+        return spdlog::level::off;
     return spdlog::level::warn;
 }
 
-std::ostream& ClientConfiguration::log_configuration(std::ostream& out) const {
+std::ostream& ClientConfiguration::log_configuration(std::ostream& out) const
+{
     out << "===== ChronoLog Client Configuration =====" << std::endl;
 
     out << "[PORTAL_CONF]" << std::endl;
@@ -131,4 +156,4 @@ std::ostream& ClientConfiguration::log_configuration(std::ostream& out) const {
     return out;
 }
 
-}
+} // namespace chronolog

--- a/Client/cpp/src/ClientConfiguration.cpp
+++ b/Client/cpp/src/ClientConfiguration.cpp
@@ -1,5 +1,11 @@
-#include <json-c/json.h>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <ostream>
+#include <string>
+
+#include <json-c/json.h>
+#include <spdlog/spdlog.h>
 
 #include <ClientConfiguration.h>
 

--- a/Client/cpp/src/ClientQueryService.cpp
+++ b/Client/cpp/src/ClientQueryService.cpp
@@ -1,6 +1,17 @@
+#include <atomic>
+#include <chrono>
+#include <exception>
+#include <mutex>
+#include <new>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+#include <cereal/archives/binary.hpp>
 #include <thallium.hpp>
 #include <thallium/serialization/stl/vector.hpp>
-#include <cereal/archives/binary.hpp>
 
 #include <client_errcode.h>
 #include <chrono_monitor.h>

--- a/Client/cpp/src/ClientQueryService.cpp
+++ b/Client/cpp/src/ClientQueryService.cpp
@@ -25,21 +25,19 @@ namespace tl = thallium;
 namespace chl = chronolog;
 
 
-
-chl::ClientQueryService::ClientQueryService(thallium::engine & tl_engine, chl::ServiceId const& client_service_id)
-        : tl::provider <ClientQueryService>(tl_engine, client_service_id.getProviderId())
-        , queryServiceEngine(tl_engine)
-        , queryServiceId(client_service_id)
-        , queryTimeoutInSecs(180) // 3 mins
+chl::ClientQueryService::ClientQueryService(thallium::engine& tl_engine, chl::ServiceId const& client_service_id)
+    : tl::provider<ClientQueryService>(tl_engine, client_service_id.getProviderId())
+    , queryServiceEngine(tl_engine)
+    , queryServiceId(client_service_id)
+    , queryTimeoutInSecs(180) // 3 mins
 {
-    std::atomic_init(&queryIndex,0);
+    std::atomic_init(&queryIndex, 0);
 
     LOG_DEBUG("[ClientQueryService] created  service {}", chl::to_string(queryServiceId));
 
-         define("receive_story_chunk", &ClientQueryService::receive_story_chunk, tl::ignore_return_value());
-         //set up callback for the case when the engine is being finalized while this provider is still alive
-         get_engine().push_finalize_callback(this, [p = this]()
-         { delete p; });
+    define("receive_story_chunk", &ClientQueryService::receive_story_chunk, tl::ignore_return_value());
+    //set up callback for the case when the engine is being finalized while this provider is still alive
+    get_engine().push_finalize_callback(this, [p = this]() { delete p; });
 }
 
 
@@ -51,72 +49,86 @@ chl::ClientQueryService::~ClientQueryService()
 
 
 ///////////////
-int chl::ClientQueryService::addStoryReader(ChronicleName const& chronicle, StoryName const& story, ServiceId const& service_id)
+int chl::ClientQueryService::addStoryReader(ChronicleName const& chronicle,
+                                            StoryName const& story,
+                                            ServiceId const& service_id)
 {
-    chl::PlaybackQueryRpcClient * playbackRpcClient = addPlaybackQueryClient(service_id);
+    chl::PlaybackQueryRpcClient* playbackRpcClient = addPlaybackQueryClient(service_id);
 
-    if( nullptr == playbackRpcClient)
+    if(nullptr == playbackRpcClient)
     {
         return chl::CL_ERR_UNKNOWN;
     }
 
-    std::lock_guard <std::mutex> lock(queryServiceMutex);
-    auto insert_return = acquiredStoryMap.insert(std::pair<std::pair<chl::ChronicleName,chl::StoryName>, chl::PlaybackQueryRpcClient*>(
-                                                        std::pair<chl::ChronicleName,chl::StoryName>(chronicle,story), playbackRpcClient));
-    
-    return ( insert_return.second ? chl::CL_SUCCESS : chl::CL_ERR_UNKNOWN);
+    std::lock_guard<std::mutex> lock(queryServiceMutex);
+    auto insert_return = acquiredStoryMap.insert(
+            std::pair<std::pair<chl::ChronicleName, chl::StoryName>, chl::PlaybackQueryRpcClient*>(
+                    std::pair<chl::ChronicleName, chl::StoryName>(chronicle, story),
+                    playbackRpcClient));
+
+    return (insert_return.second ? chl::CL_SUCCESS : chl::CL_ERR_UNKNOWN);
 }
 
-void chl::ClientQueryService::removeStoryReader(chl::ChronicleName const & chronicle, chl::StoryName const & story)
+void chl::ClientQueryService::removeStoryReader(chl::ChronicleName const& chronicle, chl::StoryName const& story)
 {
-    std::lock_guard <std::mutex> lock(queryServiceMutex);
-    acquiredStoryMap.erase(std::pair<chl::ChronicleName,chl::StoryName>(chronicle,story));
+    std::lock_guard<std::mutex> lock(queryServiceMutex);
+    acquiredStoryMap.erase(std::pair<chl::ChronicleName, chl::StoryName>(chronicle, story));
 }
 
 ////////////
 
-int chl::ClientQueryService::replay_story( chl::ChronicleName const& chronicle, chl::StoryName const& story, uint64_t start, uint64_t end, std::vector<chl::Event> & event_series)
+int chl::ClientQueryService::replay_story(chl::ChronicleName const& chronicle,
+                                          chl::StoryName const& story,
+                                          uint64_t start,
+                                          uint64_t end,
+                                          std::vector<chl::Event>& event_series)
 {
 
-    //check if the story has been acquired and the chrono_player is available for it 
+    //check if the story has been acquired and the chrono_player is available for it
 
-    auto storyReader_iter = acquiredStoryMap.find(std::pair<chl::ChronicleName,chl::StoryName>(chronicle, story));
+    auto storyReader_iter = acquiredStoryMap.find(std::pair<chl::ChronicleName, chl::StoryName>(chronicle, story));
 
     if(storyReader_iter == acquiredStoryMap.end())
-    { return chl::CL_ERR_NOT_ACQUIRED; }
+    {
+        return chl::CL_ERR_NOT_ACQUIRED;
+    }
 
-    PlaybackQueryRpcClient * playbackRpcClient = (*storyReader_iter).second;
+    PlaybackQueryRpcClient* playbackRpcClient = (*storyReader_iter).second;
 
-    // instantiate new query object 
+    // instantiate new query object
 
-    auto timeout_time = (std::chrono::steady_clock::now() + std::chrono::seconds(queryTimeoutInSecs)).time_since_epoch().count();
+    auto timeout_time =
+            (std::chrono::steady_clock::now() + std::chrono::seconds(queryTimeoutInSecs)).time_since_epoch().count();
 
-    chl::PlaybackQuery * query = start_query( timeout_time, chronicle, story, start, end, event_series);
+    chl::PlaybackQuery* query = start_query(timeout_time, chronicle, story, start, end, event_series);
 
     if(query == nullptr)
-    {   return chl::CL_ERR_UNKNOWN; }
+    {
+        return chl::CL_ERR_UNKNOWN;
+    }
 
     //TODO: check that rpcQueryClient object can not be destroyed while we make the RPC call...
 
     //send query request to the appropriate chrono_player PlaybackService
-    if( (playbackRpcClient == nullptr)
-    || ( playbackRpcClient->send_story_playback_request( query->queryId, chronicle, story, start,end) != chl::CL_SUCCESS))
+    if((playbackRpcClient == nullptr) ||
+       (playbackRpcClient->send_story_playback_request(query->queryId, chronicle, story, start, end) !=
+        chl::CL_SUCCESS))
     {
         stop_query(query->queryId);
         return chl::CL_ERR_NO_PLAYERS;
     }
-    
+
     // now wait for the asynchronous response with periodic polling of the query status
     // response will be received on a different thread
 
     uint64_t current_time = std::chrono::steady_clock::now().time_since_epoch().count();
-    while( !query->completed && current_time < query->timeout_time)
+    while(!query->completed && current_time < query->timeout_time)
     {
-        sleep(1);   //TODO: replace with finer granularity sleep...
+        sleep(1); //TODO: replace with finer granularity sleep...
         current_time = std::chrono::steady_clock::now().time_since_epoch().count();
     }
 
-    int ret_value = (query->completed == true ? chl::CL_SUCCESS : chl::CL_ERR_QUERY_TIMED_OUT );
+    int ret_value = (query->completed == true ? chl::CL_SUCCESS : chl::CL_ERR_QUERY_TIMED_OUT);
 
     // destroy query object and return to the caller
     stop_query(query->queryId);
@@ -125,34 +137,43 @@ int chl::ClientQueryService::replay_story( chl::ChronicleName const& chronicle, 
 }
 //////
 
-chl::PlaybackQuery * chl::ClientQueryService::start_query(uint64_t timeout_time, chl::ChronicleName const& chronicle, chl::StoryName const& story, 
-        chl::chrono_time const& start_time, chl::chrono_time const& end_time, std::vector<chl::Event> & playback_events)
+chl::PlaybackQuery* chl::ClientQueryService::start_query(uint64_t timeout_time,
+                                                         chl::ChronicleName const& chronicle,
+                                                         chl::StoryName const& story,
+                                                         chl::chrono_time const& start_time,
+                                                         chl::chrono_time const& end_time,
+                                                         std::vector<chl::Event>& playback_events)
 {
-    std::lock_guard <std::mutex> lock(queryServiceMutex);
+    std::lock_guard<std::mutex> lock(queryServiceMutex);
 
-    uint32_t query_id = queryIndex++; 
-    
+    uint32_t query_id = queryIndex++;
+
     //TODO add query_id to queryResponse object  and remove this line...
-    query_id=1;
-    auto insert_return = activeQueryMap.insert(std::pair<uint32_t, chl::PlaybackQuery>
-                ( query_id, chl::PlaybackQuery( playback_events, query_id, timeout_time, chronicle, story, start_time, end_time)));
+    query_id = 1;
+    auto insert_return = activeQueryMap.insert(std::pair<uint32_t, chl::PlaybackQuery>(
+            query_id,
+            chl::PlaybackQuery(playback_events, query_id, timeout_time, chronicle, story, start_time, end_time)));
 
     if(insert_return.second)
-    {   return & (*insert_return.first).second; }
+    {
+        return &(*insert_return.first).second;
+    }
     else
-    {   return nullptr; }
+    {
+        return nullptr;
+    }
 }
 
 void chl::ClientQueryService::stop_query(uint32_t query_id)
 {
-    std::lock_guard <std::mutex> lock(queryServiceMutex);
+    std::lock_guard<std::mutex> lock(queryServiceMutex);
 
     activeQueryMap.erase(query_id);
 }
 ////
 
 // find or create PlaybackServiceRpcClient associated with the remote Playback Service
-chl::PlaybackQueryRpcClient * chronolog::ClientQueryService::addPlaybackQueryClient(chl::ServiceId const& player_card)
+chl::PlaybackQueryRpcClient* chronolog::ClientQueryService::addPlaybackQueryClient(chl::ServiceId const& player_card)
 {
     LOG_DEBUG("[ClientQueryService] adding PlaybackQueryRpcClient for {}", chl::to_string(player_card));
 
@@ -165,18 +186,18 @@ chl::PlaybackQueryRpcClient * chronolog::ClientQueryService::addPlaybackQueryCli
         return (*find_iter).second;
     }
 
-    chl::PlaybackQueryRpcClient * playbackRpcClient = nullptr;
+    chl::PlaybackQueryRpcClient* playbackRpcClient = nullptr;
     LOG_DEBUG("[ClientQueryService] adding PlaybackQueryRpcClient for {}", chl::to_string(player_card));
-    
-    std::lock_guard <std::mutex> lock(queryServiceMutex);
+
+    std::lock_guard<std::mutex> lock(queryServiceMutex);
 
     try
     {
-        playbackRpcClient = chronolog::PlaybackQueryRpcClient::CreatePlaybackQueryRpcClient(*this, player_card); 
+        playbackRpcClient = chronolog::PlaybackQueryRpcClient::CreatePlaybackQueryRpcClient(*this, player_card);
 
         auto insert_return = playbackRpcClientMap.insert(
-                std::pair <chl::service_endpoint, chl::PlaybackQueryRpcClient*>(
-                        player_card.get_service_endpoint(), playbackRpcClient));
+                std::pair<chl::service_endpoint, chl::PlaybackQueryRpcClient*>(player_card.get_service_endpoint(),
+                                                                               playbackRpcClient));
 
         if(false != insert_return.second)
         {
@@ -185,13 +206,12 @@ chl::PlaybackQueryRpcClient * chronolog::ClientQueryService::addPlaybackQueryCli
         }
         else
         {
-            delete playbackRpcClient; 
+            delete playbackRpcClient;
             playbackRpcClient = nullptr;
             LOG_DEBUG("[ClientQueryService] Failed to create PlaybackQueryRpcClient}", chl::to_string(player_card));
         }
-
     }
-    catch(tl::exception const &ex)
+    catch(tl::exception const& ex)
     {
         playbackRpcClient = nullptr;
         LOG_DEBUG("[ClientQueryService] Failed to create PlaybackQueryRpcClient}", chl::to_string(player_card));
@@ -202,38 +222,40 @@ chl::PlaybackQueryRpcClient * chronolog::ClientQueryService::addPlaybackQueryCli
 // we are notified of the remote PlaybackService stopping, remove associated PlaybackQueryRpcClient
 void chronolog::ClientQueryService::removePlaybackQueryClient(chl::ServiceId const& player_card)
 {
-    std::lock_guard <std::mutex> lock(queryServiceMutex);
+    std::lock_guard<std::mutex> lock(queryServiceMutex);
     //TODO : we need to check that there no active queries associated with this PlaybackQueryRpcClient
     // to safely remove it
 }
 
 // build transfer of the Response StoryChunks
-void chl::ClientQueryService::receive_story_chunk(tl::request  const& request, tl::bulk &b)
+void chl::ClientQueryService::receive_story_chunk(tl::request const& request, tl::bulk& b)
 {
     try
     {
         tl::endpoint ep = request.get_endpoint();
         LOG_DEBUG("[ClientQueryService] receive_story_chunk :Endpoint obtained, ThreadID={}", tl::thread::self_id());
-        
-        std::vector <char> mem_vec(b.size());
-        std::vector <std::pair <void*, std::size_t>> segments(1);
+
+        std::vector<char> mem_vec(b.size());
+        std::vector<std::pair<void*, std::size_t>> segments(1);
         segments[0].first = (void*)(&mem_vec[0]);
         segments[0].second = mem_vec.size();
-        LOG_DEBUG("[ClientQueryService] Bulk memory prepared, size: {}, ThreadID={}", mem_vec.size(), tl::thread::self_id());
+        LOG_DEBUG("[ClientQueryService] Bulk memory prepared, size: {}, ThreadID={}",
+                  mem_vec.size(),
+                  tl::thread::self_id());
         tl::engine local_engine = get_engine();
-        
+
         tl::bulk local = local_engine.expose(segments, tl::bulk_mode::write_only);
         LOG_DEBUG("[ClientQueryService] Bulk memory exposed, ThreadID={}", tl::thread::self_id());
         b.on(ep) >> local;
-        LOG_DEBUG("[ClientQueryService] Received {} bytes of StoryChunk data, ThreadID={}", b.size(), tl::thread::self_id());
-  
-        StoryChunk*story_chunk = new StoryChunk();
-        int ret = deserializedWithCereal(&mem_vec[0], b.size()
-                                               , *story_chunk);
+        LOG_DEBUG("[ClientQueryService] Received {} bytes of StoryChunk data, ThreadID={}",
+                  b.size(),
+                  tl::thread::self_id());
+
+        StoryChunk* story_chunk = new StoryChunk();
+        int ret = deserializedWithCereal(&mem_vec[0], b.size(), *story_chunk);
         if(ret != chronolog::CL_SUCCESS)
         {
-            LOG_ERROR("[ClientQueryService] Failed to deserialize a story chunk, ThreadID={}"
-                            , tl::thread::self_id());
+            LOG_ERROR("[ClientQueryService] Failed to deserialize a story chunk, ThreadID={}", tl::thread::self_id());
             delete story_chunk;
             ret = 10000000 + tl::thread::self_id(); // arbitrary error code encoded with thread id
             LOG_ERROR("[ClientQueryService] Discarding the story chunk, responding {} to Keeper", ret);
@@ -241,74 +263,80 @@ void chl::ClientQueryService::receive_story_chunk(tl::request  const& request, t
             return;
         }
 
-        LOG_DEBUG("[ClientQueryService] StoryChunk received: StoryId {} StartTime {} eventCount {} ThreadID={}"
-                        , story_chunk->getStoryId(), story_chunk->getStartTime(), story_chunk->getEventCount()
-                        , tl::thread::self_id());
- 
-        // add StoryChunk to the Query response event series 
-        uint32_t query_id = 1; //TODO:  add query_id to query response transfer 
-        
+        LOG_DEBUG("[ClientQueryService] StoryChunk received: StoryId {} StartTime {} eventCount {} ThreadID={}",
+                  story_chunk->getStoryId(),
+                  story_chunk->getStartTime(),
+                  story_chunk->getEventCount(),
+                  tl::thread::self_id());
+
+        // add StoryChunk to the Query response event series
+        uint32_t query_id = 1; //TODO:  add query_id to query response transfer
+
         // NOTE: by design threre would be only one receiving thread that's writing to the specific query object
         // but we probably should take case of the possibility of the query timeout happenning while we are writing the response
 
         auto query_iter = activeQueryMap.find(query_id);
         if(query_iter != activeQueryMap.end())
         {
-            LOG_DEBUG("[ClientQueryService] Query {} got StoryChunk {}-{} StartTime {} eventCount {} ThreadID={}"
-                        , query_id, story_chunk->getChronicleName(), story_chunk->getStoryName(), story_chunk->getStartTime(), story_chunk->getEventCount() , tl::thread::self_id());
+            LOG_DEBUG("[ClientQueryService] Query {} got StoryChunk {}-{} StartTime {} eventCount {} ThreadID={}",
+                      query_id,
+                      story_chunk->getChronicleName(),
+                      story_chunk->getStoryName(),
+                      story_chunk->getStartTime(),
+                      story_chunk->getEventCount(),
+                      tl::thread::self_id());
             story_chunk->extractEventSeries((*query_iter).second.eventSeries);
-            (*query_iter).second.completed=true;
+            (*query_iter).second.completed = true;
         }
-        
+
         delete story_chunk;
- 
-        LOG_DEBUG("[ClientQueryService] StoryChunk recording RPC response {}, ThreadID={}", b.size()
-                        , tl::thread::self_id());
+
+        LOG_DEBUG("[ClientQueryService] StoryChunk recording RPC response {}, ThreadID={}",
+                  b.size(),
+                  tl::thread::self_id());
         request.respond(b.size());
- 
-        // add StoryChunk to the QueryResponse Object 
-        }
-        catch(std::bad_alloc const &ex)
-        {
-            LOG_ERROR("[ClientQueryService] Failed to allocate memory for StoryChunk data, ThreadID={}" , tl::thread::self_id());
-            request.respond(20000000 + tl::thread::self_id());
-        }
+
+        // add StoryChunk to the QueryResponse Object
+    }
+    catch(std::bad_alloc const& ex)
+    {
+        LOG_ERROR("[ClientQueryService] Failed to allocate memory for StoryChunk data, ThreadID={}",
+                  tl::thread::self_id());
+        request.respond(20000000 + tl::thread::self_id());
+    }
 }
 
-int chl::ClientQueryService::deserializedWithCereal(char *buffer, size_t size, chl::StoryChunk &story_chunk)
-     {
-         std::stringstream ss(std::ios::binary | std::ios::in | std::ios::out);
-         try
-         {
-             ss.write(buffer, size);
-             cereal::BinaryInputArchive iarchive(ss);
-             iarchive(story_chunk);
-             return chronolog::CL_SUCCESS;
-         }
-         catch(cereal::Exception const &ex)
-        {
-            LOG_ERROR("[ClientQueryService] Failed to deserialize a story chunk, size={}, ThreadID={}. "
-                       "Cereal exception: {}", ss.str().size(), tl::thread::self_id(), ex.what());
-         }
-         catch(std::exception const &ex)
-         {
-          LOG_ERROR("[ClientQueryService] Failed to deserialize a story chunk, size={}, ThreadID={}. "
-                       "std::exception : {}", ss.str().size(), tl::thread::self_id(), ex.what());
-         }
-         catch(...)
-         {
-             LOG_ERROR("[ClientQueryService] Failed to deserialize a story chunk, ThreadID={}. Unknown exception "
-                       "encountered.", tl::thread::self_id());
-         }
-        return chronolog::CL_ERR_UNKNOWN;
-     }
-
-
-
-
-
-
-
-
-
-
+int chl::ClientQueryService::deserializedWithCereal(char* buffer, size_t size, chl::StoryChunk& story_chunk)
+{
+    std::stringstream ss(std::ios::binary | std::ios::in | std::ios::out);
+    try
+    {
+        ss.write(buffer, size);
+        cereal::BinaryInputArchive iarchive(ss);
+        iarchive(story_chunk);
+        return chronolog::CL_SUCCESS;
+    }
+    catch(cereal::Exception const& ex)
+    {
+        LOG_ERROR("[ClientQueryService] Failed to deserialize a story chunk, size={}, ThreadID={}. "
+                  "Cereal exception: {}",
+                  ss.str().size(),
+                  tl::thread::self_id(),
+                  ex.what());
+    }
+    catch(std::exception const& ex)
+    {
+        LOG_ERROR("[ClientQueryService] Failed to deserialize a story chunk, size={}, ThreadID={}. "
+                  "std::exception : {}",
+                  ss.str().size(),
+                  tl::thread::self_id(),
+                  ex.what());
+    }
+    catch(...)
+    {
+        LOG_ERROR("[ClientQueryService] Failed to deserialize a story chunk, ThreadID={}. Unknown exception "
+                  "encountered.",
+                  tl::thread::self_id());
+    }
+    return chronolog::CL_ERR_UNKNOWN;
+}

--- a/Client/cpp/src/ClientQueryService.h
+++ b/Client/cpp/src/ClientQueryService.h
@@ -2,8 +2,12 @@
 #define CLIENT_QUERY_SERVICE_H
 
 #include <atomic>
+#include <cstdint>
 #include <map>
 #include <mutex>
+#include <utility>
+#include <vector>
+
 #include <thallium.hpp>
 
 #include <chronolog_types.h>

--- a/Client/cpp/src/ClientQueryService.h
+++ b/Client/cpp/src/ClientQueryService.h
@@ -24,34 +24,44 @@ class StoryChunk;
 
 struct PlaybackQuery
 {
-    std::vector<Event>  & eventSeries; 
+    std::vector<Event>& eventSeries;
     uint32_t queryId;
     uint64_t timeout_time;
     bool completed;
     ChronicleName chronicleName;
-    StoryName   storyName;
+    StoryName storyName;
     chrono_time startTime;
     chrono_time endTime;
 
-    PlaybackQuery( std::vector<Event> & playbackEvents, uint32_t query_id, uint64_t timeout_time,
-            ChronicleName const& chronicle, StoryName const& story, chrono_time const& start, chrono_time const& end)
-    : eventSeries(playbackEvents), queryId(query_id),timeout_time(timeout_time), completed(false)
-    , chronicleName(chronicle), storyName(story), startTime(start),endTime(end)
-    { }
+    PlaybackQuery(std::vector<Event>& playbackEvents,
+                  uint32_t query_id,
+                  uint64_t timeout_time,
+                  ChronicleName const& chronicle,
+                  StoryName const& story,
+                  chrono_time const& start,
+                  chrono_time const& end)
+        : eventSeries(playbackEvents)
+        , queryId(query_id)
+        , timeout_time(timeout_time)
+        , completed(false)
+        , chronicleName(chronicle)
+        , storyName(story)
+        , startTime(start)
+        , endTime(end)
+    {}
 };
 
-class ClientQueryService : public tl::provider <ClientQueryService>
+class ClientQueryService: public tl::provider<ClientQueryService>
 {
 public:
     // Service should be created on the heap not the stack thus the constructor is private...
-    static ClientQueryService *
-    CreateClientQueryService(thallium::engine & tl_engine, ServiceId const& client_service_id)
+    static ClientQueryService* CreateClientQueryService(thallium::engine& tl_engine, ServiceId const& client_service_id)
     {
-        try 
+        try
         {
             return new ClientQueryService(tl_engine, client_service_id);
         }
-        catch(thallium::exception &)
+        catch(thallium::exception&)
         {
             return nullptr;
         }
@@ -59,46 +69,53 @@ public:
 
     ~ClientQueryService();
 
-    tl::engine & get_service_engine()
-    { return queryServiceEngine; }
+    tl::engine& get_service_engine() { return queryServiceEngine; }
 
-    ServiceId const& get_service_id() const
-    { return queryServiceId; }
+    ServiceId const& get_service_id() const { return queryServiceId; }
 
     int addStoryReader(ChronicleName const&, StoryName const&, ServiceId const&);
     void removeStoryReader(ChronicleName const&, StoryName const&);
- 
-    void receive_story_chunk(tl::request const&, tl::bulk &);
 
-    int replay_story( ChronicleName const&, StoryName const&, uint64_t start, uint64_t end, std::vector<Event> & replay_events);
+    void receive_story_chunk(tl::request const&, tl::bulk&);
+
+    int replay_story(ChronicleName const&,
+                     StoryName const&,
+                     uint64_t start,
+                     uint64_t end,
+                     std::vector<Event>& replay_events);
 
 private:
-    ClientQueryService(thallium::engine & tl_engine, ServiceId const&);
+    ClientQueryService(thallium::engine& tl_engine, ServiceId const&);
 
     ClientQueryService() = delete;
     ClientQueryService(ClientQueryService const&) = delete;
 
     // create PlaybackServiceRpcClient associated with the remote Playback Service
-    PlaybackQueryRpcClient * addPlaybackQueryClient(ServiceId const& );
+    PlaybackQueryRpcClient* addPlaybackQueryClient(ServiceId const&);
     // destroy PlaybackServiceRpcClient associated with the remote Playback Service
-    void removePlaybackQueryClient(ServiceId const& );
+    void removePlaybackQueryClient(ServiceId const&);
 
-    PlaybackQuery * start_query(uint64_t, ChronicleName const&, StoryName const&, chrono_time const&, chrono_time const&, std::vector<Event>&);
+    PlaybackQuery* start_query(uint64_t,
+                               ChronicleName const&,
+                               StoryName const&,
+                               chrono_time const&,
+                               chrono_time const&,
+                               std::vector<Event>&);
     void stop_query(uint32_t);
 
-    int deserializedWithCereal(char *buffer, size_t size, StoryChunk &story_chunk);
-    thallium::engine  queryServiceEngine;
-    ServiceId       queryServiceId;
-    std::mutex queryServiceMutex;    
+    int deserializedWithCereal(char* buffer, size_t size, StoryChunk& story_chunk);
+    thallium::engine queryServiceEngine;
+    ServiceId queryServiceId;
+    std::mutex queryServiceMutex;
     std::atomic<uint32_t> queryIndex;
-    int  queryTimeoutInSecs;
+    int queryTimeoutInSecs;
     std::map<uint32_t, PlaybackQuery> activeQueryMap; // map of active queries by queryId
-    std::map<std::pair<ChronicleName,StoryName>, PlaybackQueryRpcClient*> acquiredStoryMap;
+    std::map<std::pair<ChronicleName, StoryName>, PlaybackQueryRpcClient*> acquiredStoryMap;
     // map of QueryRpcClients by service_endpoint of the remote chrono_grapher PlaybackService
-    std::map<service_endpoint, PlaybackQueryRpcClient*> playbackRpcClientMap; 
+    std::map<service_endpoint, PlaybackQueryRpcClient*> playbackRpcClientMap;
 };
 
 
-}
+} // namespace chronolog
 
 #endif

--- a/Client/cpp/src/KeeperRecordingClient.h
+++ b/Client/cpp/src/KeeperRecordingClient.h
@@ -2,6 +2,8 @@
 #define KEEPER_RECORDING_CLIENT_H
 
 #include <iostream>
+#include <string>
+
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>
 

--- a/Client/cpp/src/KeeperRecordingClient.h
+++ b/Client/cpp/src/KeeperRecordingClient.h
@@ -23,21 +23,20 @@ class KeeperRecordingClient
 {
 
 public:
-    static KeeperRecordingClient*
-    CreateKeeperRecordingClient(tl::engine &tl_engine, KeeperIdCard const &keeper_id_card)
+    static KeeperRecordingClient* CreateKeeperRecordingClient(tl::engine& tl_engine, KeeperIdCard const& keeper_id_card)
     {
         try
         {
             return new KeeperRecordingClient(tl_engine, keeper_id_card);
         }
-        catch(tl::exception const & ex)
+        catch(tl::exception const& ex)
         {
-            LOG_ERROR("[KeeperRecordingClient] Failed to create KeeperRecordingClient exception {}",ex.what());
+            LOG_ERROR("[KeeperRecordingClient] Failed to create KeeperRecordingClient exception {}", ex.what());
         }
         return nullptr;
     }
 
-    int send_event_msg(LogEvent const &eventMsg)
+    int send_event_msg(LogEvent const& eventMsg)
     {
         try
         {
@@ -48,15 +47,16 @@ public:
             //LOG_TRACE("[KeeperRecordingClient] Sent event message: {} with return code: {}", ss.str(), return_code);
             return return_code;
         }
-        catch(thallium::exception const & ex)
+        catch(thallium::exception const& ex)
         {
-            LOG_ERROR("[KeeperRecordingClient] Failed to send event message to {} exception: {}", to_string(keeperIdCard), ex.what());
+            LOG_ERROR("[KeeperRecordingClient] Failed to send event message to {} exception: {}",
+                      to_string(keeperIdCard),
+                      ex.what());
         }
         return (chronolog::CL_ERR_UNKNOWN);
     }
 
-    KeeperIdCard const & getKeeperId() const
-    { return keeperIdCard; }
+    KeeperIdCard const& getKeeperId() const { return keeperIdCard; }
 
     ~KeeperRecordingClient()
     {
@@ -65,30 +65,29 @@ public:
     }
 
 private:
-
     KeeperIdCard keeperIdCard;
-    tl::provider_handle service_ph;  //provider_handle for remote registry service
+    tl::provider_handle service_ph; //provider_handle for remote registry service
     tl::remote_procedure record_event;
 
     // constructor is private to make sure thalium rpc objects are created on the heap, not stack
-    KeeperRecordingClient(tl::engine &tl_engine, KeeperIdCard const &keeper_id_card)
+    KeeperRecordingClient(tl::engine& tl_engine, KeeperIdCard const& keeper_id_card)
         : keeperIdCard(keeper_id_card)
     {
-        LOG_DEBUG("[KeeperRecordingClient] KeeperRecordingiClient Constructor for {}",to_string(keeper_id_card));
+        LOG_DEBUG("[KeeperRecordingClient] KeeperRecordingiClient Constructor for {}", to_string(keeper_id_card));
         std::string service_addr_string;
         keeperIdCard.getRecordingServiceId().get_service_as_string(service_addr_string);
 
-        service_ph = tl::provider_handle(tl_engine.lookup(service_addr_string), keeper_id_card.getRecordingServiceId().getProviderId());
+        service_ph = tl::provider_handle(tl_engine.lookup(service_addr_string),
+                                         keeper_id_card.getRecordingServiceId().getProviderId());
 
         record_event = tl_engine.define("record_event");
     }
 
 
     KeeperRecordingClient() = delete;
-    KeeperRecordingClient(KeeperRecordingClient const &) = delete;
-    KeeperRecordingClient &operator=(KeeperRecordingClient const &) = delete;
-
+    KeeperRecordingClient(KeeperRecordingClient const&) = delete;
+    KeeperRecordingClient& operator=(KeeperRecordingClient const&) = delete;
 };
-}
+} // namespace chronolog
 
 #endif

--- a/Client/cpp/src/PlaybackQueryRpcClient.cpp
+++ b/Client/cpp/src/PlaybackQueryRpcClient.cpp
@@ -18,16 +18,17 @@ namespace tl = thallium;
 
 namespace chl = chronolog;
 
- // constructor is private to make sure thalium rpc objects are created on the heap, not stack
-chl::PlaybackQueryRpcClient::PlaybackQueryRpcClient(chl::ClientQueryService & clientQueryService
-                , chl::ServiceId const& playback_service_id)
+// constructor is private to make sure thalium rpc objects are created on the heap, not stack
+chl::PlaybackQueryRpcClient::PlaybackQueryRpcClient(chl::ClientQueryService& clientQueryService,
+                                                    chl::ServiceId const& playback_service_id)
     : theClientQueryService(clientQueryService)
     , playback_service_id(playback_service_id)
 {
     std::string service_addr_string;
     playback_service_id.get_service_as_string(service_addr_string);
 
-    playback_service_handle = tl::provider_handle(theClientQueryService.get_engine().lookup(service_addr_string), playback_service_id.getProviderId());
+    playback_service_handle = tl::provider_handle(theClientQueryService.get_engine().lookup(service_addr_string),
+                                                  playback_service_id.getProviderId());
 
     playback_service_available = theClientQueryService.get_engine().define("playback_service_available");
     story_playback_request = theClientQueryService.get_engine().define("story_playback_request");
@@ -45,36 +46,49 @@ int chl::PlaybackQueryRpcClient::is_playback_service_available()
 
     try
     {
-        return ( playback_service_available.on(playback_service_handle)() );
+        return (playback_service_available.on(playback_service_handle)());
     }
-    catch (tl::exception const &ex)
+    catch(tl::exception const& ex)
     {
-        LOG_ERROR("[PlaybackQueryRpcClient] Playback Service unavailable at {}, exceptiomn:{}", chl::to_string(playback_service_id), ex.what());
+        LOG_ERROR("[PlaybackQueryRpcClient] Playback Service unavailable at {}, exceptiomn:{}",
+                  chl::to_string(playback_service_id),
+                  ex.what());
     }
-    
+
     return chronolog::CL_ERR_UNKNOWN;
 }
-    
-int chl::PlaybackQueryRpcClient::send_story_playback_request(uint32_t query_id, chl::ChronicleName const &chronicle_name, chl::StoryName const &story_name, uint64_t start_time, uint64_t end_time)
+
+int chl::PlaybackQueryRpcClient::send_story_playback_request(uint32_t query_id,
+                                                             chl::ChronicleName const& chronicle_name,
+                                                             chl::StoryName const& story_name,
+                                                             uint64_t start_time,
+                                                             uint64_t end_time)
 {
     int return_code = chronolog::CL_ERR_UNKNOWN;
 
     //uint32_t query_id = theClientQueryService.start_new_query( chronicle_name,story_name,start_time,end_time);
-    
+
     try
     {
-        LOG_DEBUG("[PlaybackQueryRpcClient] {} ; send_story_playback_request for Story {}{}", chl::to_string(playback_service_id), chronicle_name,story_name);
-        story_playback_request.on(playback_service_handle)( theClientQueryService.get_service_id(), query_id, chronicle_name,story_name,start_time,end_time);
+        LOG_DEBUG("[PlaybackQueryRpcClient] {} ; send_story_playback_request for Story {}{}",
+                  chl::to_string(playback_service_id),
+                  chronicle_name,
+                  story_name);
+        story_playback_request.on(playback_service_handle)(theClientQueryService.get_service_id(),
+                                                           query_id,
+                                                           chronicle_name,
+                                                           story_name,
+                                                           start_time,
+                                                           end_time);
 
         return chronolog::CL_SUCCESS;
-
-    } 
-    catch (tl::exception const& ex)
+    }
+    catch(tl::exception const& ex)
     {
-        LOG_ERROR("[PlaybackQueryRpcClient] {} ; send_story_playback_request exception {}", chl::to_string(playback_service_id), ex.what());
+        LOG_ERROR("[PlaybackQueryRpcClient] {} ; send_story_playback_request exception {}",
+                  chl::to_string(playback_service_id),
+                  ex.what());
     }
 
     return return_code;
 }
-
-

--- a/Client/cpp/src/PlaybackQueryRpcClient.cpp
+++ b/Client/cpp/src/PlaybackQueryRpcClient.cpp
@@ -1,3 +1,6 @@
+#include <cstdint>
+#include <string>
+
 #include <thallium.hpp>
 #include <thallium/serialization/serialize.hpp>
 #include <thallium/serialization/stl/string.hpp>

--- a/Client/cpp/src/PlaybackQueryRpcClient.h
+++ b/Client/cpp/src/PlaybackQueryRpcClient.h
@@ -1,6 +1,9 @@
 #ifndef PLAYBACK_QUERY_RPC_CLIENT_H
 #define PLAYBACK_QUERY_RPC_CLIENT_H
 
+#include <cstdint>
+#include <string>
+
 #include <thallium.hpp>
 
 #include <ServiceId.h>

--- a/Client/cpp/src/PlaybackQueryRpcClient.h
+++ b/Client/cpp/src/PlaybackQueryRpcClient.h
@@ -12,7 +12,7 @@
 
 #include "ClientQueryService.h"
 
-namespace tl= thallium;
+namespace tl = thallium;
 
 namespace chronolog
 {
@@ -20,18 +20,18 @@ namespace chronolog
 class PlaybackQueryRpcClient
 {
 public:
-
     // Service should be created on the heap not the stack thus the constructor is private...
-    static PlaybackQueryRpcClient*
-    CreatePlaybackQueryRpcClient( ClientQueryService & localQueryService, ServiceId const& playback_service_id)
+    static PlaybackQueryRpcClient* CreatePlaybackQueryRpcClient(ClientQueryService& localQueryService,
+                                                                ServiceId const& playback_service_id)
     {
         try
         {
-            return new PlaybackQueryRpcClient( localQueryService, playback_service_id);
+            return new PlaybackQueryRpcClient(localQueryService, playback_service_id);
         }
-        catch(tl::exception const &ex)
+        catch(tl::exception const& ex)
         {
-            LOG_ERROR("[PlaybackQueryRpcClient] Failed to create PlaybackQueryRpcClient for {}", to_string(playback_service_id));
+            LOG_ERROR("[PlaybackQueryRpcClient] Failed to create PlaybackQueryRpcClient for {}",
+                      to_string(playback_service_id));
         }
 
         return nullptr;
@@ -41,25 +41,27 @@ public:
 
     int is_playback_service_available();
 
-    int send_story_playback_request(uint32_t query_id, ChronicleName const & chronicle_name, StoryName const & story_name, uint64_t start_time, uint64_t end_time);
+    int send_story_playback_request(uint32_t query_id,
+                                    ChronicleName const& chronicle_name,
+                                    StoryName const& story_name,
+                                    uint64_t start_time,
+                                    uint64_t end_time);
 
 private:
-
     PlaybackQueryRpcClient() = delete;
-    PlaybackQueryRpcClient(PlaybackQueryRpcClient const &) = delete;
-    PlaybackQueryRpcClient &operator=(PlaybackQueryRpcClient const &) = delete;
+    PlaybackQueryRpcClient(PlaybackQueryRpcClient const&) = delete;
+    PlaybackQueryRpcClient& operator=(PlaybackQueryRpcClient const&) = delete;
 
-    ClientQueryService & theClientQueryService; // ClientQueryService instance
-    ServiceId   playback_service_id;    // ServiceId of remote PlaybackService
-    tl::provider_handle playback_service_handle;  // tl::provider_handle for remote PlaybackService
+    ClientQueryService& theClientQueryService;   // ClientQueryService instance
+    ServiceId playback_service_id;               // ServiceId of remote PlaybackService
+    tl::provider_handle playback_service_handle; // tl::provider_handle for remote PlaybackService
     tl::remote_procedure playback_service_available;
     tl::remote_procedure story_playback_request;
 
     // constructor is private to make sure thalium rpc objects are created on the heap, not stack
-    PlaybackQueryRpcClient(ClientQueryService &, ServiceId const& playback_service_id);
-
+    PlaybackQueryRpcClient(ClientQueryService&, ServiceId const& playback_service_id);
 };
 
-}
+} // namespace chronolog
 
 #endif

--- a/Client/cpp/src/StorytellerClient.cpp
+++ b/Client/cpp/src/StorytellerClient.cpp
@@ -1,7 +1,14 @@
-#include <iostream>
-#include <thallium.hpp>
+#include <atomic>
 #include <chrono>
 #include <climits>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <thallium.hpp>
 
 #include <chronolog_types.h>
 

--- a/Client/cpp/src/StorytellerClient.cpp
+++ b/Client/cpp/src/StorytellerClient.cpp
@@ -28,29 +28,28 @@ uint64_t chronolog::ChronologTimer::getTimestamp()
 }
 
 /////////////////////
-chronolog::StoryHandle::~StoryHandle()
-{}
+chronolog::StoryHandle::~StoryHandle() {}
 
 ////////////////////
 template <class KeeperChoicePolicy>
 // = chronolog::RoundRobinKeeperChoice>
-chronolog::StoryWritingHandle <KeeperChoicePolicy>::~StoryWritingHandle()
+chronolog::StoryWritingHandle<KeeperChoicePolicy>::~StoryWritingHandle()
 {
     delete keeperChoicePolicy;
 }
 
 ////////////////////
 template <class KeeperChoicePolicy>
-void
-chronolog::StoryWritingHandle <KeeperChoicePolicy>::addRecordingClient(chronolog::KeeperRecordingClient*keeperClient)
+void chronolog::StoryWritingHandle<KeeperChoicePolicy>::addRecordingClient(
+        chronolog::KeeperRecordingClient* keeperClient)
 {
     storyKeepers.push_back(keeperClient);
 }
 
 ///////////////////
 template <class KeeperChoicePolicy>
-void
-chronolog::StoryWritingHandle <KeeperChoicePolicy>::removeRecordingClient(chronolog::KeeperIdCard const &keeper_id_card)
+void chronolog::StoryWritingHandle<KeeperChoicePolicy>::removeRecordingClient(
+        chronolog::KeeperIdCard const& keeper_id_card)
 {
     // this should only be called when the ChronoKeeper process unexpectedly exits
     // so it's ok to use rather inefficient vector iteration....
@@ -66,22 +65,29 @@ chronolog::StoryWritingHandle <KeeperChoicePolicy>::removeRecordingClient(chrono
 
 //////////////////
 template <class KeeperChoicePolicy>
-uint64_t chronolog::StoryWritingHandle <KeeperChoicePolicy>::log_event(std::string const &event_record)
+uint64_t chronolog::StoryWritingHandle<KeeperChoicePolicy>::log_event(std::string const& event_record)
 {
-    chronolog::LogEvent log_event(storyId, theClient.getTimestamp(), theClient.getClientId()
-                                  , theClient.get_event_index(), event_record);
+    chronolog::LogEvent log_event(storyId,
+                                  theClient.getTimestamp(),
+                                  theClient.getClientId(),
+                                  theClient.get_event_index(),
+                                  event_record);
 
     auto keeperRecordingClient = keeperChoicePolicy->chooseKeeper(storyKeepers, log_event.time());
-    if(nullptr == keeperRecordingClient)   //very unlikely...
+    if(nullptr == keeperRecordingClient) //very unlikely...
     {
         LOG_WARNING("[StoryWritingHandle] No keeper selected for logging event: {}", event_record);
         return 0;
     }
 
     if(chronolog::CL_SUCCESS == keeperRecordingClient->send_event_msg(log_event))
-    { return log_event.eventTime; }
+    {
+        return log_event.eventTime;
+    }
     else
-    { return 0; }
+    {
+        return 0;
+    }
 }
 /////////////////////
 
@@ -89,7 +95,7 @@ chronolog::StorytellerClient::~StorytellerClient()
 {
     LOG_DEBUG("[StorytellerClient] Destructor called.");
     {
-        std::lock_guard <std::mutex> lock(acquiredStoryMapMutex);
+        std::lock_guard<std::mutex> lock(acquiredStoryMapMutex);
         /*
         //TODO: investigate why the folowing lines were commented out in the previous version
         for( auto story_record_iter : acquiredStoryHandles)
@@ -98,13 +104,10 @@ chronolog::StorytellerClient::~StorytellerClient()
         }
         acquiredStoryHandles.clear();
   */  }
-    // stop & delete keeperRecordingClients
-    std::lock_guard <std::mutex> lock(recordingClientMapMutex);
-    for(auto keeper_client: recordingClientMap)
-    {
-        delete keeper_client.second;
-    }
-    recordingClientMap.clear();
+        // stop & delete keeperRecordingClients
+        std::lock_guard<std::mutex> lock(recordingClientMapMutex);
+        for(auto keeper_client: recordingClientMap) { delete keeper_client.second; }
+        recordingClientMap.clear();
 }
 
 int chronolog::StorytellerClient::get_event_index()
@@ -114,28 +117,31 @@ int chronolog::StorytellerClient::get_event_index()
     // otherwise proceed lock-free
     if((atomic_index == INT_MAX))
     {
-        std::lock_guard <std::mutex> lock(recordingClientMapMutex);
+        std::lock_guard<std::mutex> lock(recordingClientMapMutex);
         //recheck when mutex is acquired, only one thread changes the value
         if(atomic_index == INT_MAX)
-        { atomic_index = 0; }
+        {
+            atomic_index = 0;
+        }
     }
     return ++atomic_index;
 }
 ////////////////
 
 
-int chronolog::StorytellerClient::addKeeperRecordingClient(chronolog::KeeperIdCard const &keeper_id_card)
+int chronolog::StorytellerClient::addKeeperRecordingClient(chronolog::KeeperIdCard const& keeper_id_card)
 {
-    std::lock_guard <std::mutex> lock(recordingClientMapMutex);
+    std::lock_guard<std::mutex> lock(recordingClientMapMutex);
 
     try
     {
-        chronolog::KeeperRecordingClient*keeperRecordingClient = chronolog::KeeperRecordingClient::CreateKeeperRecordingClient(
-                client_engine, keeper_id_card);
+        chronolog::KeeperRecordingClient* keeperRecordingClient =
+                chronolog::KeeperRecordingClient::CreateKeeperRecordingClient(client_engine, keeper_id_card);
 
-        auto insert_return = recordingClientMap.insert(
-                std::pair <std::pair <uint32_t, uint16_t>, chronolog::KeeperRecordingClient*>(
-                        keeper_id_card.getRecordingServiceId().get_service_endpoint(), keeperRecordingClient));
+        auto insert_return =
+                recordingClientMap.insert(std::pair<std::pair<uint32_t, uint16_t>, chronolog::KeeperRecordingClient*>(
+                        keeper_id_card.getRecordingServiceId().get_service_endpoint(),
+                        keeperRecordingClient));
         if(false == insert_return.second)
         {
             LOG_ERROR("[StorytellerClient] Failed to create KeeperRecordingClient for {}", to_string(keeper_id_card));
@@ -143,7 +149,7 @@ int chronolog::StorytellerClient::addKeeperRecordingClient(chronolog::KeeperIdCa
         }
         LOG_INFO("[StorytellerClient] Added KeeperRecordingClient for {}", to_string(keeper_id_card));
     }
-    catch(tl::exception const &ex)
+    catch(tl::exception const& ex)
     {
         LOG_ERROR("[StorytellerClient] Failed to create KeeperRecordingClient for {}", to_string(keeper_id_card));
     }
@@ -154,16 +160,16 @@ int chronolog::StorytellerClient::addKeeperRecordingClient(chronolog::KeeperIdCa
 }
 /////////////////
 
-int chronolog::StorytellerClient::removeKeeperRecordingClient(chronolog::KeeperIdCard const &keeper_id_card)
+int chronolog::StorytellerClient::removeKeeperRecordingClient(chronolog::KeeperIdCard const& keeper_id_card)
 {
-    std::lock_guard <std::mutex> lock(recordingClientMapMutex);
+    std::lock_guard<std::mutex> lock(recordingClientMapMutex);
 
     // stop & delete keeperRecordingClient before erasing keeper_process entry
     auto keeper_client_iter = recordingClientMap.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
-        
+
     if(keeper_client_iter != recordingClientMap.end())
     {
-        delete (*keeper_client_iter).second;
+        delete(*keeper_client_iter).second;
         recordingClientMap.erase(keeper_client_iter);
     }
 
@@ -176,22 +182,25 @@ int chronolog::StorytellerClient::removeKeeperRecordingClient(chronolog::KeeperI
 }
 
 ///////////////////////////
-chronolog::StoryHandle*
-chronolog::StorytellerClient::findStoryWritingHandle(ChronicleName const &chronicle, StoryName const &story)
+chronolog::StoryHandle* chronolog::StorytellerClient::findStoryWritingHandle(ChronicleName const& chronicle,
+                                                                             StoryName const& story)
 {
-    std::lock_guard <std::mutex> lock(acquiredStoryMapMutex);
+    std::lock_guard<std::mutex> lock(acquiredStoryMapMutex);
 
-    auto story_record_iter = acquiredStoryHandles.find(std::pair <std::string, std::string>(chronicle, story));
+    auto story_record_iter = acquiredStoryHandles.find(std::pair<std::string, std::string>(chronicle, story));
     if(story_record_iter != acquiredStoryHandles.end())
     {
-        LOG_DEBUG("[StorytellerClient::findStoryWritingHandle] Found StoryHandle for Chronicle: '{}' and Story: '{}'."
-             , chronicle, story);
+        LOG_DEBUG("[StorytellerClient::findStoryWritingHandle] Found StoryHandle for Chronicle: '{}' and Story: '{}'.",
+                  chronicle,
+                  story);
         return ((*story_record_iter).second);
     }
     else
     {
-        LOG_DEBUG("[StorytellerClient::findStoryWritingHandle] StoryHandle not found for Chronicle: '{}' and Story: '{}'."
-             , chronicle, story);
+        LOG_DEBUG("[StorytellerClient::findStoryWritingHandle] StoryHandle not found for Chronicle: '{}' and Story: "
+                  "'{}'.",
+                  chronicle,
+                  story);
         return (nullptr);
     }
 }
@@ -199,56 +208,64 @@ chronolog::StorytellerClient::findStoryWritingHandle(ChronicleName const &chroni
 /////////////
 
 chronolog::StoryHandle*
-chronolog::StorytellerClient::initializeStoryWritingHandle(ChronicleName const &chronicle, StoryName const &story
-                                                           , StoryId const &story_id
-                                                           , std::vector <KeeperIdCard> const &vectorOfKeepers
-                        , chl::ServiceId const & player_card)
+chronolog::StorytellerClient::initializeStoryWritingHandle(ChronicleName const& chronicle,
+                                                           StoryName const& story,
+                                                           StoryId const& story_id,
+                                                           std::vector<KeeperIdCard> const& vectorOfKeepers,
+                                                           chl::ServiceId const& player_card)
 //INNA: TODO :KeeperChoicePolicy will have to be communicated here as well ....
 {
-    std::lock_guard <std::mutex> lock(acquiredStoryMapMutex);
+    std::lock_guard<std::mutex> lock(acquiredStoryMapMutex);
 
-    auto story_record_iter = acquiredStoryHandles.find(std::pair <std::string, std::string>(chronicle, story));
+    auto story_record_iter = acquiredStoryHandles.find(std::pair<std::string, std::string>(chronicle, story));
     if(story_record_iter != acquiredStoryHandles.end())
     {
-        LOG_DEBUG("[StorytellerClient] StoryHandle already exists for Chronicle: '{}' and Story: '{}'.", chronicle, story);
+        LOG_DEBUG("[StorytellerClient] StoryHandle already exists for Chronicle: '{}' and Story: '{}'.",
+                  chronicle,
+                  story);
         return story_record_iter->second;
     }
 
-    // create new StoryWritingHandle & initialize it's keeperClients vector    
-    chronolog::StoryWritingHandle <RoundRobinKeeperChoice>*storyWritingHandle = new StoryWritingHandle <RoundRobinKeeperChoice>(
-            *this, chronicle, story, story_id);
+    // create new StoryWritingHandle & initialize it's keeperClients vector
+    chronolog::StoryWritingHandle<RoundRobinKeeperChoice>* storyWritingHandle =
+            new StoryWritingHandle<RoundRobinKeeperChoice>(*this, chronicle, story, story_id);
 
     for(KeeperIdCard keeper_id_card: vectorOfKeepers)
     {
-        auto keeper_client_iter = recordingClientMap.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
+        auto keeper_client_iter =
+                recordingClientMap.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
 
         if(keeper_client_iter == recordingClientMap.end())
         {
             // unlikely but we better check
             if(addKeeperRecordingClient(keeper_id_card) == 0)
             {
-                LOG_WARNING("[StorytellerClient] Failed to add KeeperRecordingClient for {}",  to_string(keeper_id_card));
+                LOG_WARNING("[StorytellerClient] Failed to add KeeperRecordingClient for {}",
+                            to_string(keeper_id_card));
                 continue;
             }
         }
         keeper_client_iter = recordingClientMap.find(keeper_id_card.getRecordingServiceId().get_service_endpoint());
-                
+
         storyWritingHandle->addRecordingClient((*keeper_client_iter).second);
     }
 
-    auto insert_return = acquiredStoryHandles.insert(
-            std::pair <std::pair <std::string, std::string>, chronolog::StoryHandle*>(
-                    std::pair <std::string, std::string>(chronicle, story), storyWritingHandle));
+    auto insert_return =
+            acquiredStoryHandles.insert(std::pair<std::pair<std::string, std::string>, chronolog::StoryHandle*>(
+                    std::pair<std::string, std::string>(chronicle, story),
+                    storyWritingHandle));
     if(!insert_return.second)
     {
-        LOG_ERROR("[StorytellerClient] Failed to insert StoryWritingHandle for Chronicle: '{}' and Story: '{}'.", chronicle
-             , story);
+        LOG_ERROR("[StorytellerClient] Failed to insert StoryWritingHandle for Chronicle: '{}' and Story: '{}'.",
+                  chronicle,
+                  story);
         delete storyWritingHandle;
         return nullptr;
     }
 
-    LOG_INFO("[StorytellerClient] Successfully initialized StoryWritingHandle for Chronicle: '{}' and Story: '{}'."
-         , chronicle, story);
+    LOG_INFO("[StorytellerClient] Successfully initialized StoryWritingHandle for Chronicle: '{}' and Story: '{}'.",
+             chronicle,
+             story);
     return storyWritingHandle;
     /*
     // now check the state of the handle:
@@ -264,25 +281,25 @@ chronolog::StorytellerClient::initializeStoryWritingHandle(ChronicleName const &
 }
 
 //////////////////////
-void chronolog::StorytellerClient::removeAcquiredStoryHandle(ChronicleName const &chronicle, StoryName const &story)
+void chronolog::StorytellerClient::removeAcquiredStoryHandle(ChronicleName const& chronicle, StoryName const& story)
 {
-    std::lock_guard <std::mutex> lock(acquiredStoryMapMutex);
+    std::lock_guard<std::mutex> lock(acquiredStoryMapMutex);
 
-    auto story_record_iter = acquiredStoryHandles.find(std::pair <std::string, std::string>(chronicle, story));
+    auto story_record_iter = acquiredStoryHandles.find(std::pair<std::string, std::string>(chronicle, story));
     if(story_record_iter != acquiredStoryHandles.end())
     {
-        delete (*story_record_iter).second;
+        delete(*story_record_iter).second;
         acquiredStoryHandles.erase(story_record_iter);
-        LOG_INFO("[StorytellerClient] Successfully removed StoryHandle for Chronicle: '{}' and Story: '{}'.", chronicle
-             , story);
+        LOG_INFO("[StorytellerClient] Successfully removed StoryHandle for Chronicle: '{}' and Story: '{}'.",
+                 chronicle,
+                 story);
     }
     else
     {
-        LOG_WARNING("[StorytellerClient] No matching StoryHandle found for Chronicle: '{}' and Story: '{}'.", chronicle
-             , story);
+        LOG_WARNING("[StorytellerClient] No matching StoryHandle found for Chronicle: '{}' and Story: '{}'.",
+                    chronicle,
+                    story);
     }
 }
 
 /////////////////
-
-

--- a/Client/cpp/src/StorytellerClient.h
+++ b/Client/cpp/src/StorytellerClient.h
@@ -31,8 +31,8 @@ class PlaybackQueryRpcClient;
 class RoundRobinKeeperChoice
 {
 public:
-    KeeperRecordingClient*
-    chooseKeeper(std::vector <KeeperRecordingClient*> const &vectorOfKeepers, uint64_t chrono_tick)
+    KeeperRecordingClient* chooseKeeper(std::vector<KeeperRecordingClient*> const& vectorOfKeepers,
+                                        uint64_t chrono_tick)
     {
         return vectorOfKeepers[chrono_tick % vectorOfKeepers.size()];
     }
@@ -42,9 +42,7 @@ public:
 class StorytellerClient
 {
 public:
-    StorytellerClient(ChronologTimer &chronolog_timer 
-           , thallium::engine &client_tl_engine
-           , ClientId const &client_id)
+    StorytellerClient(ChronologTimer& chronolog_timer, thallium::engine& client_tl_engine, ClientId const& client_id)
         : theTimer(chronolog_timer)
         , client_engine(client_tl_engine)
         , clientId(client_id)
@@ -54,42 +52,42 @@ public:
 
     ~StorytellerClient();
 
-    int addKeeperRecordingClient(KeeperIdCard const &);
-    int removeKeeperRecordingClient(KeeperIdCard const &);
+    int addKeeperRecordingClient(KeeperIdCard const&);
+    int removeKeeperRecordingClient(KeeperIdCard const&);
 
-    StoryHandle*findStoryWritingHandle(ChronicleName const &, StoryName const &);
+    StoryHandle* findStoryWritingHandle(ChronicleName const&, StoryName const&);
 
-    StoryHandle*initializeStoryWritingHandle(ChronicleName const &, StoryName const &, StoryId const &
-                                             , std::vector <KeeperIdCard> const &, ServiceId const&);
+    StoryHandle* initializeStoryWritingHandle(ChronicleName const&,
+                                              StoryName const&,
+                                              StoryId const&,
+                                              std::vector<KeeperIdCard> const&,
+                                              ServiceId const&);
 
-    void removeAcquiredStoryHandle(ChronicleName const &, StoryName const &);
+    void removeAcquiredStoryHandle(ChronicleName const&, StoryName const&);
 
-    uint64_t getTimestamp()
-    { return theTimer.getTimestamp(); }
+    uint64_t getTimestamp() { return theTimer.getTimestamp(); }
 
-    ClientId const &getClientId() const
-    { return clientId; }
+    ClientId const& getClientId() const { return clientId; }
 
     int get_event_index();
 
- //   ServiceId const& get_local_service_id() const    { return theClientQueryService.get_service_id(); }
+    //   ServiceId const& get_local_service_id() const    { return theClientQueryService.get_service_id(); }
 
 private:
-    StorytellerClient(StorytellerClient const &) = delete;
+    StorytellerClient(StorytellerClient const&) = delete;
 
-    StorytellerClient &operator=(StorytellerClient const &) = delete;
+    StorytellerClient& operator=(StorytellerClient const&) = delete;
 
-    ChronologTimer &theTimer;
-    thallium::engine & client_engine;
+    ChronologTimer& theTimer;
+    thallium::engine& client_engine;
     ClientId clientId;
-    std::atomic <int> atomic_index;
+    std::atomic<int> atomic_index;
 
     std::mutex recordingClientMapMutex;
     std::mutex acquiredStoryMapMutex;
 
-    std::map <std::pair <uint32_t, uint16_t>, KeeperRecordingClient*> recordingClientMap;
-    std::map <std::pair <std::string, std::string>, StoryHandle*> acquiredStoryHandles;
-
+    std::map<std::pair<uint32_t, uint16_t>, KeeperRecordingClient*> recordingClientMap;
+    std::map<std::pair<std::string, std::string>, StoryHandle*> acquiredStoryHandles;
 };
 
 
@@ -98,35 +96,38 @@ template <class KeeperChoicePolicy>
 class StoryWritingHandle: public StoryHandle
 {
 public:
-    StoryWritingHandle(StorytellerClient &client, ChronicleName const &a_chronicle, StoryName const &a_story , StoryId const &story_id)
+    StoryWritingHandle(StorytellerClient& client,
+                       ChronicleName const& a_chronicle,
+                       StoryName const& a_story,
+                       StoryId const& story_id)
         : theClient(client)
-        , chronicle(a_chronicle), story(a_story), storyId(story_id)
+        , chronicle(a_chronicle)
+        , story(a_story)
+        , storyId(story_id)
         , keeperChoicePolicy(new KeeperChoicePolicy)
-     //   , playbackQueryClient(nullptr)
+    //   , playbackQueryClient(nullptr)
     {
         LOG_DEBUG("[StoryWritingHandle] Initialized for Chronicle: {}, Story: {}", a_chronicle, a_story);
     }
 
     virtual ~StoryWritingHandle();
 
-    virtual uint64_t log_event(std::string const &);
+    virtual uint64_t log_event(std::string const&);
 
-   // virtual int log_event(size_t size, void*data);
+    // virtual int log_event(size_t size, void*data);
 
     void addRecordingClient(KeeperRecordingClient*);
-    void removeRecordingClient(KeeperIdCard const &);
+    void removeRecordingClient(KeeperIdCard const&);
 
 private:
-
-    StorytellerClient &theClient;
+    StorytellerClient& theClient;
     ChronicleName chronicle;
     StoryName story;
     StoryId storyId;
-    KeeperChoicePolicy*keeperChoicePolicy;
-    std::vector <KeeperRecordingClient*> storyKeepers;
-    
+    KeeperChoicePolicy* keeperChoicePolicy;
+    std::vector<KeeperRecordingClient*> storyKeepers;
 };
 
-}//namespace
+} // namespace chronolog
 
 #endif

--- a/Client/cpp/src/StorytellerClient.h
+++ b/Client/cpp/src/StorytellerClient.h
@@ -1,9 +1,14 @@
 #ifndef STORYTELLER_CLIENT_H
 #define STORYTELLER_CLIENT_H
 
-
 #include <atomic>
+#include <cstdint>
 #include <map>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <thallium.hpp>
 
 #include <chrono_monitor.h>

--- a/Client/cpp/src/chrono_monitor.cpp
+++ b/Client/cpp/src/chrono_monitor.cpp
@@ -19,21 +19,25 @@
 namespace chronolog
 {
 
-std::shared_ptr <spdlog::logger> chrono_monitor::logger = nullptr;
+std::shared_ptr<spdlog::logger> chrono_monitor::logger = nullptr;
 std::mutex chrono_monitor::mutex;
 
-int chrono_monitor::initialize(const std::string &logType, const std::string &location, spdlog::level::level_enum logLevel
-                               , const std::string &loggerName, const std::size_t &logFileSize, const std::size_t &logFileNum
-                               , spdlog::level::level_enum flushLevel)
+int chrono_monitor::initialize(const std::string& logType,
+                               const std::string& location,
+                               spdlog::level::level_enum logLevel,
+                               const std::string& loggerName,
+                               const std::size_t& logFileSize,
+                               const std::size_t& logFileNum,
+                               spdlog::level::level_enum flushLevel)
 {
-    std::lock_guard <std::mutex> lock(mutex);
+    std::lock_guard<std::mutex> lock(mutex);
     if(logger)
     {
         return 0;
     }
     try
     {
-        std::shared_ptr <spdlog::sinks::sink> sink = nullptr;
+        std::shared_ptr<spdlog::sinks::sink> sink = nullptr;
         if(logType == "file")
         {
             /*
@@ -42,22 +46,22 @@ int chrono_monitor::initialize(const std::string &logType, const std::string &lo
              * They use C++ standard library clock:
              * Link: https://github.com/gabime/spdlog/blob/696db97f672e9082e50e50af315d0f4234c82397/include/spdlog/common.h#L141
              */
-            sink = std::make_shared <spdlog::sinks::rotating_file_sink_mt>(location, logFileSize, logFileNum);
+            sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(location, logFileSize, logFileNum);
         }
         else if(logType == "console")
         {
-            sink = std::make_shared <spdlog::sinks::stdout_color_sink_mt>();
+            sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
         }
         else
         {
             std::cerr << "[Logger] Invalid log type" << std::endl;
             return 1;
         }
-        logger = std::make_shared <spdlog::logger>(loggerName, sink);
+        logger = std::make_shared<spdlog::logger>(loggerName, sink);
         logger->flush_on(flushLevel);
         logger->set_level(logLevel);
     }
-    catch(const spdlog::spdlog_ex &ex)
+    catch(const spdlog::spdlog_ex& ex)
     {
         std::cerr << "[Logger] Logger initialization failed: " << ex.what() << std::endl;
         return 1;
@@ -65,7 +69,7 @@ int chrono_monitor::initialize(const std::string &logType, const std::string &lo
     return 0; // already initialized
 }
 
-spdlog::logger &chrono_monitor::getInstance()
+spdlog::logger& chrono_monitor::getInstance()
 {
     if(logger)
     {

--- a/Client/cpp/src/chrono_monitor.cpp
+++ b/Client/cpp/src/chrono_monitor.cpp
@@ -2,10 +2,16 @@
 // Created by eneko on 12/1/23.
 //
 
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/sinks/rotating_file_sink.h>
+#include <cstddef>
+#include <cstdlib>
 #include <iostream>
-#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 #include <chrono_monitor.h>
 

--- a/Client/cpp/src/rpcVisorClient.h
+++ b/Client/cpp/src/rpcVisorClient.h
@@ -33,13 +33,13 @@ class RpcVisorClient
 
 public:
     static RpcVisorClient*
-    CreateRpcVisorClient(tl::engine &tl_engine, std::string const &service_addr, uint16_t provider_id)
+    CreateRpcVisorClient(tl::engine& tl_engine, std::string const& service_addr, uint16_t provider_id)
     {
         try
         {
             return new RpcVisorClient(tl_engine, service_addr, provider_id);
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[RpcVisorClient] Failed to create client instance due to a Thallium exception.");
         }
@@ -49,23 +49,27 @@ public:
 
     ConnectResponseMsg Connect(uint32_t client_euid, uint32_t client_host_ip, uint32_t client_pid)
     {
-        LOG_DEBUG("[RpcVisorClient] Initiating connection for Account={}, HostID={}, PID={}", client_euid, client_host_ip
-             , client_pid);
+        LOG_DEBUG("[RpcVisorClient] Initiating connection for Account={}, HostID={}, PID={}",
+                  client_euid,
+                  client_host_ip,
+                  client_pid);
         try
         {
             ConnectResponseMsg response = visor_connect.on(service_ph)(client_euid, client_host_ip, client_pid);
-            LOG_INFO("[RpcVisorClient] Connection successful for Account={}, HostID={}, PID={}", client_euid, client_host_ip
-                 , client_pid);
+            LOG_INFO("[RpcVisorClient] Connection successful for Account={}, HostID={}, PID={}",
+                     client_euid,
+                     client_host_ip,
+                     client_pid);
             return response;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[RpcVisorClient] Connection attempt failed.");
         }
         return (ConnectResponseMsg(chronolog::CL_ERR_UNKNOWN, ClientId{0}));
     }
 
-    int Disconnect(ClientId const &client_id)
+    int Disconnect(ClientId const& client_id)
     {
         LOG_INFO("[RPCVisorClient] Initiating disconnection for ClientID={}", client_id);
         try
@@ -77,23 +81,25 @@ public:
             }
             else
             {
-                LOG_ERROR("[RPCVisorClient] Failed to disconnect ClientID={}. Unexpected return code: {}", client_id
-                     , chronolog::to_string_client(result));
+                LOG_ERROR("[RPCVisorClient] Failed to disconnect ClientID={}. Unexpected return code: {}",
+                          client_id,
+                          chronolog::to_string_client(result));
             }
             return result;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[RPCVisorClient] Failed to disconnect. Thallium exception encountered.");
         }
         return (chronolog::CL_ERR_UNKNOWN);
     }
 
-    int CreateChronicle(ClientId const &client_id, std::string const &name
-                        , const std::map <std::string, std::string> &attrs, int &flags)
+    int CreateChronicle(ClientId const& client_id,
+                        std::string const& name,
+                        const std::map<std::string, std::string>& attrs,
+                        int& flags)
     {
-        LOG_INFO("[RPCVisorClient] Initiating creation of chronicle: Name={}, Flags={}", name.c_str()
-             , flags);
+        LOG_INFO("[RPCVisorClient] Initiating creation of chronicle: Name={}, Flags={}", name.c_str(), flags);
         try
         {
             int result = create_chronicle.on(service_ph)(client_id, name, attrs, flags);
@@ -104,20 +110,22 @@ public:
             }
             else
             {
-                LOG_ERROR("[RPCVisorClient] Failed to create chronicle with Name={}, Flags={}. Unexpected return code: {}"
-                     , name.c_str(), flags, chronolog::to_string_client(result));
+                LOG_ERROR("[RPCVisorClient] Failed to create chronicle with Name={}, Flags={}. Unexpected return code: "
+                          "{}",
+                          name.c_str(),
+                          flags,
+                          chronolog::to_string_client(result));
             }
             return result;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[RPCVisorClient] Failed to create chronicle {}. Thallium exception encountered.", name.c_str());
         }
         return (chronolog::CL_ERR_UNKNOWN);
-
     }
 
-    int DestroyChronicle(ClientId const &client_id, std::string const &name)
+    int DestroyChronicle(ClientId const& client_id, std::string const& name)
     {
         LOG_INFO("[RPCVisorClient] Initiating destruction of chronicle: Name={}", name.c_str());
         try
@@ -130,109 +138,128 @@ public:
             }
             else
             {
-                LOG_ERROR("[RPCVisorClient] Failed to destroy chronicle: Name={}, Error Code={}", name.c_str(), chronolog::to_string_client(result));
+                LOG_ERROR("[RPCVisorClient] Failed to destroy chronicle: Name={}, Error Code={}",
+                          name.c_str(),
+                          chronolog::to_string_client(result));
             }
             return result;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
             LOG_ERROR("[RPCVisorClient] Failed to destroy chronicle {}. Thallium exception encountered.", name.c_str());
         }
         return (chronolog::CL_ERR_UNKNOWN);
     }
 
-    chronolog::AcquireStoryResponseMsg
-    AcquireStory(ClientId const &client_id, std::string const &chronicle_name, std::string const &story_name
-                 , const std::map <std::string, std::string> &attrs, const int &flags)
+    chronolog::AcquireStoryResponseMsg AcquireStory(ClientId const& client_id,
+                                                    std::string const& chronicle_name,
+                                                    std::string const& story_name,
+                                                    const std::map<std::string, std::string>& attrs,
+                                                    const int& flags)
     {
-        LOG_INFO("[RPCVisorClient] Initiating story acquisition: ChronicleName={}, StoryName={}", chronicle_name.c_str()
-             , story_name.c_str());
+        LOG_INFO("[RPCVisorClient] Initiating story acquisition: ChronicleName={}, StoryName={}",
+                 chronicle_name.c_str(),
+                 story_name.c_str());
         try
         {
-            chronolog::AcquireStoryResponseMsg response = acquire_story.on(service_ph)(client_id, chronicle_name
-                                                                                       , story_name, attrs, flags);
+            chronolog::AcquireStoryResponseMsg response =
+                    acquire_story.on(service_ph)(client_id, chronicle_name, story_name, attrs, flags);
 
             if(response.getErrorCode() == chronolog::CL_SUCCESS)
             {
-                LOG_INFO("[RPCVisorClient] Successfully acquired story: ChronicleName={}, StoryName={}"
-                     , chronicle_name.c_str(), story_name.c_str());
+                LOG_INFO("[RPCVisorClient] Successfully acquired story: ChronicleName={}, StoryName={}",
+                         chronicle_name.c_str(),
+                         story_name.c_str());
             }
             else
             {
-                LOG_ERROR("[RPCVisorClient] Failed to acquire story: ChronicleName={}, StoryName={}, Error Code={}"
-                     , chronicle_name.c_str(), story_name.c_str(), chronolog::to_string_client(response.getErrorCode()));
+                LOG_ERROR("[RPCVisorClient] Failed to acquire story: ChronicleName={}, StoryName={}, Error Code={}",
+                          chronicle_name.c_str(),
+                          story_name.c_str(),
+                          chronolog::to_string_client(response.getErrorCode()));
             }
 
             return response;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
-            LOG_ERROR("[RPCVisorClient] Failed to acquire story {} from chronicle {}. Thallium exception encountered."
-                 , story_name.c_str(), chronicle_name.c_str());
+            LOG_ERROR("[RPCVisorClient] Failed to acquire story {} from chronicle {}. Thallium exception encountered.",
+                      story_name.c_str(),
+                      chronicle_name.c_str());
         }
-        return (AcquireStoryResponseMsg(chronolog::CL_ERR_UNKNOWN, 0, std::vector <KeeperIdCard>{}));
+        return (AcquireStoryResponseMsg(chronolog::CL_ERR_UNKNOWN, 0, std::vector<KeeperIdCard>{}));
     }
 
-    int ReleaseStory(ClientId const &client_id, std::string const &chronicle_name, std::string const &story_name)
+    int ReleaseStory(ClientId const& client_id, std::string const& chronicle_name, std::string const& story_name)
     {
-        LOG_INFO("[RPCVisorClient] Initiating story release: ChronicleName={}, StoryName={}", chronicle_name.c_str()
-             , story_name.c_str());
+        LOG_INFO("[RPCVisorClient] Initiating story release: ChronicleName={}, StoryName={}",
+                 chronicle_name.c_str(),
+                 story_name.c_str());
         try
         {
             int resultCode = release_story.on(service_ph)(client_id, chronicle_name, story_name);
 
             if(resultCode == chronolog::CL_SUCCESS)
             {
-                LOG_INFO("[RPCVisorClient] Successfully released story: ChronicleName={}, StoryName={}"
-                     , chronicle_name.c_str(), story_name.c_str());
+                LOG_INFO("[RPCVisorClient] Successfully released story: ChronicleName={}, StoryName={}",
+                         chronicle_name.c_str(),
+                         story_name.c_str());
             }
             else
             {
-                LOG_ERROR("[RPCVisorClient] Failed to release story: ChronicleName={}, StoryName={}, Error Code={}"
-                     , chronicle_name.c_str(), story_name.c_str(), chronolog::to_string_client(resultCode));
+                LOG_ERROR("[RPCVisorClient] Failed to release story: ChronicleName={}, StoryName={}, Error Code={}",
+                          chronicle_name.c_str(),
+                          story_name.c_str(),
+                          chronolog::to_string_client(resultCode));
             }
 
             return resultCode;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
-            LOG_ERROR("[RPCVisorClient] Failed to release story {} from chronicle {}. Thallium exception encountered."
-                 , story_name.c_str(), chronicle_name.c_str());
+            LOG_ERROR("[RPCVisorClient] Failed to release story {} from chronicle {}. Thallium exception encountered.",
+                      story_name.c_str(),
+                      chronicle_name.c_str());
         }
         return (chronolog::CL_ERR_UNKNOWN);
     }
 
-    int DestroyStory(ClientId const &client_id, std::string const &chronicle_name, std::string const &story_name)
+    int DestroyStory(ClientId const& client_id, std::string const& chronicle_name, std::string const& story_name)
     {
-        LOG_INFO("[RPCVisorClient] Initiating story destruction: ChronicleName={}, StoryName={}", chronicle_name.c_str()
-             , story_name.c_str());
+        LOG_INFO("[RPCVisorClient] Initiating story destruction: ChronicleName={}, StoryName={}",
+                 chronicle_name.c_str(),
+                 story_name.c_str());
         try
         {
             int resultCode = destroy_story.on(service_ph)(client_id, chronicle_name, story_name);
 
             if(resultCode == chronolog::CL_SUCCESS)
             {
-                LOG_INFO("[RPCVisorClient] Successfully destroyed story: ChronicleName={}, StoryName={}"
-                     , chronicle_name.c_str(), story_name.c_str());
+                LOG_INFO("[RPCVisorClient] Successfully destroyed story: ChronicleName={}, StoryName={}",
+                         chronicle_name.c_str(),
+                         story_name.c_str());
             }
             else
             {
-                LOG_ERROR("[RPCVisorClient] Failed to destroy story: ChronicleName={}, StoryName={}, Error Code={}"
-                     , chronicle_name.c_str(), story_name.c_str(), chronolog::to_string_client(resultCode));
+                LOG_ERROR("[RPCVisorClient] Failed to destroy story: ChronicleName={}, StoryName={}, Error Code={}",
+                          chronicle_name.c_str(),
+                          story_name.c_str(),
+                          chronolog::to_string_client(resultCode));
             }
 
             return resultCode;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
-            LOG_ERROR("[RPCVisorClient] Failed to destroy story {} from chronicle {}. Thallium exception encountered."
-                 , story_name.c_str(), chronicle_name.c_str());
+            LOG_ERROR("[RPCVisorClient] Failed to destroy story {} from chronicle {}. Thallium exception encountered.",
+                      story_name.c_str(),
+                      chronicle_name.c_str());
         }
         return (chronolog::CL_ERR_UNKNOWN);
     }
 
 
-    int GetChronicleAttr(ClientId const &client_id, std::string const &name, const std::string &key, std::string &value)
+    int GetChronicleAttr(ClientId const& client_id, std::string const& name, const std::string& key, std::string& value)
     {
         LOG_INFO("[RPCVisorClient] Retrieving attribute: ChronicleName={}, Key={}", name.c_str(), key.c_str());
         try
@@ -241,66 +268,84 @@ public:
 
             if(resultCode == chronolog::CL_SUCCESS)
             {
-                LOG_INFO("[RPCVisorClient] Successfully retrieved attribute: ChronicleName={}, Key={}, Value={}"
-                     , name.c_str(), key.c_str(), value.c_str());
+                LOG_INFO("[RPCVisorClient] Successfully retrieved attribute: ChronicleName={}, Key={}, Value={}",
+                         name.c_str(),
+                         key.c_str(),
+                         value.c_str());
             }
             else
             {
-                LOG_ERROR("[RPCVisorClient] Failed to retrieve attribute: ChronicleName={}, Key={}, Error Code={}"
-                     , name.c_str(), key.c_str(), chronolog::to_string_client(resultCode));
+                LOG_ERROR("[RPCVisorClient] Failed to retrieve attribute: ChronicleName={}, Key={}, Error Code={}",
+                          name.c_str(),
+                          key.c_str(),
+                          chronolog::to_string_client(resultCode));
             }
 
             return resultCode;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
-            LOG_ERROR("[RPCVisorClient] Failed to retrieve attribute {} from chronicle {}. Thallium exception encountered."
-                 , key.c_str(), name.c_str());
+            LOG_ERROR("[RPCVisorClient] Failed to retrieve attribute {} from chronicle {}. Thallium exception "
+                      "encountered.",
+                      key.c_str(),
+                      name.c_str());
         }
         return (chronolog::CL_ERR_UNKNOWN);
     }
 
-    int EditChronicleAttr(ClientId const &client_id, std::string const &name, const std::string &key
-                          , const std::string &value)
+    int EditChronicleAttr(ClientId const& client_id,
+                          std::string const& name,
+                          const std::string& key,
+                          const std::string& value)
     {
-        LOG_INFO("[RPCVisorClient] Modifying attribute: ChronicleName={}, Key={}, NewValue={}", name.c_str(), key.c_str()
-             , value.c_str());
+        LOG_INFO("[RPCVisorClient] Modifying attribute: ChronicleName={}, Key={}, NewValue={}",
+                 name.c_str(),
+                 key.c_str(),
+                 value.c_str());
         try
         {
             int resultCode = edit_chronicle_attr.on(service_ph)(client_id, name, key, value);
 
             if(resultCode == chronolog::CL_SUCCESS)
             {
-                LOG_INFO("[RPCVisorClient] Successfully modified attribute: ChronicleName={}, Key={}, NewValue={}"
-                     , name.c_str(), key.c_str(), value.c_str());
+                LOG_INFO("[RPCVisorClient] Successfully modified attribute: ChronicleName={}, Key={}, NewValue={}",
+                         name.c_str(),
+                         key.c_str(),
+                         value.c_str());
             }
             else
             {
-                LOG_ERROR("[RPCVisorClient] Failed to modify attribute: ChronicleName={}, Key={}, NewValue={}, Error Code={}"
-                     , name.c_str(), key.c_str(), value.c_str(), chronolog::to_string_client(resultCode));
+                LOG_ERROR("[RPCVisorClient] Failed to modify attribute: ChronicleName={}, Key={}, NewValue={}, Error "
+                          "Code={}",
+                          name.c_str(),
+                          key.c_str(),
+                          value.c_str(),
+                          chronolog::to_string_client(resultCode));
             }
 
             return resultCode;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
-            LOG_ERROR("[RPCVisorClient] Failed to modify attribute {} of chronicle {}. Thallium exception encountered."
-                 , key.c_str(), name.c_str());
+            LOG_ERROR("[RPCVisorClient] Failed to modify attribute {} of chronicle {}. Thallium exception encountered.",
+                      key.c_str(),
+                      name.c_str());
         }
         return (chronolog::CL_ERR_UNKNOWN);
     }
 
-    std::vector <std::string> ShowChronicles(ClientId const &client_id) //, std::vector<std::string> & chronicles)
+    std::vector<std::string> ShowChronicles(ClientId const& client_id) //, std::vector<std::string> & chronicles)
     {
         LOG_INFO("[RPCVisorClient] Attempting to retrieve list of chronicles for ClientID={}", client_id);
         try
         {
-            std::vector <std::string> chronicleList = show_chronicles.on(service_ph)(client_id);
+            std::vector<std::string> chronicleList = show_chronicles.on(service_ph)(client_id);
 
             if(!chronicleList.empty())
             {
-                LOG_INFO("[RPCVisorClient] Successfully fetched {} chronicles for ClientID={}", chronicleList.size()
-                     , client_id);
+                LOG_INFO("[RPCVisorClient] Successfully fetched {} chronicles for ClientID={}",
+                         chronicleList.size(),
+                         client_id);
             }
             else
             {
@@ -308,42 +353,48 @@ public:
             }
             return chronicleList;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
-            LOG_ERROR("[RPCVisorClient] Failed to fetch chronicles for ClientID {}. Thallium exception encountered."
-                 , client_id);
+            LOG_ERROR("[RPCVisorClient] Failed to fetch chronicles for ClientID {}. Thallium exception encountered.",
+                      client_id);
         }
-        return (std::vector <std::string>{});
+        return (std::vector<std::string>{});
     }
 
-    std::vector <std::string>
-    ShowStories(ClientId const &client_id, std::string const &chronicle_name) //, std::vector<std::string> & stories )
+    std::vector<std::string> ShowStories(ClientId const& client_id,
+                                         std::string const& chronicle_name) //, std::vector<std::string> & stories )
     {
-        LOG_INFO("[RPCVisorClient] Attempting to retrieve stories for ClientID={}, ChronicleName={}", client_id
-             , chronicle_name);
+        LOG_INFO("[RPCVisorClient] Attempting to retrieve stories for ClientID={}, ChronicleName={}",
+                 client_id,
+                 chronicle_name);
         try
         {
-            std::vector <std::string> storyList = show_stories.on(service_ph)(client_id, chronicle_name);
+            std::vector<std::string> storyList = show_stories.on(service_ph)(client_id, chronicle_name);
 
             if(!storyList.empty())
             {
-                LOG_INFO("[RPCVisorClient] Successfully fetched {} stories for ClientID={} from ChronicleName={}"
-                     , storyList.size(), client_id, chronicle_name);
+                LOG_INFO("[RPCVisorClient] Successfully fetched {} stories for ClientID={} from ChronicleName={}",
+                         storyList.size(),
+                         client_id,
+                         chronicle_name);
             }
             else
             {
-                LOG_WARNING("[RPCVisorClient] Retrieved an empty list of stories for ClientID={} from ChronicleName={}"
-                     , client_id, chronicle_name);
+                LOG_WARNING("[RPCVisorClient] Retrieved an empty list of stories for ClientID={} from ChronicleName={}",
+                            client_id,
+                            chronicle_name);
             }
 
             return storyList;
         }
-        catch(tl::exception const &)
+        catch(tl::exception const&)
         {
-            LOG_ERROR("[RPCVisorClient] Failed to fetch stories for ClientID {} from ChronicleName {}. Thallium exception encountered."
-                 , client_id, chronicle_name);
+            LOG_ERROR("[RPCVisorClient] Failed to fetch stories for ClientID {} from ChronicleName {}. Thallium "
+                      "exception encountered.",
+                      client_id,
+                      chronicle_name);
         }
-        return (std::vector <std::string>{});
+        return (std::vector<std::string>{});
     }
 
     ~RpcVisorClient()
@@ -362,9 +413,9 @@ public:
     }
 
 private:
-    std::string service_addr;     // na address of ChronoVisor ClientService  
-    uint16_t service_provider_id;          // ChronoVisor ClientService provider_id id
-    tl::provider_handle service_ph;  //provider_handle for client registry service
+    std::string service_addr;       // na address of ChronoVisor ClientService
+    uint16_t service_provider_id;   // ChronoVisor ClientService provider_id id
+    tl::provider_handle service_ph; //provider_handle for client registry service
     tl::remote_procedure visor_connect;
     tl::remote_procedure visor_disconnect;
     tl::remote_procedure create_chronicle;
@@ -377,16 +428,19 @@ private:
     tl::remote_procedure show_chronicles;
     tl::remote_procedure show_stories;
 
-    RpcVisorClient(RpcVisorClient const &) = delete;
+    RpcVisorClient(RpcVisorClient const&) = delete;
 
-    RpcVisorClient &operator=(RpcVisorClient const &) = delete;
+    RpcVisorClient& operator=(RpcVisorClient const&) = delete;
 
     // constructor is private to make sure thalium rpc objects are created on the heap, not stack
-    RpcVisorClient(tl::engine &tl_engine, std::string const &service_addr, uint16_t provider_id): service_addr(
-            service_addr), service_provider_id(provider_id), service_ph(tl_engine.lookup(service_addr), provider_id)
+    RpcVisorClient(tl::engine& tl_engine, std::string const& service_addr, uint16_t provider_id)
+        : service_addr(service_addr)
+        , service_provider_id(provider_id)
+        , service_ph(tl_engine.lookup(service_addr), provider_id)
     {
-        LOG_DEBUG("[RpcVisorClient] Initialized for Visor Service at {} with ProviderID={}", service_addr
-             , service_provider_id);
+        LOG_DEBUG("[RpcVisorClient] Initialized for Visor Service at {} with ProviderID={}",
+                  service_addr,
+                  service_provider_id);
         visor_connect = tl_engine.define("Connect");
         visor_disconnect = tl_engine.define("Disconnect");
         create_chronicle = tl_engine.define("CreateChronicle");
@@ -401,6 +455,6 @@ private:
     }
 };
 
-}
+} // namespace chronolog
 
 #endif

--- a/Client/cpp/src/rpcVisorClient.h
+++ b/Client/cpp/src/rpcVisorClient.h
@@ -1,11 +1,15 @@
 #ifndef RPC_VISOR_PORTAL_CLIENT_H
 #define RPC_VISOR_PORTAL_CLIENT_H
 
-#include <string>
-#include <map>
+#include <cstdint>
 #include <iostream>
+#include <map>
+#include <ostream>
+#include <string>
 #include <sys/types.h>
 #include <unistd.h>
+#include <vector>
+
 #include <thallium.hpp>
 #include <thallium/serialization/serialize.hpp>
 #include <thallium/serialization/stl/string.hpp>

--- a/Client/examples/cpp/client_lib_basic_example.cpp
+++ b/Client/examples/cpp/client_lib_basic_example.cpp
@@ -1,6 +1,9 @@
-#include <cassert>
-#include <common.h>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
 #include <unistd.h>
+#include <vector>
 
 #include <ClientConfiguration.h>
 #include <chronolog_client.h>

--- a/Client/examples/cpp/client_lib_basic_example.cpp
+++ b/Client/examples/cpp/client_lib_basic_example.cpp
@@ -39,11 +39,17 @@ int main(int argc, char** argv)
     confManager.log_configuration(std::cout);
 
     // Initialize logging
-    int result = chronolog::chrono_monitor::initialize(
-            confManager.LOG_CONF.LOGTYPE, confManager.LOG_CONF.LOGFILE, confManager.LOG_CONF.LOGLEVEL,
-            confManager.LOG_CONF.LOGNAME, confManager.LOG_CONF.LOGFILESIZE, confManager.LOG_CONF.LOGFILENUM,
-            confManager.LOG_CONF.FLUSHLEVEL);
-    if(result == 1) { return EXIT_FAILURE; }
+    int result = chronolog::chrono_monitor::initialize(confManager.LOG_CONF.LOGTYPE,
+                                                       confManager.LOG_CONF.LOGFILE,
+                                                       confManager.LOG_CONF.LOGLEVEL,
+                                                       confManager.LOG_CONF.LOGNAME,
+                                                       confManager.LOG_CONF.LOGFILESIZE,
+                                                       confManager.LOG_CONF.LOGFILENUM,
+                                                       confManager.LOG_CONF.FLUSHLEVEL);
+    if(result == 1)
+    {
+        return EXIT_FAILURE;
+    }
 
     // Build portal configs
     chronolog::ClientPortalServiceConf portalConf;

--- a/Client/examples/cpp/client_lib_distributed_telemetry_writer.cpp
+++ b/Client/examples/cpp/client_lib_distributed_telemetry_writer.cpp
@@ -22,27 +22,29 @@ typedef struct workload_conf_args_
     int interval_seconds = 5;
 } workload_conf_args;
 
-void usage(char**argv)
+void usage(char** argv)
 {
-    std::cerr << "\nUsage: " << argv[0] << " [options]\n"
-                                           "-c|--config <config_file>\n"
-                                           "-d|--duration <duration>\n"
-                                           "-i|--interval <interval>\n" << argv[0] << std::endl;
+    std::cerr << "\nUsage: " << argv[0]
+              << " [options]\n"
+                 "-c|--config <config_file>\n"
+                 "-d|--duration <duration>\n"
+                 "-i|--interval <interval>\n"
+              << argv[0] << std::endl;
 }
 
-std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
+std::pair<std::string, workload_conf_args> cmd_arg_parse(int argc, char** argv)
 {
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     int opt;
-    char *config_file = nullptr;
+    char* config_file = nullptr;
     workload_conf_args workload_args;
 
     // Define the long options and their corresponding short options
-    struct option long_options[] = {{  "config"  , required_argument, nullptr, 'c'}
-                                    , {"duration", optional_argument, nullptr, 'd'}
-                                    , {"interval", optional_argument, nullptr, 'i'}
-                                    , {nullptr   , 0                , nullptr, 0}};
+    struct option long_options[] = {{"config", required_argument, nullptr, 'c'},
+                                    {"duration", optional_argument, nullptr, 'd'},
+                                    {"interval", optional_argument, nullptr, 'i'},
+                                    {nullptr, 0, nullptr, 0}};
 
     // Parse the command-line options
     while((opt = getopt_long(argc, argv, "c:d:i:", long_options, nullptr)) != -1)
@@ -73,14 +75,16 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
     if(rank == 0)
     {
         std::cout << "[DistributedTelemetryWriter] Config file: " << (config_file ? config_file : "None") << std::endl;
-        std::cout << "[DistributedTelemetryWriter] Duration: " << workload_args.duration_seconds << " seconds" << std::endl;
-        std::cout << "[DistributedTelemetryWriter] Interval: " << workload_args.interval_seconds << " seconds" << std::endl;
+        std::cout << "[DistributedTelemetryWriter] Duration: " << workload_args.duration_seconds << " seconds"
+                  << std::endl;
+        std::cout << "[DistributedTelemetryWriter] Interval: " << workload_args.interval_seconds << " seconds"
+                  << std::endl;
     }
 
     // Return the config file and workload args
     if(config_file)
     {
-        return {std::pair <std::string, workload_conf_args>((config_file), workload_args)};
+        return {std::pair<std::string, workload_conf_args>((config_file), workload_args)};
     }
     else
     {
@@ -103,12 +107,12 @@ private:
     int rank{};
     int size{};
     std::string node_name;
-    chronolog::Client *client{};
+    chronolog::Client* client{};
 
     // Story handles for different metrics - using traditional pointers
-    chronolog::StoryHandle *cpu_story_handle;
-    chronolog::StoryHandle *memory_story_handle;
-    chronolog::StoryHandle *network_story_handle;
+    chronolog::StoryHandle* cpu_story_handle;
+    chronolog::StoryHandle* memory_story_handle;
+    chronolog::StoryHandle* network_story_handle;
 
     // CPU monitoring - system-wide
     unsigned long long last_total_cpu_time{};
@@ -119,7 +123,9 @@ private:
     long baseline_tx_bytes{};
 
 public:
-    TelemetryCollector(int rank, int size): rank(rank), size(size)
+    TelemetryCollector(int rank, int size)
+        : rank(rank)
+        , size(size)
     {
         // Get node name
         char hostname[256];
@@ -138,7 +144,7 @@ public:
         network_story_handle = nullptr;
     }
 
-    bool initializeChronoLog(chronolog::ClientConfiguration &confManager)
+    bool initializeChronoLog(chronolog::ClientConfiguration& confManager)
     {
         // Configure the client connection
         chronolog::ClientPortalServiceConf portalConf = confManager.PORTAL_CONF;
@@ -152,7 +158,7 @@ public:
 
         // Create a chronicle named after the hostname
         std::string chronicle_name = node_name;
-        std::map <std::string, std::string> chronicle_attrs;
+        std::map<std::string, std::string> chronicle_attrs;
         chronicle_attrs["description"] = "System telemetry metrics for node " + node_name;
         chronicle_attrs["node"] = node_name;
         int flags = 0;
@@ -160,7 +166,7 @@ public:
         assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_CHRONICLE_EXISTS);
 
         // Acquire stories for different metrics
-        std::map <std::string, std::string> story_attrs;
+        std::map<std::string, std::string> story_attrs;
         story_attrs["node"] = node_name;
         story_attrs["rank"] = std::to_string(rank);
 
@@ -211,7 +217,7 @@ public:
         }
     }
 
-    void getSystemCpuTimes(unsigned long long &total_time, unsigned long long &idle_time)
+    void getSystemCpuTimes(unsigned long long& total_time, unsigned long long& idle_time)
     {
         std::ifstream stat_file("/proc/stat");
         std::string line;
@@ -292,7 +298,7 @@ public:
         return (double)mem_used / 1024.0; // Convert from KB to MB
     }
 
-    void getNetworkStats(long &rx_bytes, long &tx_bytes)
+    void getNetworkStats(long& rx_bytes, long& tx_bytes)
     {
         std::ifstream net_dev("/proc/net/dev");
         std::string line;
@@ -340,10 +346,10 @@ public:
         return metrics;
     }
 
-    void logMetrics(const SystemMetrics &metrics)
+    void logMetrics(const SystemMetrics& metrics)
     {
         auto time_since_epoch = metrics.timestamp.time_since_epoch();
-        auto millis = std::chrono::duration_cast <std::chrono::milliseconds>(time_since_epoch).count();
+        auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(time_since_epoch).count();
 
         // Log CPU usage to cpu_usage story
         std::ostringstream cpu_entry;
@@ -359,9 +365,9 @@ public:
 
         // Log network usage to network_usage story
         std::ostringstream network_entry;
-        network_entry << "{" << "\"timestamp\":" << millis << R"(,"node":")" << node_name << "\"" << ",\"rank\":"
-                      << rank << ",\"network_rx_bytes\":" << metrics.network_rx_bytes << ",\"network_tx_bytes\":"
-                      << metrics.network_tx_bytes << "}";
+        network_entry << "{" << "\"timestamp\":" << millis << R"(,"node":")" << node_name << "\""
+                      << ",\"rank\":" << rank << ",\"network_rx_bytes\":" << metrics.network_rx_bytes
+                      << ",\"network_tx_bytes\":" << metrics.network_tx_bytes << "}";
         network_story_handle->log_event(std::to_string(metrics.network_rx_bytes) + "," +
                                         std::to_string(metrics.network_tx_bytes));
     }
@@ -373,8 +379,8 @@ public:
 
         if(rank == 0)
         {
-            std::cout << "[DistributedTelemetryWriter] Starting telemetry collection for " << duration_seconds << " seconds with "
-                      << interval_seconds << "s intervals\n";
+            std::cout << "[DistributedTelemetryWriter] Starting telemetry collection for " << duration_seconds
+                      << " seconds with " << interval_seconds << "s intervals\n";
             std::cout << "[DistributedTelemetryWriter] Chronicle: " << node_name << "\n";
             std::cout << "[DistributedTelemetryWriter] Stories: cpu_usage, memory_usage, network_usage\n";
         }
@@ -389,8 +395,9 @@ public:
 
             if(rank == 0)
             {
-                auto elapsed = std::chrono::duration_cast <std::chrono::seconds>(
-                        std::chrono::steady_clock::now() - start_time).count();
+                auto elapsed =
+                        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - start_time)
+                                .count();
                 std::cout << "[DistributedTelemetryWriter] Collected metrics at " << elapsed << "s - "
                           << "CPU: " << std::fixed << std::setprecision(1) << metrics.cpu_usage << "%, "
                           << "Memory: " << std::setprecision(1) << metrics.memory_usage_mb << "MB, "
@@ -408,7 +415,7 @@ public:
     }
 };
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
     // To suppress argobots warning
     std::string argobots_conf_str = R"({"argobots" : {"abt_mem_max_num_stacks" : 8
@@ -425,7 +432,7 @@ int main(int argc, char *argv[])
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
     std::string default_conf_file_path = "./default_conf.json";
-    std::pair <std::string, workload_conf_args> cmd_args = cmd_arg_parse(argc, argv);
+    std::pair<std::string, workload_conf_args> cmd_args = cmd_arg_parse(argc, argv);
     std::string conf_file_path = cmd_args.first;
     workload_conf_args workload_args = cmd_args.second;
     if(conf_file_path.empty())
@@ -443,8 +450,8 @@ int main(int argc, char *argv[])
         }
         else
         {
-            std::cout << "[DistributedTelemetryWriter] Configuration file loaded successfully from '" << conf_file_path << "'."
-                      << std::endl;
+            std::cout << "[DistributedTelemetryWriter] Configuration file loaded successfully from '" << conf_file_path
+                      << "'." << std::endl;
         }
     }
     else
@@ -457,12 +464,9 @@ int main(int argc, char *argv[])
         confManager.log_configuration(std::cout);
     }
 
-    std::cout << "[DistributedTelemetryWriter] Monitoring system stats on " << rank << "-th node out of "
-                                                                            << size << " nodes every "
-                                                                            << workload_args.interval_seconds
-                                                                            << " seconds for "
-                                                                            << workload_args.duration_seconds
-                                                                            << " seconds" << std::endl;
+    std::cout << "[DistributedTelemetryWriter] Monitoring system stats on " << rank << "-th node out of " << size
+              << " nodes every " << workload_args.interval_seconds << " seconds for " << workload_args.duration_seconds
+              << " seconds" << std::endl;
 
     TelemetryCollector collector(rank, size);
 

--- a/Client/examples/cpp/client_lib_distributed_telemetry_writer.cpp
+++ b/Client/examples/cpp/client_lib_distributed_telemetry_writer.cpp
@@ -1,14 +1,16 @@
-#include <mpi.h>
-#include <fstream>
-#include <sstream>
-#include <unistd.h>
 #include <cassert>
 #include <chrono>
-#include <thread>
-#include <iostream>
-#include <iomanip>
+#include <cstdlib>
+#include <fstream>
 #include <getopt.h>
+#include <iomanip>
+#include <iostream>
 #include <margo.h>
+#include <mpi.h>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <unistd.h>
 
 #include <chronolog_client.h>
 

--- a/Client/examples/cpp/client_lib_reader_example.cpp
+++ b/Client/examples/cpp/client_lib_reader_example.cpp
@@ -41,11 +41,17 @@ int main(int argc, char** argv)
     confManager.log_configuration(std::cout);
 
     // Initialize logging
-    int result = chronolog::chrono_monitor::initialize(
-            confManager.LOG_CONF.LOGTYPE, confManager.LOG_CONF.LOGFILE, confManager.LOG_CONF.LOGLEVEL,
-            confManager.LOG_CONF.LOGNAME, confManager.LOG_CONF.LOGFILESIZE, confManager.LOG_CONF.LOGFILENUM,
-            confManager.LOG_CONF.FLUSHLEVEL);
-    if(result == 1) { return EXIT_FAILURE; }
+    int result = chronolog::chrono_monitor::initialize(confManager.LOG_CONF.LOGTYPE,
+                                                       confManager.LOG_CONF.LOGFILE,
+                                                       confManager.LOG_CONF.LOGLEVEL,
+                                                       confManager.LOG_CONF.LOGNAME,
+                                                       confManager.LOG_CONF.LOGFILESIZE,
+                                                       confManager.LOG_CONF.LOGFILENUM,
+                                                       confManager.LOG_CONF.FLUSHLEVEL);
+    if(result == 1)
+    {
+        return EXIT_FAILURE;
+    }
 
     // Build portal configs
     chronolog::ClientPortalServiceConf portalConf;

--- a/Client/examples/cpp/client_lib_reader_example.cpp
+++ b/Client/examples/cpp/client_lib_reader_example.cpp
@@ -1,6 +1,8 @@
-#include <cassert>
-#include <common.h>
-#include <unistd.h>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
 
 #include <ClientConfiguration.h>
 #include <chronolog_client.h>

--- a/Client/examples/cpp/client_lib_writer_example.cpp
+++ b/Client/examples/cpp/client_lib_writer_example.cpp
@@ -1,11 +1,12 @@
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
+
 #include <ClientConfiguration.h>
 #include <chronolog_client.h>
 #include <chrono_monitor.h>
 #include <cmd_arg_parse.h>
-
-#include <cassert>
-#include <common.h>
-#include <unistd.h>
 
 // This file is the writer part of the reader example also available in the same
 // folder. Therefore, the code is responsible for creating the chronicle and

--- a/Client/examples/cpp/client_lib_writer_example.cpp
+++ b/Client/examples/cpp/client_lib_writer_example.cpp
@@ -42,23 +42,29 @@ int main(int argc, char** argv)
     confManager.log_configuration(std::cout);
 
     // Initialize logging
-    int result = chronolog::chrono_monitor::initialize(
-            confManager.LOG_CONF.LOGTYPE, confManager.LOG_CONF.LOGFILE, confManager.LOG_CONF.LOGLEVEL,
-            confManager.LOG_CONF.LOGNAME, confManager.LOG_CONF.LOGFILESIZE, confManager.LOG_CONF.LOGFILENUM,
-            confManager.LOG_CONF.FLUSHLEVEL);
-    if(result == 1) { return EXIT_FAILURE; }
+    int result = chronolog::chrono_monitor::initialize(confManager.LOG_CONF.LOGTYPE,
+                                                       confManager.LOG_CONF.LOGFILE,
+                                                       confManager.LOG_CONF.LOGLEVEL,
+                                                       confManager.LOG_CONF.LOGNAME,
+                                                       confManager.LOG_CONF.LOGFILESIZE,
+                                                       confManager.LOG_CONF.LOGFILENUM,
+                                                       confManager.LOG_CONF.FLUSHLEVEL);
+    if(result == 1)
+    {
+        return EXIT_FAILURE;
+    }
 
-  // Build portal config
-  chronolog::ClientPortalServiceConf portalConf;
-  portalConf.PROTO_CONF = confManager.PORTAL_CONF.PROTO_CONF;
-  portalConf.IP = confManager.PORTAL_CONF.IP;
-  portalConf.PORT = confManager.PORTAL_CONF.PORT;
-  portalConf.PROVIDER_ID = confManager.PORTAL_CONF.PROVIDER_ID;
+    // Build portal config
+    chronolog::ClientPortalServiceConf portalConf;
+    portalConf.PROTO_CONF = confManager.PORTAL_CONF.PROTO_CONF;
+    portalConf.IP = confManager.PORTAL_CONF.IP;
+    portalConf.PORT = confManager.PORTAL_CONF.PORT;
+    portalConf.PROVIDER_ID = confManager.PORTAL_CONF.PROVIDER_ID;
 
-  LOG_INFO("[ClientExample] Starting ChronoLog Client Example");
+    LOG_INFO("[ClientExample] Starting ChronoLog Client Example");
 
-  // Create a ChronoLog client
-  chronolog::Client client(portalConf);
+    // Create a ChronoLog client
+    chronolog::Client client(portalConf);
 
     /// Connect to ChronoVisor
     int ret = client.Connect();
@@ -92,6 +98,6 @@ int main(int argc, char** argv)
     ret = client.Disconnect();
     std::cout << "[ClientExample] Disconnect returned: " << chronolog::to_string_client(ret) << "\n";
 
-  LOG_INFO("[ClientExample] Finished successfully");
-  return 0;
+    LOG_INFO("[ClientExample] Finished successfully");
+    return 0;
 }

--- a/Client/python/py_chronolog_client.cpp
+++ b/Client/python/py_chronolog_client.cpp
@@ -1,4 +1,9 @@
 
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>

--- a/Client/python/py_chronolog_client.cpp
+++ b/Client/python/py_chronolog_client.cpp
@@ -11,90 +11,81 @@
 #include <chronolog_client.h>
 
 
-
 using chronolog::ClientPortalServiceConf;
-void BindChronologClientPortalServiceConf(pybind11::module &m) 
+void BindChronologClientPortalServiceConf(pybind11::module& m)
 {
-   pybind11::class_<ClientPortalServiceConf>(m,"ClientPortalServiceConf")
-      .def(pybind11::init<const std::string &, const std::string &, uint16_t, uint16_t>())
-    ;
+    pybind11::class_<ClientPortalServiceConf>(m, "ClientPortalServiceConf")
+            .def(pybind11::init<const std::string&, const std::string&, uint16_t, uint16_t>());
 };
 
 using chronolog::ClientQueryServiceConf;
-void BindChronologClientQueryServiceConf(pybind11::module &m) 
+void BindChronologClientQueryServiceConf(pybind11::module& m)
 {
-   pybind11::class_<ClientQueryServiceConf>(m,"ClientQueryServiceConf")
-      .def(pybind11::init<const std::string &, const std::string &, uint16_t, uint16_t>())
-    ;
+    pybind11::class_<ClientQueryServiceConf>(m, "ClientQueryServiceConf")
+            .def(pybind11::init<const std::string&, const std::string&, uint16_t, uint16_t>());
 };
 
 
 using chronolog::StoryHandle;
-class PyStoryHandle : public StoryHandle 
+class PyStoryHandle: public StoryHandle
 {
 public:
     /* Inherit the constructors */
     using StoryHandle::StoryHandle;
 
     /* Trampoline (need one for each virtual function) */
-    uint64_t log_event(std::string const & event_string) override {
-        PYBIND11_OVERRIDE_PURE(
-            uint64_t, /* Return type */
-            StoryHandle,      /* Parent class */
-            log_event,          /* Name of function in C++ (must match Python name) */
-            event_string      /* Argument(s) */
+    uint64_t log_event(std::string const& event_string) override
+    {
+        PYBIND11_OVERRIDE_PURE(uint64_t,    /* Return type */
+                               StoryHandle, /* Parent class */
+                               log_event,   /* Name of function in C++ (must match Python name) */
+                               event_string /* Argument(s) */
         );
     }
 };
 
-void BindChronologStoryHandle(pybind11::module &m)
+void BindChronologStoryHandle(pybind11::module& m)
 {
-   pybind11::class_<StoryHandle,PyStoryHandle>(m, "StoryHandle")
-    .def(pybind11::init<>())
-    .def("log_event",&StoryHandle::log_event, pybind11::arg("log_string") );
-
+    pybind11::class_<StoryHandle, PyStoryHandle>(m, "StoryHandle")
+            .def(pybind11::init<>())
+            .def("log_event", &StoryHandle::log_event, pybind11::arg("log_string"));
 };
 
-PYBIND11_MAKE_OPAQUE(std::pair<int,StoryHandle>);
+PYBIND11_MAKE_OPAQUE(std::pair<int, StoryHandle>);
 
 using chronolog::Event;
-void BindChronologEvent(pybind11::module & m)
+void BindChronologEvent(pybind11::module& m)
 {
-    pybind11::class_<Event>(m,"Event")
-    .def(pybind11::init< uint64_t, uint64_t, uint32_t, const std::string &>())
-    .def("time",&Event::time)
-    .def("client_id",&Event::client_id)
-    .def("index",&Event::index)
-    .def("log_record",&Event::log_record);
-
+    pybind11::class_<Event>(m, "Event")
+            .def(pybind11::init<uint64_t, uint64_t, uint32_t, const std::string&>())
+            .def("time", &Event::time)
+            .def("client_id", &Event::client_id)
+            .def("index", &Event::index)
+            .def("log_record", &Event::log_record);
 };
 
 PYBIND11_MAKE_OPAQUE(std::vector<Event>);
 
-void BindChronologEventVector(pybind11::module &m)
-{
-    pybind11::bind_vector<std::vector<Event>>(m, "EventList");
-};
+void BindChronologEventVector(pybind11::module& m) { pybind11::bind_vector<std::vector<Event>>(m, "EventList"); };
 
 using chronolog::Client;
 
-void BindChronologClient(pybind11::module &m)
+void BindChronologClient(pybind11::module& m)
 {
-   pybind11::class_<Client>(m,"Client")
-    .def(pybind11::init<const ClientPortalServiceConf &>())
-    .def(pybind11::init<const ClientPortalServiceConf & , const ClientQueryServiceConf & >())
-    .def("Connect", &Client::Connect)
-    .def("Disconnect", &Client::Disconnect)
-    .def("CreateChronicle", &Client::CreateChronicle)
-    .def("DestroyChronicle", &Client::DestroyChronicle)
-    .def("AcquireStory", &Client::AcquireStory, pybind11::return_value_policy::reference)
-    .def("ReleaseStory", &Client::ReleaseStory, pybind11::arg("chronicle_name"), pybind11::arg("story_name"))
-    .def("DestroyStory", &Client::DestroyStory, pybind11::arg("chronicle_name"), pybind11::arg("story_name"))
-    .def("ReplayStory", &Client::ReplayStory)
-    ;
+    pybind11::class_<Client>(m, "Client")
+            .def(pybind11::init<const ClientPortalServiceConf&>())
+            .def(pybind11::init<const ClientPortalServiceConf&, const ClientQueryServiceConf&>())
+            .def("Connect", &Client::Connect)
+            .def("Disconnect", &Client::Disconnect)
+            .def("CreateChronicle", &Client::CreateChronicle)
+            .def("DestroyChronicle", &Client::DestroyChronicle)
+            .def("AcquireStory", &Client::AcquireStory, pybind11::return_value_policy::reference)
+            .def("ReleaseStory", &Client::ReleaseStory, pybind11::arg("chronicle_name"), pybind11::arg("story_name"))
+            .def("DestroyStory", &Client::DestroyStory, pybind11::arg("chronicle_name"), pybind11::arg("story_name"))
+            .def("ReplayStory", &Client::ReplayStory);
 };
 
-PYBIND11_MODULE(py_chronolog_client, m) 
+PYBIND11_MODULE(py_chronolog_client, m)
 {
     BindChronologClientPortalServiceConf(m);
     BindChronologClientQueryServiceConf(m);

--- a/Plugins/chronokvs/examples/chronokvs_reader_example.cpp
+++ b/Plugins/chronokvs/examples/chronokvs_reader_example.cpp
@@ -6,20 +6,20 @@
 #include <vector>
 #include "chronokvs.h"
 
-std::vector<std::uint64_t> readTimestampsFromFile(const std::string& filename) {
+std::vector<std::uint64_t> readTimestampsFromFile(const std::string& filename)
+{
     std::vector<std::uint64_t> timestamps;
     std::ifstream file(filename);
     std::uint64_t timestamp;
-    
-    if (!file.is_open()) {
+
+    if(!file.is_open())
+    {
         std::cerr << "Error: Could not open " << filename << "\n";
         return timestamps;
     }
 
-    while (file >> timestamp) {
-        timestamps.push_back(timestamp);
-    }
-    
+    while(file >> timestamp) { timestamps.push_back(timestamp); }
+
     file.close();
     return timestamps;
 }
@@ -31,12 +31,14 @@ int main()
 
     // Read timestamps from file
     std::vector<std::uint64_t> timestamps = readTimestampsFromFile("chronokvs_timestamps.txt");
-    if (timestamps.empty()) {
+    if(timestamps.empty())
+    {
         std::cerr << "No timestamps found. Please run the writer example first.\n";
         return 1;
     }
 
-    if (timestamps.size() != 3) {
+    if(timestamps.size() != 3)
+    {
         std::cerr << "Expected 3 timestamps, but found " << timestamps.size() << "\n";
         return 1;
     }
@@ -47,14 +49,17 @@ int main()
     // Read and display history for key2
     std::cout << "\nReading history for key2:\n";
     auto historyForKey2 = chronoKVS.get_history(key2);
-    
-    if (historyForKey2.empty()) {
+
+    if(historyForKey2.empty())
+    {
         std::cout << "No history found for key2\n";
-    } else {
+    }
+    else
+    {
         std::cout << "Found " << historyForKey2.size() << " values in history:\n";
-        for (const auto& event : historyForKey2) {
-            std::cout << "Timestamp: " << event.timestamp 
-                     << "\nValue    : " << event.value << "\n\n";
+        for(const auto& event: historyForKey2)
+        {
+            std::cout << "Timestamp: " << event.timestamp << "\nValue    : " << event.value << "\n\n";
         }
     }
 
@@ -63,20 +68,22 @@ int main()
     std::string value2_t1 = chronoKVS.get(key2, timestamps[1]);
     std::string value2_t2 = chronoKVS.get(key2, timestamps[2]);
 
-    std::cout << "Value at timestamp " << timestamps[1] << ": " 
-              << (value2_t1.empty() ? "Not found" : value2_t1) << "\n";
-    std::cout << "Value at timestamp " << timestamps[2] << ": " 
-              << (value2_t2.empty() ? "Not found" : value2_t2) << "\n";    
+    std::cout << "Value at timestamp " << timestamps[1] << ": " << (value2_t1.empty() ? "Not found" : value2_t1)
+              << "\n";
+    std::cout << "Value at timestamp " << timestamps[2] << ": " << (value2_t2.empty() ? "Not found" : value2_t2)
+              << "\n";
 
     // Read and display value for key1
     std::cout << "\nReading value for key1 at timestamp " << timestamps[0] << ":\n";
     std::string value1 = chronoKVS.get(key1, timestamps[0]);
-    if (!value1.empty()) {
+    if(!value1.empty())
+    {
         std::cout << "Value: " << value1 << "\n";
-    } else {
+    }
+    else
+    {
         std::cout << "No value found\n";
     }
 
     return 0;
-   
 }

--- a/Plugins/chronokvs/examples/chronokvs_reader_example.cpp
+++ b/Plugins/chronokvs/examples/chronokvs_reader_example.cpp
@@ -1,3 +1,5 @@
+#include <cstdint>
+#include <cstddef>
 #include <string>
 #include <iostream>
 #include <fstream>

--- a/Plugins/chronokvs/examples/chronokvs_writer_example.cpp
+++ b/Plugins/chronokvs/examples/chronokvs_writer_example.cpp
@@ -21,7 +21,7 @@ int main()
     std::uint64_t timestamp1 = chronoKVS.put(key1, value1);
     std::uint64_t timestamp2 = chronoKVS.put(key2, value2);
     std::uint64_t timestamp3 = chronoKVS.put(key2, value3);
-    
+
     std::cout << "Inserted values with timestamps:\n";
     std::cout << "1. key1=" << value1 << " timestamp=" << timestamp1 << "\n";
     std::cout << "2. key2=" << value2 << " timestamp=" << timestamp2 << "\n";
@@ -29,13 +29,16 @@ int main()
 
     // Save timestamps to a file for the reader
     std::ofstream timestampFile("chronokvs_timestamps.txt");
-    if (timestampFile.is_open()) {
+    if(timestampFile.is_open())
+    {
         timestampFile << timestamp1 << "\n";
         timestampFile << timestamp2 << "\n";
         timestampFile << timestamp3 << "\n";
         timestampFile.close();
         std::cout << "\nTimestamps have been saved to 'chronokvs_timestamps.txt'\n";
-    } else {
+    }
+    else
+    {
         std::cerr << "Error: Could not save timestamps to file\n";
     }
 

--- a/Plugins/chronokvs/examples/chronokvs_writer_example.cpp
+++ b/Plugins/chronokvs/examples/chronokvs_writer_example.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <string>
 #include <iostream>
 #include <fstream>

--- a/Plugins/chronokvs/include/chronokvs.h
+++ b/Plugins/chronokvs/include/chronokvs.h
@@ -1,6 +1,7 @@
 #ifndef CHRONOKVS_H_
 #define CHRONOKVS_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>

--- a/Plugins/chronokvs/include/chronokvs.h
+++ b/Plugins/chronokvs/include/chronokvs.h
@@ -19,18 +19,17 @@ private:
     std::unique_ptr<ChronoKVSMapper> mapper;
 
 public:
-
     ChronoKVS();
 
     ~ChronoKVS();
 
-    std::uint64_t put(const std::string &key, const std::string &value);
+    std::uint64_t put(const std::string& key, const std::string& value);
 
-    std::string get(const std::string &key, uint64_t timestamp);
+    std::string get(const std::string& key, uint64_t timestamp);
 
-    std::vector<EventData> get_history(const std::string &key);
+    std::vector<EventData> get_history(const std::string& key);
 };
 
-}
+} // namespace chronokvs
 
 #endif // CHRONOKVS_H_

--- a/Plugins/chronokvs/src/chronokvs.cpp
+++ b/Plugins/chronokvs/src/chronokvs.cpp
@@ -1,3 +1,7 @@
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 #include "chronokvs.h"
 #include "chronokvs_mapper.h"
 

--- a/Plugins/chronokvs/src/chronokvs.cpp
+++ b/Plugins/chronokvs/src/chronokvs.cpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "chronokvs.h"
 #include "chronokvs_mapper.h"
 

--- a/Plugins/chronokvs/src/chronokvs.cpp
+++ b/Plugins/chronokvs/src/chronokvs.cpp
@@ -9,25 +9,21 @@ namespace chronokvs
 {
 
 ChronoKVS::ChronoKVS()
-    : mapper(std::make_unique<ChronoKVSMapper>())  // Use member initializer list
-{
-}
+    : mapper(std::make_unique<ChronoKVSMapper>()) // Use member initializer list
+{}
 
 ChronoKVS::~ChronoKVS() = default;
 
-std::uint64_t ChronoKVS::put(const std::string &key, const std::string &value)
+std::uint64_t ChronoKVS::put(const std::string& key, const std::string& value)
 {
     return mapper->storeKeyValue(key, value);
 }
 
-std::string ChronoKVS::get(const std::string &key, std::uint64_t timestamp)
+std::string ChronoKVS::get(const std::string& key, std::uint64_t timestamp)
 {
     return mapper->retrieveByKeyAndTs(key, timestamp);
 }
 
-std::vector<EventData> ChronoKVS::get_history(const std::string &key)
-{
-    return mapper->retrieveByKey(key);
-}
+std::vector<EventData> ChronoKVS::get_history(const std::string& key) { return mapper->retrieveByKey(key); }
 
 } // namespace chronokvs

--- a/Plugins/chronokvs/src/chronokvs_client_adapter.cpp
+++ b/Plugins/chronokvs/src/chronokvs_client_adapter.cpp
@@ -18,23 +18,20 @@ ChronoKVSClientAdapter::ChronoKVSClientAdapter()
     chronolog::ClientConfiguration confManager;
 
     // Configure portal and query services from the configuration manager
-    chronolog::ClientPortalServiceConf portalConf{
-        confManager.PORTAL_CONF.PROTO_CONF,
-        confManager.PORTAL_CONF.IP,
-        confManager.PORTAL_CONF.PORT,
-        confManager.PORTAL_CONF.PROVIDER_ID
-    };
+    chronolog::ClientPortalServiceConf portalConf{confManager.PORTAL_CONF.PROTO_CONF,
+                                                  confManager.PORTAL_CONF.IP,
+                                                  confManager.PORTAL_CONF.PORT,
+                                                  confManager.PORTAL_CONF.PROVIDER_ID};
 
-    chronolog::ClientQueryServiceConf queryConf{
-        confManager.QUERY_CONF.PROTO_CONF,
-        confManager.QUERY_CONF.IP,
-        confManager.QUERY_CONF.PORT,
-        confManager.QUERY_CONF.PROVIDER_ID
-    };
+    chronolog::ClientQueryServiceConf queryConf{confManager.QUERY_CONF.PROTO_CONF,
+                                                confManager.QUERY_CONF.IP,
+                                                confManager.QUERY_CONF.PORT,
+                                                confManager.QUERY_CONF.PROVIDER_ID};
 
     // Initialize and connect the ChronoLog client
     chronolog = std::make_unique<chronolog::Client>(portalConf, queryConf);
-    if (int ret = chronolog->Connect(); ret != chronolog::CL_SUCCESS) {
+    if(int ret = chronolog->Connect(); ret != chronolog::CL_SUCCESS)
+    {
         chronolog->Disconnect();
         chronolog.reset();
         throw std::runtime_error("Failed to connect to ChronoLog");
@@ -42,30 +39,34 @@ ChronoKVSClientAdapter::ChronoKVSClientAdapter()
 
     // Ensure the default chronicle exists
     std::map<std::string, std::string> chronicle_attrs;
-    if (int ret = chronolog->CreateChronicle(defaultChronicle, chronicle_attrs, DEFAULT_FLAGS);
-        ret != chronolog::CL_SUCCESS && ret != chronolog::CL_ERR_CHRONICLE_EXISTS) {
+    if(int ret = chronolog->CreateChronicle(defaultChronicle, chronicle_attrs, DEFAULT_FLAGS);
+       ret != chronolog::CL_SUCCESS && ret != chronolog::CL_ERR_CHRONICLE_EXISTS)
+    {
         throw std::runtime_error("Failed to create chronicle");
     }
 }
 
 ChronoKVSClientAdapter::~ChronoKVSClientAdapter()
 {
-    if (chronolog) {
+    if(chronolog)
+    {
         chronolog->Disconnect();
     }
 }
 
-std::uint64_t ChronoKVSClientAdapter::storeEvent(const std::string &key, const std::string &value)
+std::uint64_t ChronoKVSClientAdapter::storeEvent(const std::string& key, const std::string& value)
 {
     // Acquire a story handle for the given key
     std::map<std::string, std::string> story_attrs;
     auto [status, handle] = chronolog->AcquireStory(defaultChronicle, key, story_attrs, DEFAULT_FLAGS);
-    if (status != chronolog::CL_SUCCESS) {
+    if(status != chronolog::CL_SUCCESS)
+    {
         throw std::runtime_error("Failed to acquire story handle for key: " + key);
     }
 
     // RAII-style story handle management using scope guard
-    struct StoryHandleGuard {
+    struct StoryHandleGuard
+    {
         chronolog::Client* client;
         const std::string& chronicle;
         const std::string& key;
@@ -75,18 +76,20 @@ std::uint64_t ChronoKVSClientAdapter::storeEvent(const std::string &key, const s
     return handle->log_event(value);
 }
 
-std::vector<EventData> ChronoKVSClientAdapter::retrieveEvents(const std::string &key, 
-    std::uint64_t start_ts, std::uint64_t end_ts)
+std::vector<EventData>
+ChronoKVSClientAdapter::retrieveEvents(const std::string& key, std::uint64_t start_ts, std::uint64_t end_ts)
 {
     // Acquire a story handle for the given key
     std::map<std::string, std::string> story_attrs;
     auto [status, handle] = chronolog->AcquireStory(defaultChronicle, key, story_attrs, DEFAULT_FLAGS);
-    if (status != chronolog::CL_SUCCESS) {
+    if(status != chronolog::CL_SUCCESS)
+    {
         throw std::runtime_error("Failed to acquire story handle for key: " + key);
     }
 
     // RAII-style story handle management
-    struct StoryHandleGuard {
+    struct StoryHandleGuard
+    {
         chronolog::Client* client;
         const std::string& chronicle;
         const std::string& key;
@@ -95,18 +98,16 @@ std::vector<EventData> ChronoKVSClientAdapter::retrieveEvents(const std::string 
 
     // Retrieve events for the specified time range
     std::vector<chronolog::Event> events;
-    if (int ret = chronolog->ReplayStory(defaultChronicle, key, start_ts, end_ts, events);
-        ret != chronolog::CL_SUCCESS) {
+    if(int ret = chronolog->ReplayStory(defaultChronicle, key, start_ts, end_ts, events); ret != chronolog::CL_SUCCESS)
+    {
         throw std::runtime_error("Failed to replay events for key: " + key);
     }
 
     // Transform ChronoLog events into EventData objects
     std::vector<EventData> eventDataList;
     eventDataList.reserve(events.size());
-    for (const auto& event : events) {
-        eventDataList.emplace_back(event.time(), event.log_record());
-    }
+    for(const auto& event: events) { eventDataList.emplace_back(event.time(), event.log_record()); }
     return eventDataList;
 }
 
-}
+} // namespace chronokvs

--- a/Plugins/chronokvs/src/chronokvs_client_adapter.cpp
+++ b/Plugins/chronokvs/src/chronokvs_client_adapter.cpp
@@ -1,3 +1,9 @@
+#include <cstdint>
+#include <memory>
+#include <map>
+#include <string>
+#include <stdexcept>
+#include <vector>
 #include "chronokvs_client_adapter.h"
 #include <ClientConfiguration.h>
 

--- a/Plugins/chronokvs/src/chronokvs_client_adapter.h
+++ b/Plugins/chronokvs/src/chronokvs_client_adapter.h
@@ -1,6 +1,7 @@
 #ifndef CHRONOKVS_CLIENT_ADAPTER_H_
 #define CHRONOKVS_CLIENT_ADAPTER_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <optional>

--- a/Plugins/chronokvs/src/chronokvs_client_adapter.h
+++ b/Plugins/chronokvs/src/chronokvs_client_adapter.h
@@ -24,9 +24,9 @@ public:
 
     ~ChronoKVSClientAdapter();
 
-    std::uint64_t storeEvent(const std::string &key, const std::string &value);
+    std::uint64_t storeEvent(const std::string& key, const std::string& value);
 
-    std::vector<EventData> retrieveEvents(const std::string &key, std::uint64_t start_ts, std::uint64_t end_ts);
+    std::vector<EventData> retrieveEvents(const std::string& key, std::uint64_t start_ts, std::uint64_t end_ts);
 };
-}
+} // namespace chronokvs
 #endif // CHRONOKVS_CLIENT_ADAPTER_H_

--- a/Plugins/chronokvs/src/chronokvs_mapper.cpp
+++ b/Plugins/chronokvs/src/chronokvs_mapper.cpp
@@ -8,42 +8,41 @@ namespace chronokvs
 {
 
 
-ChronoKVSMapper::ChronoKVSMapper()
-{
-    chronoClientAdapter = std::make_unique<ChronoKVSClientAdapter>();
-}
+ChronoKVSMapper::ChronoKVSMapper() { chronoClientAdapter = std::make_unique<ChronoKVSClientAdapter>(); }
 
-std::uint64_t ChronoKVSMapper::storeKeyValue(const std::string &key, const std::string &value)
+std::uint64_t ChronoKVSMapper::storeKeyValue(const std::string& key, const std::string& value)
 {
     return chronoClientAdapter->storeEvent(key, value);
 }
 
-std::string ChronoKVSMapper::retrieveByKeyAndTs(const std::string &key, std::uint64_t timestamp)
+std::string ChronoKVSMapper::retrieveByKeyAndTs(const std::string& key, std::uint64_t timestamp)
 {
     // Retrieve events in the narrow time range [timestamp, timestamp + 1)
     auto events = chronoClientAdapter->retrieveEvents(key, timestamp, timestamp + 1);
-    
-    if (events.empty()) {
+
+    if(events.empty())
+    {
         return "";
     }
-    
+
     // Return the first event's value only if its timestamp matches the requested timestamp
-    if (events[0].timestamp == timestamp) {
+    if(events[0].timestamp == timestamp)
+    {
         return events[0].value;
     }
     return "";
 }
 
-std::vector<EventData> ChronoKVSMapper::retrieveByKey(const std::string &key)
+std::vector<EventData> ChronoKVSMapper::retrieveByKey(const std::string& key)
 {
     // Constants for time range boundaries
-    constexpr uint64_t MIN_TIMESTAMP = 1;  // Earliest possible timestamp
-    constexpr uint64_t MAX_TIMESTAMP = 2000000000000000000;  // ~May 18, 2033 03:33:20 UTC
-    
+    constexpr uint64_t MIN_TIMESTAMP = 1;                   // Earliest possible timestamp
+    constexpr uint64_t MAX_TIMESTAMP = 2000000000000000000; // ~May 18, 2033 03:33:20 UTC
+
     // Retrieve all events for the given key using the full time range.
     // This ensures we capture all events regardless of their timestamp,
     // avoiding any potential data loss from timing uncertainties.
     return chronoClientAdapter->retrieveEvents(key, MIN_TIMESTAMP, MAX_TIMESTAMP);
 }
 
-}
+} // namespace chronokvs

--- a/Plugins/chronokvs/src/chronokvs_mapper.cpp
+++ b/Plugins/chronokvs/src/chronokvs_mapper.cpp
@@ -1,3 +1,7 @@
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 #include "chronokvs_mapper.h"
 
 namespace chronokvs

--- a/Plugins/chronokvs/src/chronokvs_mapper.h
+++ b/Plugins/chronokvs/src/chronokvs_mapper.h
@@ -23,12 +23,11 @@ public:
 
     ~ChronoKVSMapper() = default;
 
-    std::uint64_t storeKeyValue(const std::string &key, const std::string &value);
+    std::uint64_t storeKeyValue(const std::string& key, const std::string& value);
 
-    std::string retrieveByKeyAndTs(const std::string &key, std::uint64_t timestamp);
+    std::string retrieveByKeyAndTs(const std::string& key, std::uint64_t timestamp);
 
-    std::vector<EventData> retrieveByKey(const std::string &key);
-
+    std::vector<EventData> retrieveByKey(const std::string& key);
 };
-}
+} // namespace chronokvs
 #endif // KVS_MAPPER_H_

--- a/Plugins/chronokvs/src/chronokvs_mapper.h
+++ b/Plugins/chronokvs/src/chronokvs_mapper.h
@@ -1,6 +1,7 @@
 #ifndef KVS_MAPPER_H_
 #define KVS_MAPPER_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>

--- a/chrono_common/include/AcquireStoryResponseMsg.h
+++ b/chrono_common/include/AcquireStoryResponseMsg.h
@@ -16,19 +16,20 @@ class AcquireStoryResponseMsg
 {
     int error_code;
     StoryId storyId;
-    std::vector <KeeperIdCard> keepers;
+    std::vector<KeeperIdCard> keepers;
     ServiceId player;
 
 public:
-
     AcquireStoryResponseMsg()
         : error_code(chronolog::CL_SUCCESS)
         , storyId(0)
         , player(ServiceId())
     {}
 
-    AcquireStoryResponseMsg(int code, StoryId const &story_id, std::vector <KeeperIdCard> const &keepers_to_use
-                        , ServiceId const& player_to_use=ServiceId())
+    AcquireStoryResponseMsg(int code,
+                            StoryId const& story_id,
+                            std::vector<KeeperIdCard> const& keepers_to_use,
+                            ServiceId const& player_to_use = ServiceId())
         : error_code(code)
         , storyId(story_id)
         , keepers(keepers_to_use)
@@ -37,38 +38,32 @@ public:
 
     ~AcquireStoryResponseMsg() = default;
 
-    int getErrorCode() const
-    { return error_code; }
+    int getErrorCode() const { return error_code; }
 
-    StoryId const &getStoryId() const
-    { return storyId; }
+    StoryId const& getStoryId() const { return storyId; }
 
-    std::vector <KeeperIdCard> const &getKeepers() const
-    { return keepers; }
+    std::vector<KeeperIdCard> const& getKeepers() const { return keepers; }
 
-    ServiceId const& getPlayer() const
-    { return player; }
+    ServiceId const& getPlayer() const { return player; }
 
     template <typename SerArchiveT>
-    void serialize(SerArchiveT &serT)
+    void serialize(SerArchiveT& serT)
     {
         serT & error_code;
         serT & storyId;
         serT & keepers;
         serT & player;
     }
-
 };
 
-}//namespace
+} // namespace chronolog
 
 
-inline std::ostream &operator<<(std::ostream &out, chronolog::AcquireStoryResponseMsg const &msg)
+inline std::ostream& operator<<(std::ostream& out, chronolog::AcquireStoryResponseMsg const& msg)
 {
     out << "AcquireStoryResponseMsg{" << msg.getErrorCode() << "}{story_id:" << msg.getStoryId() << "}{";
-    for(chronolog::KeeperIdCard keeper_card: msg.getKeepers())
-    { out << keeper_card; }
-    out << "}{"<<msg.getPlayer()<<"}";
+    for(chronolog::KeeperIdCard keeper_card: msg.getKeepers()) { out << keeper_card; }
+    out << "}{" << msg.getPlayer() << "}";
 
     return out;
 }

--- a/chrono_common/include/AcquireStoryResponseMsg.h
+++ b/chrono_common/include/AcquireStoryResponseMsg.h
@@ -2,10 +2,12 @@
 #define STORY_ACQUISITION_RESPONSE_MSG_H
 
 #include <iostream>
+#include <vector>
 
 #include "chronolog_types.h"
 #include "ServiceId.h"
 #include "KeeperIdCard.h"
+#include "client_errcode.h"
 
 namespace chronolog
 {

--- a/chrono_common/include/ConfigurationManager.h
+++ b/chrono_common/include/ConfigurationManager.h
@@ -36,8 +36,8 @@ struct ClockConf
     [[nodiscard]] std::string to_String() const
     {
         return "CLOCKSOURCE_TYPE: " + std::string(getClocksourceTypeString(CLOCKSOURCE_TYPE)) +
-               ", DRIFT_CAL_SLEEP_SEC: " + std::to_string(DRIFT_CAL_SLEEP_SEC) + ", DRIFT_CAL_SLEEP_NSEC: " +
-               std::to_string(DRIFT_CAL_SLEEP_NSEC);
+               ", DRIFT_CAL_SLEEP_SEC: " + std::to_string(DRIFT_CAL_SLEEP_SEC) +
+               ", DRIFT_CAL_SLEEP_NSEC: " + std::to_string(DRIFT_CAL_SLEEP_NSEC);
     }
 };
 
@@ -51,15 +51,11 @@ struct AuthConf
         /* Authentication-related configurations */
         AUTH_TYPE = "RBAC";
         MODULE_PATH = "";
-
     }
 
     int parseJsonConf(json_object*);
 
-    [[nodiscard]] std::string to_String() const
-    {
-        return "AUTH_TYPE: " + AUTH_TYPE + ", MODULE_PATH: " + MODULE_PATH;
-    }
+    [[nodiscard]] std::string to_String() const { return "AUTH_TYPE: " + AUTH_TYPE + ", MODULE_PATH: " + MODULE_PATH; }
 };
 
 struct RPCProviderConf
@@ -73,9 +69,8 @@ struct RPCProviderConf
 
     [[nodiscard]] std::string to_String() const
     {
-        return "[PROTO_CONF: " +
-               PROTO_CONF + ", IP: " + IP + ", BASE_PORT: " + std::to_string(BASE_PORT) + ", SERVICE_PROVIDER_ID: " +
-               std::to_string(SERVICE_PROVIDER_ID) + ", PORTS: " + "]";
+        return "[PROTO_CONF: " + PROTO_CONF + ", IP: " + IP + ", BASE_PORT: " + std::to_string(BASE_PORT) +
+               ", SERVICE_PROVIDER_ID: " + std::to_string(SERVICE_PROVIDER_ID) + ", PORTS: " + "]";
     }
 };
 
@@ -89,11 +84,11 @@ struct LogConf
     size_t LOGFILENUM{};
     spdlog::level::level_enum FLUSHLEVEL{};
 
-    void parselogLevelConf(json_object*json_conf, spdlog::level::level_enum &log_level)
+    void parselogLevelConf(json_object* json_conf, spdlog::level::level_enum& log_level)
     {
         if(json_object_is_type(json_conf, json_type_string))
         {
-            const char*conf_str = json_object_get_string(json_conf);
+            const char* conf_str = json_object_get_string(json_conf);
             if(strcmp(conf_str, "trace") == 0)
             {
                 log_level = spdlog::level::trace;
@@ -133,11 +128,11 @@ struct LogConf
         }
     }
 
-    void parseFlushLevelConf(json_object*json_conf, spdlog::level::level_enum &flush_level)
+    void parseFlushLevelConf(json_object* json_conf, spdlog::level::level_enum& flush_level)
     {
         if(json_object_is_type(json_conf, json_type_string))
         {
-            const char*conf_str = json_object_get_string(json_conf);
+            const char* conf_str = json_object_get_string(json_conf);
             if(strcmp(conf_str, "trace") == 0)
             {
                 flush_level = spdlog::level::trace;
@@ -168,8 +163,10 @@ struct LogConf
             }
             else
             {
-                std::cout << "[ConfigurationManager] Unknown flush level: " << conf_str << "Set it to default value: "
-                                                                                           "Warning" << std::endl;
+                std::cout << "[ConfigurationManager] Unknown flush level: " << conf_str
+                          << "Set it to default value: "
+                             "Warning"
+                          << std::endl;
                 flush_level = spdlog::level::warn;
             }
         }
@@ -207,9 +204,9 @@ struct LogConf
 
     [[nodiscard]] std::string to_String() const
     {
-        return "[TYPE: " + LOGTYPE + ", FILE: " + LOGFILE + ", LEVEL: " + LevelToString(LOGLEVEL) + ", NAME: " +
-               LOGNAME + ", LOGFILESIZE: " + std::to_string(LOGFILESIZE) + ", LOGFILENUM: " +
-               std::to_string(LOGFILENUM) + ", FLUSH LEVEL: " + LevelToString(FLUSHLEVEL) + "]";
+        return "[TYPE: " + LOGTYPE + ", FILE: " + LOGFILE + ", LEVEL: " + LevelToString(LOGLEVEL) +
+               ", NAME: " + LOGNAME + ", LOGFILESIZE: " + std::to_string(LOGFILESIZE) +
+               ", LOGFILENUM: " + std::to_string(LOGFILENUM) + ", FLUSH LEVEL: " + LevelToString(FLUSHLEVEL) + "]";
     }
 };
 
@@ -220,18 +217,16 @@ struct DataStoreConf
     int acceptance_window_secs = 60;
     int inactive_story_delay_secs = 180;
 
-    DataStoreConf()
-    { }
+    DataStoreConf() {}
 
     int parseJsonConf(json_object*);
 
     [[nodiscard]] std::string to_String() const
     {
-        return  "[DATA_STORE_CONF: max_story_chunk_size: " + std::to_string(max_story_chunk_size) +
-                " story_chunk_duration_secs: " + std::to_string(story_chunk_duration_secs) +
-                " acceptance_window_secs: " + std::to_string(acceptance_window_secs) +
-                " inactive_story_delay_secs: " + std::to_string(inactive_story_delay_secs) +
-                "]";
+        return "[DATA_STORE_CONF: max_story_chunk_size: " + std::to_string(max_story_chunk_size) +
+               " story_chunk_duration_secs: " + std::to_string(story_chunk_duration_secs) +
+               " acceptance_window_secs: " + std::to_string(acceptance_window_secs) +
+               " inactive_story_delay_secs: " + std::to_string(inactive_story_delay_secs) + "]";
     }
 };
 
@@ -243,8 +238,7 @@ struct ExtractorReaderConf
 
     [[nodiscard]] std::string to_String() const
     {
-        return  "[EXTRACTOR_READER_CONF: STORY_FILES_DIR: " + story_files_dir +
-                "]";
+        return "[EXTRACTOR_READER_CONF: STORY_FILES_DIR: " + story_files_dir + "]";
     }
 };
 
@@ -278,8 +272,8 @@ struct VisorConfiguration
     {
         return "[VISOR_CLIENT_PORTAL_SERVICE_CONF: " + VISOR_CLIENT_PORTAL_SERVICE_CONF.to_String() +
                ", VISOR_KEEPER_REGISTRY_SERVICE_CONF: " + VISOR_KEEPER_REGISTRY_SERVICE_CONF.to_String() +
-               ", VISOR_LOG: " + VISOR_LOG_CONF.to_String() + ", DELAYED_DATA_ADMIN_EXIT_IN_SECS: " +
-               std::to_string(DELAYED_DATA_ADMIN_EXIT_IN_SECS) + "]";
+               ", VISOR_LOG: " + VISOR_LOG_CONF.to_String() +
+               ", DELAYED_DATA_ADMIN_EXIT_IN_SECS: " + std::to_string(DELAYED_DATA_ADMIN_EXIT_IN_SECS) + "]";
     }
 };
 
@@ -323,14 +317,12 @@ struct KeeperConfiguration
     int parseJsonConf(json_object*);
     [[nodiscard]] std::string to_String() const
     {
-        return "[CHRONO_GRAPHER_CONFIGURATION: RECORDING_GROUP: "+ std::to_string(RECORDING_GROUP) +
+        return "[CHRONO_GRAPHER_CONFIGURATION: RECORDING_GROUP: " + std::to_string(RECORDING_GROUP) +
                ", KEEPER_GRAPHER_DRAIN_SERVICE_CONF: " + KEEPER_GRAPHER_DRAIN_SERVICE_CONF.to_String() +
                ", DATA_STORE_ADMIN_SERVICE_CONF: " + DATA_STORE_ADMIN_SERVICE_CONF.to_String() +
                ", VISOR_REGISTRY_SERVICE_CONF: " + VISOR_REGISTRY_SERVICE_CONF.to_String() +
-               ", LOG_CONF: " + LOG_CONF.to_String() +
-               ", DATA_STORE_CONF: " + DATA_STORE_CONF.to_String() +
-               ", EXTRACTOR_CONF: " + EXTRACTOR_CONF.to_String() +
-               "]";
+               ", LOG_CONF: " + LOG_CONF.to_String() + ", DATA_STORE_CONF: " + DATA_STORE_CONF.to_String() +
+               ", EXTRACTOR_CONF: " + EXTRACTOR_CONF.to_String() + "]";
     }
 };
 
@@ -373,14 +365,12 @@ struct GrapherConfiguration
     int parseJsonConf(json_object*);
     [[nodiscard]] std::string to_String() const
     {
-        return "[CHRONO_GRAPHER_CONFIGURATION: RECORDING_GROUP: "+ std::to_string(RECORDING_GROUP) +
+        return "[CHRONO_GRAPHER_CONFIGURATION: RECORDING_GROUP: " + std::to_string(RECORDING_GROUP) +
                ", KEEPER_GRAPHER_DRAIN_SERVICE_CONF: " + KEEPER_GRAPHER_DRAIN_SERVICE_CONF.to_String() +
                ", DATA_STORE_ADMIN_SERVICE_CONF: " + DATA_STORE_ADMIN_SERVICE_CONF.to_String() +
                ", VISOR_REGISTRY_SERVICE_CONF: " + VISOR_REGISTRY_SERVICE_CONF.to_String() +
-               ", LOG_CONF: " + LOG_CONF.to_String() +
-               ", DATA_STORE_CONF: " + DATA_STORE_CONF.to_String() +
-               ", EXTRACTOR_CONF: " + EXTRACTOR_CONF.to_String() +
-               "]";
+               ", LOG_CONF: " + LOG_CONF.to_String() + ", DATA_STORE_CONF: " + DATA_STORE_CONF.to_String() +
+               ", EXTRACTOR_CONF: " + EXTRACTOR_CONF.to_String() + "]";
     }
 };
 
@@ -411,12 +401,12 @@ struct PlayerConfiguration
         VISOR_REGISTRY_SERVICE_CONF.IP = "127.0.0.1";
         VISOR_REGISTRY_SERVICE_CONF.BASE_PORT = 8888;
         VISOR_REGISTRY_SERVICE_CONF.SERVICE_PROVIDER_ID = 88;
-    
+
         DATA_STORE_CONF.max_story_chunk_size = 4096;
         DATA_STORE_CONF.story_chunk_duration_secs = 60;
         DATA_STORE_CONF.acceptance_window_secs = 180;
         DATA_STORE_CONF.inactive_story_delay_secs = 300;
-    
+
         READER_CONF.story_files_dir = "/tmp/";
     }
     int parseJsonConf(json_object*);
@@ -427,10 +417,8 @@ struct PlayerConfiguration
                ", DATA_STORE_ADMIN_SERVICE_CONF: " + DATA_STORE_ADMIN_SERVICE_CONF.to_String() +
                ", PLAYBACK_SERVICE_CONF: " + PLAYBACK_SERVICE_CONF.to_String() +
                ", VISOR_REGISTRY_SERVICE_CONF: " + VISOR_REGISTRY_SERVICE_CONF.to_String() +
-               ", LOG_CONF: " + LOG_CONF.to_String() +
-               ", DATA_STORE_CONF: " + DATA_STORE_CONF.to_String() +
-               ", READER_CONF: " + READER_CONF.to_String() +
-               "]";
+               ", LOG_CONF: " + LOG_CONF.to_String() + ", DATA_STORE_CONF: " + DATA_STORE_CONF.to_String() +
+               ", READER_CONF: " + READER_CONF.to_String() + "]";
     }
 };
 
@@ -445,24 +433,19 @@ public:
     PlayerConfiguration PLAYER_CONF{};
 
     ConfigurationManager()
-    : CLOCK_CONF{}
-    , AUTH_CONF{}
-    , VISOR_CONF{}
-    , KEEPER_CONF{}
-    , GRAPHER_CONF{}
-    , PLAYER_CONF{}
-    {
+        : CLOCK_CONF{}
+        , AUTH_CONF{}
+        , VISOR_CONF{}
+        , KEEPER_CONF{}
+        , GRAPHER_CONF{}
+        , PLAYER_CONF{}
+    {}
 
-    }
+    explicit ConfigurationManager(const std::string& conf_file_path) { LoadConfFromJSONFile(conf_file_path); }
 
-    explicit ConfigurationManager(const std::string &conf_file_path)
+    void LoadConfFromJSONFile(const std::string& conf_file_path)
     {
-        LoadConfFromJSONFile(conf_file_path);
-    }
-
-    void LoadConfFromJSONFile(const std::string &conf_file_path)
-    {
-        json_object*root = json_object_from_file(conf_file_path.c_str());
+        json_object* root = json_object_from_file(conf_file_path.c_str());
         if(root == nullptr)
         {
             std::cerr << "[ConfigurationManager] Failed to open configuration file at path: " << conf_file_path.c_str()
@@ -474,7 +457,7 @@ public:
         {
             if(strcmp(key, "clock") == 0)
             {
-                json_object*clock_conf = json_object_object_get(root, "clock");
+                json_object* clock_conf = json_object_object_get(root, "clock");
                 if(clock_conf == nullptr || !json_object_is_type(clock_conf, json_type_object))
                 {
                     std::cerr << "[ConfigurationManager] Error while parsing configuration file "
@@ -486,7 +469,7 @@ public:
             }
             else if(strcmp(key, "authentication") == 0)
             {
-                json_object*auth_conf = json_object_object_get(root, "authentication");
+                json_object* auth_conf = json_object_object_get(root, "authentication");
                 if(auth_conf == nullptr || !json_object_is_type(auth_conf, json_type_object))
                 {
                     std::cerr << "[ConfigurationManager] Error while parsing configuration file "
@@ -498,7 +481,7 @@ public:
             }
             else if(strcmp(key, "chrono_visor") == 0)
             {
-                json_object*chrono_visor_conf = json_object_object_get(root, "chrono_visor");
+                json_object* chrono_visor_conf = json_object_object_get(root, "chrono_visor");
                 if(chrono_visor_conf == nullptr || !json_object_is_type(chrono_visor_conf, json_type_object))
                 {
                     std::cerr << "[ConfigurationManager] Error while parsing configuration file "
@@ -510,7 +493,7 @@ public:
             }
             else if(strcmp(key, "chrono_keeper") == 0)
             {
-                json_object*chrono_keeper_conf = json_object_object_get(root, "chrono_keeper");
+                json_object* chrono_keeper_conf = json_object_object_get(root, "chrono_keeper");
                 if(chrono_keeper_conf == nullptr || !json_object_is_type(chrono_keeper_conf, json_type_object))
                 {
                     std::cerr << "[ConfigurationManager] Error while parsing configuration file "
@@ -522,7 +505,7 @@ public:
             }
             else if(strcmp(key, "chrono_grapher") == 0)
             {
-                json_object*chrono_grapher_conf = json_object_object_get(root, "chrono_grapher");
+                json_object* chrono_grapher_conf = json_object_object_get(root, "chrono_grapher");
                 if(chrono_grapher_conf == nullptr || !json_object_is_type(chrono_grapher_conf, json_type_object))
                 {
                     std::cerr << "[ConfigurationManager] Error while parsing configuration file "
@@ -534,7 +517,7 @@ public:
             }
             else if(strcmp(key, "chrono_player") == 0)
             {
-                json_object*chrono_player_conf = json_object_object_get(root, "chrono_player");
+                json_object* chrono_player_conf = json_object_object_get(root, "chrono_player");
                 if(chrono_player_conf == nullptr || !json_object_is_type(chrono_player_conf, json_type_object))
                 {
                     std::cerr << "[ConfigurationManager] Error while parsing configuration file "
@@ -548,6 +531,6 @@ public:
         json_object_put(root);
     }
 };
-}
+} // namespace chronolog
 
 #endif //CHRONOLOG_CONFIGURATIONMANAGER_H

--- a/chrono_common/include/ConfigurationManager.h
+++ b/chrono_common/include/ConfigurationManager.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <cassert>

--- a/chrono_common/include/ConnectResponseMsg.h
+++ b/chrono_common/include/ConnectResponseMsg.h
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include "chronolog_types.h"
+#include "client_errcode.h"
 
 namespace chronolog
 {

--- a/chrono_common/include/ConnectResponseMsg.h
+++ b/chrono_common/include/ConnectResponseMsg.h
@@ -15,34 +15,34 @@ class ConnectResponseMsg
     ClientId clientId;
 
 public:
-
-    ConnectResponseMsg(): error_code(chronolog::CL_SUCCESS), clientId(0)
+    ConnectResponseMsg()
+        : error_code(chronolog::CL_SUCCESS)
+        , clientId(0)
     {}
 
-    ConnectResponseMsg(int code, ClientId const &client_id): error_code(code), clientId(client_id)
+    ConnectResponseMsg(int code, ClientId const& client_id)
+        : error_code(code)
+        , clientId(client_id)
     {}
 
     ~ConnectResponseMsg() = default;
 
-    int getErrorCode() const
-    { return error_code; }
+    int getErrorCode() const { return error_code; }
 
-    ClientId const &getClientId() const
-    { return clientId; }
+    ClientId const& getClientId() const { return clientId; }
 
     template <typename SerArchiveT>
-    void serialize(SerArchiveT &serT)
+    void serialize(SerArchiveT& serT)
     {
-        serT&error_code;
-        serT&clientId;
+        serT & error_code;
+        serT & clientId;
     }
-
 };
 
-}//namespace
+} // namespace chronolog
 
 
-inline std::ostream &operator<<(std::ostream &out, chronolog::ConnectResponseMsg const &msg)
+inline std::ostream& operator<<(std::ostream& out, chronolog::ConnectResponseMsg const& msg)
 {
     out << "ConnectResponseMsg{" << msg.getErrorCode() << "}{client_id:" << msg.getClientId() << "}";
     return out;

--- a/chrono_common/include/GrapherStatsMsg.h
+++ b/chrono_common/include/GrapherStatsMsg.h
@@ -17,28 +17,23 @@ class GrapherStatsMsg
     uint32_t active_story_count;
 
 public:
-
-
-    GrapherStatsMsg(GrapherIdCard const & grapher_card = GrapherIdCard{}, uint32_t count = 0)
+    GrapherStatsMsg(GrapherIdCard const& grapher_card = GrapherIdCard{}, uint32_t count = 0)
         : grapherIdCard(grapher_card)
         , active_story_count(count)
     {}
 
     ~GrapherStatsMsg() = default;
 
-    GrapherIdCard const & getGrapherIdCard() const
-    { return grapherIdCard; }
+    GrapherIdCard const& getGrapherIdCard() const { return grapherIdCard; }
 
-    uint32_t getActiveStoryCount() const
-    { return active_story_count; }
+    uint32_t getActiveStoryCount() const { return active_story_count; }
 
     template <typename SerArchiveT>
-    void serialize(SerArchiveT &serT)
+    void serialize(SerArchiveT& serT)
     {
         serT & grapherIdCard;
         serT & active_story_count;
     }
-
 };
 
 inline std::string to_string(GrapherStatsMsg const& stats_msg)
@@ -46,15 +41,15 @@ inline std::string to_string(GrapherStatsMsg const& stats_msg)
     return std::string("GrapherStatsMsg{") + chronolog::to_string(stats_msg.getGrapherIdCard()) + "}";
 }
 
-}
+} // namespace chronolog
 
-inline std::ostream &operator<<(std::ostream &out, chronolog::GrapherStatsMsg const &stats_msg)
+inline std::ostream& operator<<(std::ostream& out, chronolog::GrapherStatsMsg const& stats_msg)
 {
     out << "GrapherStatsMsg{" << stats_msg.getGrapherIdCard() << "}";
     return out;
 }
 
-inline std::string & operator+= (std::string & a_string, chronolog::GrapherStatsMsg const &stats_msg)
+inline std::string& operator+=(std::string& a_string, chronolog::GrapherStatsMsg const& stats_msg)
 {
     a_string += std::string("GrapherStatsMsg{") + chronolog::to_string(stats_msg.getGrapherIdCard()) + "}";
     return a_string;

--- a/chrono_common/include/GrapherStatsMsg.h
+++ b/chrono_common/include/GrapherStatsMsg.h
@@ -2,6 +2,7 @@
 #define GRAPHER_STATS_MSG_H
 
 #include <iostream>
+#include <cstdint>
 
 #include "GrapherIdCard.h"
 

--- a/chrono_common/include/KeeperIdCard.h
+++ b/chrono_common/include/KeeperIdCard.h
@@ -3,6 +3,7 @@
 
 #include <arpa/inet.h>
 #include <iostream>
+#include <cstdint>
 
 #include "ServiceId.h"
 

--- a/chrono_common/include/KeeperIdCard.h
+++ b/chrono_common/include/KeeperIdCard.h
@@ -7,9 +7,9 @@
 
 #include "ServiceId.h"
 
-// this class wrapps ChronoKeeper Process identification 
-// that will be used by all the ChronoLog Processes 
-// to both identify the Keepr process and create RPC client channels 
+// this class wrapps ChronoKeeper Process identification
+// that will be used by all the ChronoLog Processes
+// to both identify the Keepr process and create RPC client channels
 // to send the data to the Keeper RecordingService and Keeper DataStoreAdminService
 
 namespace chronolog
@@ -23,19 +23,17 @@ class KeeperIdCard
     ServiceId recordingServiceId;
 
 public:
-
-
-    KeeperIdCard( uint32_t group_id = 0, ServiceId const& service_id = ServiceId{})
+    KeeperIdCard(uint32_t group_id = 0, ServiceId const& service_id = ServiceId{})
         : groupId(group_id)
         , recordingServiceId(service_id)
     {}
 
-    KeeperIdCard( KeeperIdCard const& other)
+    KeeperIdCard(KeeperIdCard const& other)
         : groupId(other.getGroupId())
         , recordingServiceId(other.getRecordingServiceId())
     {}
 
-    ~KeeperIdCard()=default;
+    ~KeeperIdCard() = default;
 
     RecordingGroupId getGroupId() const { return groupId; }
     ServiceId const& getRecordingServiceId() const { return recordingServiceId; }
@@ -44,19 +42,18 @@ public:
     // serialization function used by thallium RPC providers
     // to serialize/deserialize KeeperIdCard
     template <typename SerArchiveT>
-    void serialize( SerArchiveT & serT)
+    void serialize(SerArchiveT& serT)
     {
         serT & groupId;
         serT & recordingServiceId;
     }
-
 };
 
 inline std::string to_string(chronolog::KeeperIdCard const& keeper_id_card)
 {
     std::string a_string;
-    return std::string("KeeperIdCard{Group{") + std::to_string(keeper_id_card.getGroupId()) + "}" 
-            + to_string(keeper_id_card.getRecordingServiceId()) + "}";
+    return std::string("KeeperIdCard{Group{") + std::to_string(keeper_id_card.getGroupId()) + "}" +
+           to_string(keeper_id_card.getRecordingServiceId()) + "}";
 }
 
 } //namespace chronolog
@@ -64,19 +61,17 @@ inline std::string to_string(chronolog::KeeperIdCard const& keeper_id_card)
 
 inline bool operator==(chronolog::KeeperIdCard const& card1, chronolog::KeeperIdCard const& card2)
 {
-    return (card1.getRecordingServiceId()==card2.getRecordingServiceId());
-
+    return (card1.getRecordingServiceId() == card2.getRecordingServiceId());
 }
 
-inline std::ostream & operator<< (std::ostream & out , chronolog::KeeperIdCard const & keeper_id_card)
+inline std::ostream& operator<<(std::ostream& out, chronolog::KeeperIdCard const& keeper_id_card)
 {
     std::string a_string;
-    out << "KeeperIdCard{Group{"<<keeper_id_card.getGroupId() <<"}"
-       <<keeper_id_card.getRecordingServiceId()<<"}";
+    out << "KeeperIdCard{Group{" << keeper_id_card.getGroupId() << "}" << keeper_id_card.getRecordingServiceId() << "}";
     return out;
 }
 
-inline std::string & operator+= (std::string & a_string , chronolog::KeeperIdCard const & keeper_id_card)
+inline std::string& operator+=(std::string& a_string, chronolog::KeeperIdCard const& keeper_id_card)
 {
     a_string += chronolog::to_string(keeper_id_card);
     return a_string;

--- a/chrono_common/include/KeeperStatsMsg.h
+++ b/chrono_common/include/KeeperStatsMsg.h
@@ -2,6 +2,7 @@
 #define KEEPER_STATS_MSG_H
 
 #include <iostream>
+#include <cstdint>
 
 #include "KeeperIdCard.h"
 

--- a/chrono_common/include/KeeperStatsMsg.h
+++ b/chrono_common/include/KeeperStatsMsg.h
@@ -17,46 +17,41 @@ class KeeperStatsMsg
     uint32_t active_story_count;
 
 public:
-
-
-    KeeperStatsMsg(KeeperIdCard const & keeper_card = KeeperIdCard{}, uint32_t count = 0)
+    KeeperStatsMsg(KeeperIdCard const& keeper_card = KeeperIdCard{}, uint32_t count = 0)
         : keeperIdCard(keeper_card)
         , active_story_count(count)
     {}
 
     ~KeeperStatsMsg() = default;
 
-    KeeperIdCard const & getKeeperIdCard() const
-    { return keeperIdCard; }
+    KeeperIdCard const& getKeeperIdCard() const { return keeperIdCard; }
 
-    uint32_t getActiveStoryCount() const
-    { return active_story_count; }
+    uint32_t getActiveStoryCount() const { return active_story_count; }
 
     template <typename SerArchiveT>
-    void serialize(SerArchiveT &serT)
+    void serialize(SerArchiveT& serT)
     {
         serT & keeperIdCard;
         serT & active_story_count;
     }
-
 };
 
-inline std::string to_string(KeeperStatsMsg const &stats_msg)
+inline std::string to_string(KeeperStatsMsg const& stats_msg)
 {
     return std::string("KeeperStatsMsg{") + to_string(stats_msg.getKeeperIdCard()) + "}";
 }
 
 } //namespace chronolog
 
-inline std::ostream & operator<<(std::ostream &out, chronolog::KeeperStatsMsg const &stats_msg)
+inline std::ostream& operator<<(std::ostream& out, chronolog::KeeperStatsMsg const& stats_msg)
 {
     out << "KeeperStatsMsg{" << stats_msg.getKeeperIdCard() << "}";
     return out;
 }
 
-inline std::string & operator+= (std::string &a_string, chronolog::KeeperStatsMsg const &stats_msg)
+inline std::string& operator+=(std::string& a_string, chronolog::KeeperStatsMsg const& stats_msg)
 {
-    a_string += std::string("KeeperStatsMsg{") + chronolog::to_string(stats_msg.getKeeperIdCard()) + "}"; 
+    a_string += std::string("KeeperStatsMsg{") + chronolog::to_string(stats_msg.getKeeperIdCard()) + "}";
     return a_string;
 }
 

--- a/chrono_common/include/LogEventHVL.h
+++ b/chrono_common/include/LogEventHVL.h
@@ -8,7 +8,8 @@
 #include <H5Cpp.h>
 
 
-namespace chronolog {
+namespace chronolog
+{
 
 class LogEventHVL
 {
@@ -19,90 +20,107 @@ public:
     uint32_t eventIndex{};
     hvl_t logRecord{};
 
-    LogEventHVL(): storyId(0), eventTime(0), clientId(0), eventIndex(0)
+    LogEventHVL()
+        : storyId(0)
+        , eventTime(0)
+        , clientId(0)
+        , eventIndex(0)
     {
         logRecord.len = 0;
         logRecord.p = nullptr;
     };
 
     LogEventHVL(uint64_t story_id, uint64_t event_time, uint32_t client_id, uint32_t event_index, hvl_t log_record)
-            : storyId(story_id), eventTime(event_time), clientId(client_id), eventIndex(event_index)
+        : storyId(story_id)
+        , eventTime(event_time)
+        , clientId(client_id)
+        , eventIndex(event_index)
     {
         logRecord.len = log_record.len;
         logRecord.p = new uint8_t[log_record.len];
         std::memcpy(logRecord.p, log_record.p, log_record.len);
     };
 
-    ~LogEventHVL() {
-        if (logRecord.p) {
+    ~LogEventHVL()
+    {
+        if(logRecord.p)
+        {
             delete[] static_cast<uint8_t*>(logRecord.p);
             logRecord.p = nullptr;
         }
     }
 
     LogEventHVL(const LogEventHVL& other)
-            : storyId(other.storyId), eventTime(other.eventTime), clientId(other.clientId), eventIndex(other.eventIndex) {
+        : storyId(other.storyId)
+        , eventTime(other.eventTime)
+        , clientId(other.clientId)
+        , eventIndex(other.eventIndex)
+    {
         logRecord.len = other.logRecord.len;
         logRecord.p = new uint8_t[logRecord.len];
         std::memcpy(logRecord.p, other.logRecord.p, logRecord.len);
     }
 
-    [[nodiscard]] uint64_t const &time() const
-    { return eventTime; }
+    [[nodiscard]] uint64_t const& time() const { return eventTime; }
 
-    [[nodiscard]] uint32_t const &index() const
-    { return eventIndex; }
+    [[nodiscard]] uint32_t const& index() const { return eventIndex; }
 
     [[nodiscard]] std::string toString() const
     {
-        std::string str =
-                "storyId: " + std::to_string(storyId) + "\n" + "eventTime: " + std::to_string(eventTime) + "\n" +
-                "clientId: " + std::to_string(clientId) + "\n" + "eventIndex: " + std::to_string(eventIndex) + "\n";
+        std::string str = "storyId: " + std::to_string(storyId) + "\n" + "eventTime: " + std::to_string(eventTime) +
+                          "\n" + "clientId: " + std::to_string(clientId) + "\n" +
+                          "eventIndex: " + std::to_string(eventIndex) + "\n";
         str += "logRecord: ";
-        char*ptr = static_cast<char*>(logRecord.p);
+        char* ptr = static_cast<char*>(logRecord.p);
         for(hsize_t i = 0; i < logRecord.len; i++)
         {
             str += *(ptr + i);
             str += " ";
         }
         str += "\n";
-//        LOG_DEBUG("logRecord len: {}", logRecord.len);
+        //        LOG_DEBUG("logRecord len: {}", logRecord.len);
         return str;
     }
 
-    bool operator==(const LogEventHVL &other) const
+    bool operator==(const LogEventHVL& other) const
     {
         return storyId == other.storyId && eventTime == other.eventTime && clientId == other.clientId &&
                eventIndex == other.eventIndex;
     }
 
-    bool operator!=(const LogEventHVL &other) const
-    {
-        return !(*this == other);
-    }
+    bool operator!=(const LogEventHVL& other) const { return !(*this == other); }
 
-    bool operator<(const LogEventHVL &other) const
+    bool operator<(const LogEventHVL& other) const
     {
-        if (eventTime < other.eventTime) {
+        if(eventTime < other.eventTime)
+        {
             return true;
-        } else if (eventTime == other.eventTime) {
-            if (clientId < other.clientId) {
+        }
+        else if(eventTime == other.eventTime)
+        {
+            if(clientId < other.clientId)
+            {
                 return true;
-            } else if (clientId == other.clientId) {
+            }
+            else if(clientId == other.clientId)
+            {
                 return eventIndex < other.eventIndex;
             }
         }
         return false;
     }
 
-    LogEventHVL& operator=(const LogEventHVL& other) {
-        if (this != &other) {
+    LogEventHVL& operator=(const LogEventHVL& other)
+    {
+        if(this != &other)
+        {
             storyId = other.storyId;
             eventTime = other.eventTime;
             clientId = other.clientId;
             eventIndex = other.eventIndex;
 
-            if (logRecord.p) {
+            if(logRecord.p)
+            {
                 delete[] static_cast<uint8_t*>(logRecord.p);
             }
 

--- a/chrono_common/include/LogEventHVL.h
+++ b/chrono_common/include/LogEventHVL.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <cstring>
+#include <cstdint>
 #include <H5Cpp.h>
 
 

--- a/chrono_common/include/PlayerStatsMsg.h
+++ b/chrono_common/include/PlayerStatsMsg.h
@@ -2,6 +2,7 @@
 #define PLAYER_STATS_MSG_H
 
 #include <iostream>
+#include <cstdint>
 
 #include "PlayerIdCard.h"
 

--- a/chrono_common/include/PlayerStatsMsg.h
+++ b/chrono_common/include/PlayerStatsMsg.h
@@ -17,45 +17,40 @@ class PlayerStatsMsg
     uint32_t active_story_count;
 
 public:
-
-
-    PlayerStatsMsg(PlayerIdCard const & player_card = PlayerIdCard{}, uint32_t count = 0)
+    PlayerStatsMsg(PlayerIdCard const& player_card = PlayerIdCard{}, uint32_t count = 0)
         : playerIdCard(player_card)
         , active_story_count(count)
     {}
 
     ~PlayerStatsMsg() = default;
 
-    PlayerIdCard const & getPlayerIdCard() const
-    { return playerIdCard; }
+    PlayerIdCard const& getPlayerIdCard() const { return playerIdCard; }
 
-    uint32_t getActiveStoryCount() const
-    { return active_story_count; }
+    uint32_t getActiveStoryCount() const { return active_story_count; }
 
     template <typename SerArchiveT>
-    void serialize(SerArchiveT & serT)
+    void serialize(SerArchiveT& serT)
     {
         serT & playerIdCard;
         serT & active_story_count;
     }
-
 };
 
-inline std::string to_string(chronolog::PlayerStatsMsg const &stats_msg)
+inline std::string to_string(chronolog::PlayerStatsMsg const& stats_msg)
 {
     return std::string("PlayerStatsMsg{") + to_string(stats_msg.getPlayerIdCard()) + "}";
 }
 
 
-}
+} // namespace chronolog
 
-inline std::ostream & operator<<(std::ostream &out, chronolog::PlayerStatsMsg const &stats_msg)
+inline std::ostream& operator<<(std::ostream& out, chronolog::PlayerStatsMsg const& stats_msg)
 {
     out << "PlayerStatsMsg{" << stats_msg.getPlayerIdCard() << "}";
     return out;
 }
 
-inline std::string & operator+= (std::string & a_string, chronolog::PlayerStatsMsg const &stats_msg)
+inline std::string& operator+=(std::string& a_string, chronolog::PlayerStatsMsg const& stats_msg)
 {
     a_string += std::string("PlayerStatsMsg{") + chronolog::to_string(stats_msg.getPlayerIdCard()) + "}";
     return a_string;

--- a/chrono_common/include/ServiceId.h
+++ b/chrono_common/include/ServiceId.h
@@ -3,6 +3,9 @@
 
 #include <arpa/inet.h>
 #include <iostream>
+#include <string>
+#include <utility>
+#include <cstdint>
 
 
 namespace chronolog

--- a/chrono_common/include/ServiceId.h
+++ b/chrono_common/include/ServiceId.h
@@ -13,19 +13,19 @@ namespace chronolog
 
 typedef uint32_t RecordingGroupId;
 
-typedef uint32_t        in_addr_t;
-typedef uint16_t        in_port_t;
-typedef std::pair <in_addr_t, in_port_t> service_endpoint;
+typedef uint32_t in_addr_t;
+typedef uint16_t in_port_t;
+typedef std::pair<in_addr_t, in_port_t> service_endpoint;
 
-static int ip_addr_from_dotted_string_to_uint32(std::string const &ip_string, uint32_t & ip_address)
+static int ip_addr_from_dotted_string_to_uint32(std::string const& ip_string, uint32_t& ip_address)
 {
     struct sockaddr_in sa;
     // translate the recording service dotted IP string into 32bit network byte order representation
     int inet_pton_return = inet_pton(AF_INET, ip_string.c_str(), &sa.sin_addr.s_addr); //returns 1 on success
     if(1 != inet_pton_return)
     {
-        ip_address=0;
-        return(-1);
+        ip_address = 0;
+        return (-1);
     }
 
     // translate 32bit ip from network byte order into the host byte order
@@ -36,24 +36,27 @@ static int ip_addr_from_dotted_string_to_uint32(std::string const &ip_string, ui
 
 class ServiceId
 {
-// we are using a combination of the uint32_t representation of the service IP address
-// and uint16_t representation of the port number to identify service endpoint
-// NOTE: both IP and port values ServiceId are kept in the host byte order, not the network order)
+    // we are using a combination of the uint32_t representation of the service IP address
+    // and uint16_t representation of the port number to identify service endpoint
+    // NOTE: both IP and port values ServiceId are kept in the host byte order, not the network order)
 
-    std::string protocol;//protocol string : ex "ofi+sockets"
-    uint32_t ip_addr;    //32int IP representation in host notation
-    uint16_t port;       //16int port representation in host notation
-    uint16_t provider_id;//thalium provider id
+    std::string protocol; //protocol string : ex "ofi+sockets"
+    uint32_t ip_addr;     //32int IP representation in host notation
+    uint16_t port;        //16int port representation in host notation
+    uint16_t provider_id; //thalium provider id
 
 public:
-    ServiceId(std::string const & protocol=std::string(), uint32_t addr = 0, uint16_t a_port = 0, uint16_t a_provider_id = 0)
+    ServiceId(std::string const& protocol = std::string(),
+              uint32_t addr = 0,
+              uint16_t a_port = 0,
+              uint16_t a_provider_id = 0)
         : protocol(protocol)
         , ip_addr(addr)
         , port(a_port)
         , provider_id(a_provider_id)
     {}
 
-    ServiceId(std::string const & protocol, std::string const & ip_string, uint16_t a_port, uint16_t a_provider_id)
+    ServiceId(std::string const& protocol, std::string const& ip_string, uint16_t a_port, uint16_t a_provider_id)
         : protocol(protocol)
         , ip_addr(0)
         , port(a_port)
@@ -62,7 +65,7 @@ public:
         ip_addr_from_dotted_string_to_uint32(ip_string, ip_addr);
     }
 
-    ServiceId( std::string const & protocol, service_endpoint const & endpoint, uint16_t a_provider_id)
+    ServiceId(std::string const& protocol, service_endpoint const& endpoint, uint16_t a_provider_id)
         : protocol(protocol)
         , ip_addr(endpoint.first)
         , port(endpoint.second)
@@ -70,23 +73,17 @@ public:
     {}
 
     ServiceId(ServiceId const&) = default;
-    ServiceId & operator=(ServiceId const&) = default;
+    ServiceId& operator=(ServiceId const&) = default;
     ~ServiceId() = default;
 
     std::string const& getProtocol() const { return protocol; }
     uint32_t getIPaddr() const { return ip_addr; }
-    uint16_t getPort() const { return port;}
-    uint16_t getProviderId () const { return provider_id; }
+    uint16_t getPort() const { return port; }
+    uint16_t getProviderId() const { return provider_id; }
 
-    inline service_endpoint get_service_endpoint() const
-    {
-        return service_endpoint(ip_addr,port);
-    }
+    inline service_endpoint get_service_endpoint() const { return service_endpoint(ip_addr, port); }
 
-    bool is_valid() const
-    {
-        return (!protocol.empty() && (ip_addr != 0) && (port != 0) && (provider_id != 0));
-    }
+    bool is_valid() const { return (!protocol.empty() && (ip_addr != 0) && (port != 0) && (provider_id != 0)); }
 
     template <typename SerArchiveT>
     void serialize(SerArchiveT& serT)
@@ -97,53 +94,58 @@ public:
         serT & provider_id;
     }
 
-    std::string & get_ip_as_dotted_string(std::string & a_string) const
+    std::string& get_ip_as_dotted_string(std::string& a_string) const
     {
 
         char buffer[INET_ADDRSTRLEN];
         // convert ip from host to network byte order uint32_t
         uint32_t ip_net_order = htonl(ip_addr);
         // convert network byte order uint32_t to a dotted string
-        if(NULL != inet_ntop(AF_INET, &ip_net_order, buffer, INET_ADDRSTRLEN)) { a_string += std::string(buffer); }
+        if(NULL != inet_ntop(AF_INET, &ip_net_order, buffer, INET_ADDRSTRLEN))
+        {
+            a_string += std::string(buffer);
+        }
         return a_string;
     }
 
-    std::string & get_service_as_string(std::string & service_as_string) const
+    std::string& get_service_as_string(std::string& service_as_string) const
     {
-        service_as_string =  protocol + "://" + get_ip_as_dotted_string(service_as_string) + ":"+ std::to_string(port);
-        
-        return service_as_string;
+        service_as_string = protocol + "://" + get_ip_as_dotted_string(service_as_string) + ":" + std::to_string(port);
 
+        return service_as_string;
     }
 };
 
 inline std::string to_string(ServiceId const& serviceId)
 {
     std::string a_string;
-    return std::string("ServiceId{") +serviceId.getProtocol() + ":" + serviceId.get_ip_as_dotted_string(a_string) + ":" + std::to_string(serviceId.getPort()) + ":" +
-                std::to_string(serviceId.getProviderId()) + "}";
+    return std::string("ServiceId{") + serviceId.getProtocol() + ":" + serviceId.get_ip_as_dotted_string(a_string) +
+           ":" + std::to_string(serviceId.getPort()) + ":" + std::to_string(serviceId.getProviderId()) + "}";
 }
 
-}//namespace chronolog
+} //namespace chronolog
 
 inline bool operator==(chronolog::ServiceId const& service_id_1, chronolog::ServiceId const& service_id_2)
 {
-    return ( (service_id_1.getProtocol() == service_id_2.getProtocol()) && (service_id_1.getIPaddr() == service_id_2.getIPaddr())
-            && (service_id_1.getPort() == service_id_2.getPort()) && (service_id_1.getProviderId() == service_id_2.getProviderId()));
+    return ((service_id_1.getProtocol() == service_id_2.getProtocol()) &&
+            (service_id_1.getIPaddr() == service_id_2.getIPaddr()) &&
+            (service_id_1.getPort() == service_id_2.getPort()) &&
+            (service_id_1.getProviderId() == service_id_2.getProviderId()));
 }
 
 
 inline std::ostream& operator<<(std::ostream& out, chronolog::ServiceId const serviceId)
 {
     std::string a_string;
-    out << "ServiceId{" << serviceId.getProtocol()<<":"<<serviceId.get_ip_as_dotted_string(a_string) << ":" << serviceId.getPort() << ":" 
-        << serviceId.getProviderId() << "}";
+    out << "ServiceId{" << serviceId.getProtocol() << ":" << serviceId.get_ip_as_dotted_string(a_string) << ":"
+        << serviceId.getPort() << ":" << serviceId.getProviderId() << "}";
     return out;
 }
 
-inline std::string& operator+= (std::string& a_string, chronolog::ServiceId const& serviceId)
+inline std::string& operator+=(std::string& a_string, chronolog::ServiceId const& serviceId)
 {
-    a_string += std::string("ServiceId{") + serviceId.getProtocol() + ":" + serviceId.get_ip_as_dotted_string(a_string) + ":" + std::to_string(serviceId.getPort()) + ":" +
+    a_string += std::string("ServiceId{") + serviceId.getProtocol() + ":" +
+                serviceId.get_ip_as_dotted_string(a_string) + ":" + std::to_string(serviceId.getPort()) + ":" +
                 std::to_string(serviceId.getProviderId()) + "}";
     return a_string;
 }

--- a/chrono_common/include/StoryChunk.h
+++ b/chrono_common/include/StoryChunk.h
@@ -11,7 +11,7 @@
 #include <chrono_monitor.h>
 #include <chronolog_client.h> //for chronolog::Event definition
 
-#include "chronolog_types.h"  //for chronolog::LogEvent definition
+#include "chronolog_types.h" //for chronolog::LogEvent definition
 
 
 namespace chronolog
@@ -22,61 +22,54 @@ namespace chronolog
 // startTime included, endTime excluded
 // startTime/endTime are invariant
 
-typedef std::tuple <chrono_time, chrono_index> ArrivalSequence;
-typedef std::tuple <chrono_time, ClientId, chrono_index> EventSequence;
+typedef std::tuple<chrono_time, chrono_index> ArrivalSequence;
+typedef std::tuple<chrono_time, ClientId, chrono_index> EventSequence;
 
 class StoryChunk
 {
 public:
-
-    StoryChunk(ChronicleName const &chronicle_name = "", StoryName const &story_name = ""
-               , StoryId const &story_id = 0, uint64_t start_time = 0, uint64_t end_time = 0
-               , uint32_t chunk_size = 1024);
+    StoryChunk(ChronicleName const& chronicle_name = "",
+               StoryName const& story_name = "",
+               StoryId const& story_id = 0,
+               uint64_t start_time = 0,
+               uint64_t end_time = 0,
+               uint32_t chunk_size = 1024);
 
     ~StoryChunk();
 
-    ChronicleName const &getChronicleName() const
-    { return chronicleName; }
+    ChronicleName const& getChronicleName() const { return chronicleName; }
 
-    StoryName const &getStoryName() const
-    { return storyName; }
+    StoryName const& getStoryName() const { return storyName; }
 
-    StoryId const &getStoryId() const
-    { return storyId; }
+    StoryId const& getStoryId() const { return storyId; }
 
-    uint64_t getStartTime() const
-    { return startTime; }
+    uint64_t getStartTime() const { return startTime; }
 
-    uint64_t getEndTime() const
-    { return endTime; }
+    uint64_t getEndTime() const { return endTime; }
 
-    int getEventCount() const
-    { return logEvents.size(); }
+    int getEventCount() const { return logEvents.size(); }
 
-    bool empty() const
-    { return (logEvents.empty() ? true : false); }
+    bool empty() const { return (logEvents.empty() ? true : false); }
 
-    std::map <EventSequence, LogEvent>::const_iterator begin() const
-    { return logEvents.begin(); }
+    std::map<EventSequence, LogEvent>::const_iterator begin() const { return logEvents.begin(); }
 
-    std::map <EventSequence, LogEvent>::const_iterator end() const
-    { return logEvents.end(); }
+    std::map<EventSequence, LogEvent>::const_iterator end() const { return logEvents.end(); }
 
-    std::map <EventSequence, LogEvent>::const_iterator lower_bound(uint64_t chrono_time) const
-    { return logEvents.lower_bound(EventSequence{chrono_time, 0, 0}); }
+    std::map<EventSequence, LogEvent>::const_iterator lower_bound(uint64_t chrono_time) const
+    {
+        return logEvents.lower_bound(EventSequence{chrono_time, 0, 0});
+    }
 
-    uint64_t firstEventTime() const
-    { return (logEvents.empty() ? 0 : (*logEvents.begin()).second.time()); }
+    uint64_t firstEventTime() const { return (logEvents.empty() ? 0 : (*logEvents.begin()).second.time()); }
 
-    uint64_t lastEventTime() const
-    { return (logEvents.empty() ? 0 : (*(--logEvents.end())).second.time()); }
+    uint64_t lastEventTime() const { return (logEvents.empty() ? 0 : (*(--logEvents.end())).second.time()); }
 
-    int insertEvent(LogEvent const &);
+    int insertEvent(LogEvent const&);
 
-    uint32_t mergeEvents(std::map <EventSequence, LogEvent> &events
-                         , std::map <EventSequence, LogEvent>::const_iterator &merge_start);
+    uint32_t mergeEvents(std::map<EventSequence, LogEvent>& events,
+                         std::map<EventSequence, LogEvent>::const_iterator& merge_start);
 
-    uint32_t mergeEvents(StoryChunk &other_chunk, uint64_t start_time = 0);
+    uint32_t mergeEvents(StoryChunk& other_chunk, uint64_t start_time = 0);
 
     /*    uint32_t
     extractEvents(std::map <EventSequence, LogEvent> &target_map, std::map <EventSequence, LogEvent>::iterator first_pos
@@ -86,39 +79,40 @@ public:
 
     uint32_t extractEvents( StoryChunk & target_chunk, uint64_t start_time, uint64_t end_time);
 */
-    std::map <EventSequence, LogEvent>::iterator
-    eraseEvents(std::map <EventSequence, LogEvent>::const_iterator &first_pos
-                , std::map <EventSequence, LogEvent>::const_iterator &last_pos);
+    std::map<EventSequence, LogEvent>::iterator
+    eraseEvents(std::map<EventSequence, LogEvent>::const_iterator& first_pos,
+                std::map<EventSequence, LogEvent>::const_iterator& last_pos);
 
-    std::map <EventSequence, LogEvent>::iterator eraseEvents(uint64_t start_time, uint64_t end_time);
-    
+    std::map<EventSequence, LogEvent>::iterator eraseEvents(uint64_t start_time, uint64_t end_time);
+
     // serialization function used by thallium RPC providers
     template <typename SerArchiveT>
-    void serialize(SerArchiveT &serT)
+    void serialize(SerArchiveT& serT)
     {
-        serT&chronicleName;
-        serT&storyName;
-        serT&storyId;
-        serT&startTime;
-        serT&endTime;
-        serT&revisionTime;
-        serT&logEvents;
+        serT & chronicleName;
+        serT & storyName;
+        serT & storyId;
+        serT & startTime;
+        serT & endTime;
+        serT & revisionTime;
+        serT & logEvents;
     }
 
-inline std::string to_string() const
-{
+    inline std::string to_string() const
+    {
         std::stringstream sstream;
         sstream << "StoryChunk:{" << storyId << ":" << startTime << ":" << endTime << "} has " << logEvents.size()
-           << " events total";
-        for(auto const &event: logEvents)
+                << " events total";
+        for(auto const& event: logEvents)
         {
-            sstream << std::endl <<"<" << std::get <0>(event.first) << ", " << std::get <1>(event.first) << ", "
-               << std::get <2>(event.first);
+            sstream << std::endl
+                    << "<" << std::get<0>(event.first) << ", " << std::get<1>(event.first) << ", "
+                    << std::get<2>(event.first);
         }
         return sstream.str();
-}
+    }
 
-    std::vector<Event> & extractEventSeries( std::vector<Event> & event_series);
+    std::vector<Event>& extractEventSeries(std::vector<Event>& event_series);
 
 private:
     ChronicleName chronicleName;
@@ -127,8 +121,8 @@ private:
     uint64_t startTime;
     uint64_t endTime;
     uint64_t revisionTime;
-    std::map <EventSequence, LogEvent> logEvents;
+    std::map<EventSequence, LogEvent> logEvents;
 };
 
-}
+} // namespace chronolog
 #endif

--- a/chrono_common/include/StoryChunk.h
+++ b/chrono_common/include/StoryChunk.h
@@ -8,8 +8,8 @@
 #include <thallium/serialization/stl/map.hpp>
 #include <thallium/serialization/stl/tuple.hpp>
 
-#include <chronolog_client.h> //for chronolog::Event definition
 #include <chrono_monitor.h>
+#include <chronolog_client.h> //for chronolog::Event definition
 
 #include "chronolog_types.h"  //for chronolog::LogEvent definition
 

--- a/chrono_common/include/StoryChunkHVL.h
+++ b/chrono_common/include/StoryChunkHVL.h
@@ -9,7 +9,8 @@
 #include "chronolog_types.h"
 #include "LogEventHVL.h"
 
-namespace chronolog {
+namespace chronolog
+{
 
 typedef std::tuple<chrono_time, chrono_index> ArrivalSequence;
 typedef std::tuple<chrono_time, ClientId, chrono_index> EventSequence;
@@ -18,91 +19,87 @@ typedef std::tuple<uint64_t, uint64_t> EventOffsetSize;
 class StoryChunkHVL
 {
 public:
-    explicit StoryChunkHVL(ChronicleName const &chronicle_name = "", StoryName const &story_name = ""
-                           , StoryId const &story_id = 0, uint64_t start_time = 0
-                           , uint64_t end_time = 0, uint32_t chunk_size = 0)
-            : chronicleName(chronicle_name), storyName(story_name)
-              , storyId(story_id)
-              , startTime(start_time), endTime(end_time), revisionTime(end_time)
+    explicit StoryChunkHVL(ChronicleName const& chronicle_name = "",
+                           StoryName const& story_name = "",
+                           StoryId const& story_id = 0,
+                           uint64_t start_time = 0,
+                           uint64_t end_time = 0,
+                           uint32_t chunk_size = 0)
+        : chronicleName(chronicle_name)
+        , storyName(story_name)
+        , storyId(story_id)
+        , startTime(start_time)
+        , endTime(end_time)
+        , revisionTime(end_time)
     {}
 
     ~StoryChunkHVL() = default;
 
-    ChronicleName const &getChronicleName() const
-    { return chronicleName; }
+    ChronicleName const& getChronicleName() const { return chronicleName; }
 
-    StoryName const &getStoryName() const
-    { return storyName; }
+    StoryName const& getStoryName() const { return storyName; }
 
-    [[nodiscard]] StoryId const &getStoryId() const
-    { return storyId; }
+    [[nodiscard]] StoryId const& getStoryId() const { return storyId; }
 
-    [[nodiscard]] uint64_t getStartTime() const
-    { return startTime; }
+    [[nodiscard]] uint64_t getStartTime() const { return startTime; }
 
-    [[nodiscard]] uint64_t getEndTime() const
-    { return endTime; }
+    [[nodiscard]] uint64_t getEndTime() const { return endTime; }
 
-    [[nodiscard]] bool empty() const
-    { return logEvents.empty(); }
+    [[nodiscard]] bool empty() const { return logEvents.empty(); }
 
-    [[nodiscard]] size_t getEventCount() const
-    { return logEvents.size(); }
+    [[nodiscard]] size_t getEventCount() const { return logEvents.size(); }
 
     [[nodiscard]] size_t getTotalPayloadSize() const
     {
         size_t total_size = 0;
-        for(auto const &event: logEvents)
-        { total_size += event.second.logRecord.len; }
+        for(auto const& event: logEvents) { total_size += event.second.logRecord.len; }
         return total_size;
     }
 
-    [[nodiscard]] std::map <EventSequence, LogEventHVL>::const_iterator begin() const
-    { return logEvents.begin(); }
+    [[nodiscard]] std::map<EventSequence, LogEventHVL>::const_iterator begin() const { return logEvents.begin(); }
 
-    [[nodiscard]] std::map <EventSequence, LogEventHVL>::const_iterator end() const
-    { return logEvents.end(); }
+    [[nodiscard]] std::map<EventSequence, LogEventHVL>::const_iterator end() const { return logEvents.end(); }
 
-    [[nodiscard]] std::map <EventSequence, LogEventHVL>::const_iterator lower_bound(uint64_t chrono_time) const
-    { return logEvents.lower_bound(EventSequence{chrono_time, 0, 0}); }
+    [[nodiscard]] std::map<EventSequence, LogEventHVL>::const_iterator lower_bound(uint64_t chrono_time) const
+    {
+        return logEvents.lower_bound(EventSequence{chrono_time, 0, 0});
+    }
 
-    [[nodiscard]] uint64_t firstEventTime() const
-    { return (*logEvents.begin()).second.time(); }
+    [[nodiscard]] uint64_t firstEventTime() const { return (*logEvents.begin()).second.time(); }
 
-    int insertEvent(LogEventHVL const &event)
+    int insertEvent(LogEventHVL const& event)
     {
         if((event.time() >= startTime) && (event.time() < endTime))
         {
-            logEvents.insert(std::pair <EventSequence, LogEventHVL>({event.time(), event.clientId, event.index()},
-                                                                  event));
+            logEvents.insert(
+                    std::pair<EventSequence, LogEventHVL>({event.time(), event.clientId, event.index()}, event));
             return 1;
         }
         else
-        { return 0; }
+        {
+            return 0;
+        }
     }
 
-    bool operator==(const StoryChunkHVL &other) const
+    bool operator==(const StoryChunkHVL& other) const
     {
         return ((storyId == other.storyId) && (startTime == other.startTime) && (endTime == other.endTime) &&
                 (revisionTime == other.revisionTime) && (logEvents == other.logEvents));
     }
 
-    bool operator!=(const StoryChunkHVL &other) const
-    {
-        return !(*this == other);
-    }
+    bool operator!=(const StoryChunkHVL& other) const { return !(*this == other); }
 
     [[nodiscard]] std::string toString() const
     {
         std::stringstream ss;
         ss << "StoryChunk:{" << storyId << ":" << startTime << ":" << endTime << "} has " << logEvents.size()
            << " events: ";
-        for(auto const &event: logEvents)
+        for(auto const& event: logEvents)
         {
-            ss << "<" << std::get <0>(event.first) << ", " << std::get <1>(event.first) << ", "
-               << std::get <2>(event.first) << ">: " << event.second.toString();
+            ss << "<" << std::get<0>(event.first) << ", " << std::get<1>(event.first) << ", "
+               << std::get<2>(event.first) << ">: " << event.second.toString();
         }
-//        LOG_DEBUG("string size in StoryChunk::toString(): {}", ss.str().size());
+        //        LOG_DEBUG("string size in StoryChunk::toString(): {}", ss.str().size());
         return ss.str();
     }
 
@@ -113,8 +110,7 @@ public:
     uint64_t endTime;
     uint64_t revisionTime;
 
-    std::map <EventSequence, LogEventHVL> logEvents;
-
+    std::map<EventSequence, LogEventHVL> logEvents;
 };
 
 struct OffsetMapEntry
@@ -128,8 +124,9 @@ struct OffsetMapEntry
         offsetSize = EventOffsetSize(0, 0);
     }
 
-    OffsetMapEntry(EventSequence eventId, EventOffsetSize offsetSize): eventId(
-            std::move(eventId)), offsetSize(std::move(offsetSize))
+    OffsetMapEntry(EventSequence eventId, EventOffsetSize offsetSize)
+        : eventId(std::move(eventId))
+        , offsetSize(std::move(offsetSize))
     {}
 };
 

--- a/chrono_common/include/StoryChunkHVL.h
+++ b/chrono_common/include/StoryChunkHVL.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <cstdint>
 
 #include "chronolog_types.h"
 #include "LogEventHVL.h"

--- a/chrono_common/include/StoryPipeline.h
+++ b/chrono_common/include/StoryPipeline.h
@@ -32,41 +32,44 @@ class StoryPipeline
 {
 
 public:
-    StoryPipeline(StoryChunkExtractionQueue &, ChronicleName const &chronicle_name, StoryName const &story_name
-                  , StoryId const &story_id, uint64_t start_time, uint32_t chunk_granularity = 60 // seconds
-                  , uint32_t acceptance_window = 120 // seconds
+    StoryPipeline(StoryChunkExtractionQueue&,
+                  ChronicleName const& chronicle_name,
+                  StoryName const& story_name,
+                  StoryId const& story_id,
+                  uint64_t start_time,
+                  uint32_t chunk_granularity = 60 // seconds
+                  ,
+                  uint32_t acceptance_window = 120 // seconds
     );
 
-    StoryPipeline(StoryPipeline const &) = delete;
+    StoryPipeline(StoryPipeline const&) = delete;
 
-    StoryPipeline &operator=(StoryPipeline const &) = delete;
+    StoryPipeline& operator=(StoryPipeline const&) = delete;
 
     ~StoryPipeline();
 
 
-    StoryChunkIngestionHandle*getActiveIngestionHandle();
+    StoryChunkIngestionHandle* getActiveIngestionHandle();
 
     void collectIngestedEvents();
 
-    void mergeEvents(StoryChunk &);
+    void mergeEvents(StoryChunk&);
 
     void extractDecayedStoryChunks(uint64_t);
 
-    StoryId const &getStoryId() const
-    { return storyId; }
+    StoryId const& getStoryId() const { return storyId; }
 
-    uint64_t getAcceptanceWindow() const
-    { return acceptanceWindow; }
+    uint64_t getAcceptanceWindow() const { return acceptanceWindow; }
 
-    uint64_t TimelineStart() const
-    { return (*storyTimelineMap.begin()).first; }  // storyTimelineMap is never left empty 
+    uint64_t TimelineStart() const { return (*storyTimelineMap.begin()).first; } // storyTimelineMap is never left empty
 
     uint64_t TimelineEnd() const
-    { return (*storyTimelineMap.rbegin()).second->getEndTime(); } // storyTimelineMap is never left empty
+    {
+        return (*storyTimelineMap.rbegin()).second->getEndTime();
+    } // storyTimelineMap is never left empty
 
 private:
-
-    StoryChunkExtractionQueue &theExtractionQueue;
+    StoryChunkExtractionQueue& theExtractionQueue;
     StoryId storyId;
     ChronicleName chronicleName;
     StoryName storyName;
@@ -77,28 +80,28 @@ private:
     // mutex used to protect the IngestionQueue from concurrent access
     // by RecordingService threads
     std::mutex ingestionMutex;
-    // two ingestion queues so that they can take turns playing 
+    // two ingestion queues so that they can take turns playing
     // active/passive ingestion duty
-    // 
-    std::deque <StoryChunk*> chunkQueue1;
-    std::deque <StoryChunk*> chunkQueue2;
+    //
+    std::deque<StoryChunk*> chunkQueue1;
+    std::deque<StoryChunk*> chunkQueue2;
 
-    StoryChunkIngestionHandle*activeIngestionHandle;
+    StoryChunkIngestionHandle* activeIngestionHandle;
 
-    // mutex used to protect Story sequencing operations 
+    // mutex used to protect Story sequencing operations
     // from concurrent access by the DataStore Sequencing threads
     std::mutex sequencingMutex;
 
     // map of storyChunks ordered by StoryChunck.startTime
-    std::map <chrono_time, StoryChunk*> storyTimelineMap;
+    std::map<chrono_time, StoryChunk*> storyTimelineMap;
 
     // Added friend tests for the unit tests to test private functions
 
     FRIEND_TEST(::StoryPipeline_TestPrependStoryChunk, testSuccess);
-    std::map <uint64_t, StoryChunk*>::iterator prependStoryChunk();
+    std::map<uint64_t, StoryChunk*>::iterator prependStoryChunk();
 
     FRIEND_TEST(::StoryPipeline_TestAppendStoryChunk, testSuccess);
-    std::map <uint64_t, StoryChunk*>::iterator appendStoryChunk();
+    std::map<uint64_t, StoryChunk*>::iterator appendStoryChunk();
 
     FRIEND_TEST(::StoryPipeline_TestFinalize, testNoPendingChunks);
     FRIEND_TEST(::StoryPipeline_TestFinalize, testOnlyPassiveDeque);
@@ -110,5 +113,5 @@ private:
     void finalize();
 };
 
-}
+} // namespace chronolog
 #endif

--- a/chrono_common/include/StoryPipeline.h
+++ b/chrono_common/include/StoryPipeline.h
@@ -7,12 +7,11 @@
 #include <mutex>
 #include <iostream>
 
+#include <gtest/gtest.h>
+
 #include "chronolog_types.h"
 #include "StoryChunk.h"
 #include "StoryChunkExtractionQueue.h"
-
-// Added helper for the unit tests to test private functions
-#include <gtest/gtest.h>
 class StoryPipeline_TestAppendStoryChunk_testSuccess_Test;
 class StoryPipeline_TestPrependStoryChunk_testSuccess_Test;
 class StoryPipeline_TestFinalize_testNoPendingChunks_Test;

--- a/chrono_common/include/TimerWrapper.h
+++ b/chrono_common/include/TimerWrapper.h
@@ -15,13 +15,15 @@
 class TimerWrapper
 {
 public:
-    TimerWrapper(bool enable_timing, const std::string &name): name(name), enabled(enable_timing)
+    TimerWrapper(bool enable_timing, const std::string& name)
+        : name(name)
+        , enabled(enable_timing)
     {
         int rank;
         MPI_Comm_rank(MPI_COMM_WORLD, &rank);
         if(rank == 0)
         {
-//            std::cout << "Resolution of timer " << name << ": " << MPI_Wtick() << " second.\n";
+            //            std::cout << "Resolution of timer " << name << ": " << MPI_Wtick() << " second.\n";
             int global_time_flag;
             int flag;
             MPI_Attr_get(MPI_COMM_SELF, MPI_WTIME_IS_GLOBAL, &global_time_flag, &flag);
@@ -30,22 +32,24 @@ public:
                 // If the attribute exists, print its value
                 if(!global_time_flag)
                 {
-                    std::cerr << "MPI_Wtime clocks are NOT synchronized across all processes for timer " << name <<
-                    std::endl;
+                    std::cerr << "MPI_Wtime clocks are NOT synchronized across all processes for timer " << name
+                              << std::endl;
                 }
             }
             else
             {
-                std::cerr << "MPI_WTIME_IS_GLOBAL is not available in this MPI implementation for timer " << name <<
-                std::endl;
+                std::cerr << "MPI_WTIME_IS_GLOBAL is not available in this MPI implementation for timer " << name
+                          << std::endl;
             }
         }
     }
 
     // Timing wrapper for functions that return non-void
-    template <typename Func, typename... Args, typename RetType = decltype(std::invoke(std::declval <Func>()
-                                                                                       , std::declval <Args>()...)), typename std::enable_if <!std::is_void <RetType>::value, int>::type = 0>
-    auto timeBlock(Func &&func, Args &&... args) -> RetType
+    template <typename Func,
+              typename... Args,
+              typename RetType = decltype(std::invoke(std::declval<Func>(), std::declval<Args>()...)),
+              typename std::enable_if<!std::is_void<RetType>::value, int>::type = 0>
+    auto timeBlock(Func&& func, Args&&... args) -> RetType
     {
         if(enabled)
         {
@@ -53,8 +57,7 @@ public:
             MPI_Comm_rank(MPI_COMM_WORLD, &rank);
             MPI_Comm_size(MPI_COMM_WORLD, &size);
             double local_start_time = MPI_Wtime();
-            auto result = std::invoke(std::forward <Func>(func), std::forward <Args>(
-                    args)...);  // Call function or block
+            auto result = std::invoke(std::forward<Func>(func), std::forward<Args>(args)...); // Call function or block
             double local_end_time = MPI_Wtime();
             double local_elapsed = local_end_time - local_start_time;
             double global_start_time, global_end_time;
@@ -72,18 +75,20 @@ public:
                 duration_ave += elapsed_ave;
                 duration_max += elapsed_max;
             }
-            return result;  // Return the result of the function or block
+            return result; // Return the result of the function or block
         }
         else
         {
-            return std::invoke(std::forward <Func>(func), std::forward <Args>(args)...);  // Call without timing
+            return std::invoke(std::forward<Func>(func), std::forward<Args>(args)...); // Call without timing
         }
     }
 
     // Timing wrapper for functions that return void
-    template <typename Func, typename... Args, typename RetType = decltype(std::invoke(std::declval <Func>()
-                                                                                       , std::declval <Args>()...)), typename std::enable_if <std::is_void <RetType>::value, int>::type = 0>
-    void timeBlock(Func &&func, Args &&... args)
+    template <typename Func,
+              typename... Args,
+              typename RetType = decltype(std::invoke(std::declval<Func>(), std::declval<Args>()...)),
+              typename std::enable_if<std::is_void<RetType>::value, int>::type = 0>
+    void timeBlock(Func&& func, Args&&... args)
     {
         if(enabled)
         {
@@ -91,7 +96,7 @@ public:
             MPI_Comm_rank(MPI_COMM_WORLD, &rank);
             MPI_Comm_size(MPI_COMM_WORLD, &size);
             double local_start_time = MPI_Wtime();
-            std::invoke(std::forward <Func>(func), std::forward <Args>(args)...);  // Call function or block
+            std::invoke(std::forward<Func>(func), std::forward<Args>(args)...); // Call function or block
             double local_end_time = MPI_Wtime();
             double local_elapsed = local_end_time - local_start_time;
             double global_start_time, global_end_time;
@@ -112,15 +117,12 @@ public:
         }
         else
         {
-            std::invoke(std::forward <Func>(func), std::forward <Args>(args)...);  // Call without timing
+            std::invoke(std::forward<Func>(func), std::forward<Args>(args)...); // Call without timing
         }
     }
 
     // Pause timer
-    void pauseTimer()
-    {
-        pause_time = MPI_Wtime();
-    }
+    void pauseTimer() { pause_time = MPI_Wtime(); }
 
     // Resume timer
     void resumeTimer()
@@ -154,37 +156,25 @@ public:
     }
 
     // Get end-to-end duration of last call
-    [[nodiscard]] double getDuration() const
-    {
-        return e2e_duration;
-    }
+    [[nodiscard]] double getDuration() const { return e2e_duration; }
 
     // Get max duration of last call
-    [[nodiscard]] double getDurationMax() const
-    {
-        return duration_max;
-    }
+    [[nodiscard]] double getDurationMax() const { return duration_max; }
 
     // Get min duration of last call
-    [[nodiscard]] double getDurationMin() const
-    {
-        return duration_min;
-    }
+    [[nodiscard]] double getDurationMin() const { return duration_min; }
 
     // Get ave duration of last call
-    [[nodiscard]] double getDurationAve() const
-    {
-        return duration_ave;
-    }
+    [[nodiscard]] double getDurationAve() const { return duration_ave; }
 
 private:
-    std::string name;  // Name of the timer
-    bool enabled;  // Flag to enable or disable timing
-    double e2e_duration;  // End-to-end duration of last call
-    double duration_min;  // Min duration of last call
-    double duration_ave;  // Ave duration of last call
-    double duration_max;  // Max duration of last call
-    double pause_time;  // Time of pause
+    std::string name;    // Name of the timer
+    bool enabled;        // Flag to enable or disable timing
+    double e2e_duration; // End-to-end duration of last call
+    double duration_min; // Min duration of last call
+    double duration_ave; // Ave duration of last call
+    double duration_max; // Max duration of last call
+    double pause_time;   // Time of pause
 };
 
 #endif //CHRONOLOG_TIMERWRAPPER_H

--- a/chrono_common/include/TimerWrapper.h
+++ b/chrono_common/include/TimerWrapper.h
@@ -6,6 +6,7 @@
 #define CHRONOLOG_TIMERWRAPPER_H
 
 #include <iostream>
+#include <string>
 #include <chrono>
 #include <functional>
 #include <mpi.h>

--- a/chrono_common/include/chronolog_types.h
+++ b/chrono_common/include/chronolog_types.h
@@ -25,9 +25,16 @@ class LogEvent
 public:
     LogEvent() = default;
 
-    LogEvent(StoryId const &story_id, chrono_time event_time, ClientId client_id, chrono_index index
-             , std::string const &record): storyId(story_id), eventTime(event_time), clientId(client_id), eventIndex(
-            index), logRecord(record)
+    LogEvent(StoryId const& story_id,
+             chrono_time event_time,
+             ClientId client_id,
+             chrono_index index,
+             std::string const& record)
+        : storyId(story_id)
+        , eventTime(event_time)
+        , clientId(client_id)
+        , eventIndex(index)
+        , logRecord(record)
     {}
 
     StoryId storyId;
@@ -36,32 +43,27 @@ public:
     uint32_t eventIndex;
     std::string logRecord; //INNA: replace with size_t  length; & void * data; later on
 
-    StoryId const &getStoryId() const
-    { return storyId; }
+    StoryId const& getStoryId() const { return storyId; }
 
-    uint64_t time() const
-    { return eventTime; }
+    uint64_t time() const { return eventTime; }
 
-    ClientId const &getClientId() const
-    { return clientId; }
+    ClientId const& getClientId() const { return clientId; }
 
-    uint32_t index() const
-    { return eventIndex; }
+    uint32_t index() const { return eventIndex; }
 
-    std::string const &getRecord() const
-    { return logRecord; }
+    std::string const& getRecord() const { return logRecord; }
 
     // serialization function used by thallium RPC providers
     template <typename SerArchiveT>
-    void serialize(SerArchiveT &serT)
+    void serialize(SerArchiveT& serT)
     {
         serT(storyId, eventTime, clientId, eventIndex, logRecord);
     }
 
-    bool operator==(const LogEvent &other) const
+    bool operator==(const LogEvent& other) const
     {
         return (storyId == other.storyId && eventTime == other.eventTime && clientId == other.clientId &&
-                eventIndex == other.eventIndex );
+                eventIndex == other.eventIndex);
     }
 
     // convert to string
@@ -73,9 +75,9 @@ public:
         return str;
     }
 };
-}
+} // namespace chronolog
 
-inline std::ostream &operator<<(std::ostream &out, chronolog::LogEvent const &event)
+inline std::ostream& operator<<(std::ostream& out, chronolog::LogEvent const& event)
 {
     out << "event : " << event.getStoryId() << ":" << event.time() << ":" << event.getClientId() << ":" << event.index()
         << ":" << event.getRecord();

--- a/chrono_common/include/chronolog_types.h
+++ b/chrono_common/include/chronolog_types.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <ostream>
 #include <cstring>
+#include <cstdint>
 #include <tuple>
 
 namespace chronolog

--- a/chrono_common/include/common.h
+++ b/chrono_common/include/common.h
@@ -6,6 +6,8 @@
 #define CHRONOLOG_COMMON_H
 
 #include <random>
+#include <string>
+#include <climits>
 
 std::random_device rd;
 std::seed_seq ssq{rd()};

--- a/chrono_common/include/common.h
+++ b/chrono_common/include/common.h
@@ -12,7 +12,7 @@
 std::random_device rd;
 std::seed_seq ssq{rd()};
 std::default_random_engine mt{rd()};
-std::uniform_int_distribution <int> dist(0, INT32_MAX);
+std::uniform_int_distribution<int> dist(0, INT32_MAX);
 
 std::string gen_random(const int len)
 {
@@ -22,10 +22,7 @@ std::string gen_random(const int len)
     std::string tmp_s;
     tmp_s.reserve(len);
 
-    for(int i = 0; i < len; ++i)
-    {
-        tmp_s += alphanum[dist(mt) % (sizeof(alphanum) - 1)];
-    }
+    for(int i = 0; i < len; ++i) { tmp_s += alphanum[dist(mt) % (sizeof(alphanum) - 1)]; }
 
     return tmp_s;
 }

--- a/chrono_common/src/ConfigurationManager.cpp
+++ b/chrono_common/src/ConfigurationManager.cpp
@@ -1,4 +1,4 @@
-#include <ConfigurationManager.h>
+#include "ConfigurationManager.h"
 
 
 int chronolog::ClockConf::parseJsonConf(json_object *clock_conf)

--- a/chrono_common/src/ConfigurationManager.cpp
+++ b/chrono_common/src/ConfigurationManager.cpp
@@ -1,7 +1,7 @@
 #include "ConfigurationManager.h"
 
 
-int chronolog::ClockConf::parseJsonConf(json_object *clock_conf)
+int chronolog::ClockConf::parseJsonConf(json_object* clock_conf)
 {
     json_object_object_foreach(clock_conf, key, val)
     {
@@ -9,7 +9,7 @@ int chronolog::ClockConf::parseJsonConf(json_object *clock_conf)
         {
             if(json_object_is_type(val, json_type_string))
             {
-                const char *clocksource_type = json_object_get_string(val);
+                const char* clocksource_type = json_object_get_string(val);
                 if(strcmp(clocksource_type, "C_STYLE") == 0)
                     CLOCKSOURCE_TYPE = ClocksourceType::C_STYLE;
                 else if(strcmp(clocksource_type, "CPP_STYLE") == 0)
@@ -34,9 +34,9 @@ int chronolog::ClockConf::parseJsonConf(json_object *clock_conf)
             }
             else
             {
-                std::cerr
-                        << "[ClockConfiguration] Failed to parse configuration file: drift_cal_sleep_sec is not an integer"
-                        << std::endl;
+                std::cerr << "[ClockConfiguration] Failed to parse configuration file: drift_cal_sleep_sec is not an "
+                             "integer"
+                          << std::endl;
                 return (chronolog::CL_ERR_INVALID_CONF);
             }
         }
@@ -48,9 +48,9 @@ int chronolog::ClockConf::parseJsonConf(json_object *clock_conf)
             }
             else
             {
-                std::cerr
-                        << "[ConfigurationManager] Failed to parse configuration file: drift_cal_sleep_nsec is not an integer"
-                        << std::endl;
+                std::cerr << "[ConfigurationManager] Failed to parse configuration file: drift_cal_sleep_nsec is not "
+                             "an integer"
+                          << std::endl;
                 return (chronolog::CL_ERR_INVALID_CONF);
             }
         }
@@ -58,13 +58,13 @@ int chronolog::ClockConf::parseJsonConf(json_object *clock_conf)
     return 1;
 }
 
-int chronolog::AuthConf::parseJsonConf(json_object *auth_conf)
+int chronolog::AuthConf::parseJsonConf(json_object* auth_conf)
 {
     if(auth_conf == nullptr || !json_object_is_type(auth_conf, json_type_object))
     {
-        std::cerr
-                << "[AuthConfiguration] Error while parsing configuration file. Authentication configuration is not found or is not an object."
-                << std::endl;
+        std::cerr << "[AuthConfiguration] Error while parsing configuration file. Authentication configuration is not "
+                     "found or is not an object."
+                  << std::endl;
         return (chronolog::CL_ERR_INVALID_CONF);
     }
     json_object_object_foreach(auth_conf, key, val)
@@ -99,7 +99,7 @@ int chronolog::AuthConf::parseJsonConf(json_object *auth_conf)
     return 1;
 }
 
-int chronolog::RPCProviderConf::parseJsonConf(json_object *json_conf)
+int chronolog::RPCProviderConf::parseJsonConf(json_object* json_conf)
 {
     json_object_object_foreach(json_conf, key, val)
     {
@@ -131,78 +131,77 @@ int chronolog::RPCProviderConf::parseJsonConf(json_object *json_conf)
     return 1;
 }
 
-int chronolog::LogConf::parseJsonConf(json_object *json_conf)
+int chronolog::LogConf::parseJsonConf(json_object* json_conf)
 {
 
-        if(!json_object_is_type(json_conf, json_type_object))
+    if(!json_object_is_type(json_conf, json_type_object))
+    {
+        std::cerr << "[LogConf] Logger configuration is not found or is not an object." << std::endl;
+        return (chronolog::CL_ERR_INVALID_CONF);
+    }
+    json_object_object_foreach(json_conf, key, json_val)
+    {
+        if(strcmp(key, "monitor") != 0)
         {
-            std::cerr
-                    << "[LogConf] Logger configuration is not found or is not an object." << std::endl;
+            std::cerr << "[LogConf] Unknown Log configuration key : " << key << std::endl;
             return (chronolog::CL_ERR_INVALID_CONF);
         }
-        json_object_object_foreach(json_conf, key, json_val)
-        {
-            if(strcmp(key, "monitor") != 0)
-            {
-                std::cerr << "[LogConf] Unknown Log configuration key : " << key << std::endl;
-                return (chronolog::CL_ERR_INVALID_CONF);
-            }
 
-            json_object_object_foreach(json_val, key, val)
+        json_object_object_foreach(json_val, key, val)
+        {
+            if(strcmp(key, "type") == 0)
             {
-                if(strcmp(key, "type") == 0)
-                {
-                    assert(json_object_is_type(val, json_type_string));
-                    LOGTYPE = json_object_get_string(val);
-                }
-                else if(strcmp(key, "file") == 0)
-                {
-                    assert(json_object_is_type(val, json_type_string));
-                    LOGFILE = json_object_get_string(val);
-                }
-                else if(strcmp(key, "level") == 0)
-                {
-                    assert(json_object_is_type(val, json_type_string));
-                    parselogLevelConf(val, LOGLEVEL);
-                }
-                else if(strcmp(key, "name") == 0)
-                {
-                    assert(json_object_is_type(val, json_type_string));
-                    LOGNAME = json_object_get_string(val);
-                }
-                else if(strcmp(key, "filesize") == 0)
-                {
-                    assert(json_object_is_type(val, json_type_int));
-                    LOGFILESIZE = json_object_get_int(val);
-                }
-                else if(strcmp(key, "filenum") == 0)
-                {
-                    assert(json_object_is_type(val, json_type_int));
-                    LOGFILENUM = json_object_get_int(val);
-                }
-                else if(strcmp(key, "flushlevel") == 0)
-                {
-                    assert(json_object_is_type(val, json_type_string));
-                    parseFlushLevelConf(val, FLUSHLEVEL);
-                }
-                else
-                {
-                    std::cerr << "[LogConf] Unknown log configuration: " << key << std::endl;
-                }
+                assert(json_object_is_type(val, json_type_string));
+                LOGTYPE = json_object_get_string(val);
             }
+            else if(strcmp(key, "file") == 0)
+            {
+                assert(json_object_is_type(val, json_type_string));
+                LOGFILE = json_object_get_string(val);
+            }
+            else if(strcmp(key, "level") == 0)
+            {
+                assert(json_object_is_type(val, json_type_string));
+                parselogLevelConf(val, LOGLEVEL);
+            }
+            else if(strcmp(key, "name") == 0)
+            {
+                assert(json_object_is_type(val, json_type_string));
+                LOGNAME = json_object_get_string(val);
+            }
+            else if(strcmp(key, "filesize") == 0)
+            {
+                assert(json_object_is_type(val, json_type_int));
+                LOGFILESIZE = json_object_get_int(val);
+            }
+            else if(strcmp(key, "filenum") == 0)
+            {
+                assert(json_object_is_type(val, json_type_int));
+                LOGFILENUM = json_object_get_int(val);
+            }
+            else if(strcmp(key, "flushlevel") == 0)
+            {
+                assert(json_object_is_type(val, json_type_string));
+                parseFlushLevelConf(val, FLUSHLEVEL);
+            }
+            else
+            {
+                std::cerr << "[LogConf] Unknown log configuration: " << key << std::endl;
+            }
+        }
     }
     return 1;
 }
 
-int chronolog::VisorConfiguration::parseJsonConf(json_object *json_conf)
+int chronolog::VisorConfiguration::parseJsonConf(json_object* json_conf)
 {
     json_object_object_foreach(json_conf, key, val)
     {
         if(strcmp(key, "VisorClientPortalService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *visor_client_portal_service_conf = json_object_object_get(json_conf
-                                                                                   , "VisorClientPortalService");
+            json_object* visor_client_portal_service_conf =
+                    json_object_object_get(json_conf, "VisorClientPortalService");
             json_object_object_foreach(visor_client_portal_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -212,15 +211,16 @@ int chronolog::VisorConfiguration::parseJsonConf(json_object *json_conf)
                 else
                 {
                     std::cerr << "[VisorConfiguration] [chrono_visor] Unknown VisorClientPortalService "
-                                 "configuration: " << key << std::endl;
+                                 "configuration: "
+                              << key << std::endl;
                 }
             }
         }
         else if(strcmp(key, "VisorKeeperRegistryService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *visor_keeper_registry_service_conf = json_object_object_get(json_conf
-                                                                                     , "VisorKeeperRegistryService");
+            json_object* visor_keeper_registry_service_conf =
+                    json_object_object_get(json_conf, "VisorKeeperRegistryService");
             json_object_object_foreach(visor_keeper_registry_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -230,22 +230,23 @@ int chronolog::VisorConfiguration::parseJsonConf(json_object *json_conf)
                 else
                 {
                     std::cerr << "[VisorConfiguration]  Unknown VisorKeeperRegistryService "
-                                 "configuration: " << key << std::endl;
+                                 "configuration: "
+                              << key << std::endl;
                 }
             }
         }
         else if(strcmp(key, "Monitoring") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *chronovisor_log = json_object_object_get(json_conf, "Monitoring");
+            json_object* chronovisor_log = json_object_object_get(json_conf, "Monitoring");
             VISOR_LOG_CONF.parseJsonConf(chronovisor_log);
         }
         else if(strcmp(key, "delayed_data_admin_exit_in_secs") == 0)
         {
             assert(json_object_is_type(val, json_type_int));
             int delayed_exit_value = json_object_get_int(val);
-            DELAYED_DATA_ADMIN_EXIT_IN_SECS = ((0 < delayed_exit_value && delayed_exit_value < 60) ? delayed_exit_value
-                                                                                                   : 5);
+            DELAYED_DATA_ADMIN_EXIT_IN_SECS =
+                    ((0 < delayed_exit_value && delayed_exit_value < 60) ? delayed_exit_value : 5);
         }
         else
         {
@@ -255,7 +256,7 @@ int chronolog::VisorConfiguration::parseJsonConf(json_object *json_conf)
     return 1;
 }
 
-int chronolog::KeeperConfiguration::parseJsonConf(json_object *json_conf)
+int chronolog::KeeperConfiguration::parseJsonConf(json_object* json_conf)
 {
     json_object_object_foreach(json_conf, key, val)
     {
@@ -268,7 +269,7 @@ int chronolog::KeeperConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "KeeperRecordingService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *keeper_recording_service_conf = json_object_object_get(json_conf, "KeeperRecordingService");
+            json_object* keeper_recording_service_conf = json_object_object_get(json_conf, "KeeperRecordingService");
             json_object_object_foreach(keeper_recording_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -278,15 +279,16 @@ int chronolog::KeeperConfiguration::parseJsonConf(json_object *json_conf)
                 else
                 {
                     std::cerr << "[KeeperConfiguration] Unknown KeeperRecordingService "
-                                 "configuration: " << key << std::endl;
+                                 "configuration: "
+                              << key << std::endl;
                 }
             }
         }
         else if(strcmp(key, "KeeperDataStoreAdminService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *keeper_data_store_admin_service_conf = json_object_object_get(json_conf
-                                                                                       , "KeeperDataStoreAdminService");
+            json_object* keeper_data_store_admin_service_conf =
+                    json_object_object_get(json_conf, "KeeperDataStoreAdminService");
             json_object_object_foreach(keeper_data_store_admin_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -296,15 +298,16 @@ int chronolog::KeeperConfiguration::parseJsonConf(json_object *json_conf)
                 else
                 {
                     std::cerr << "[KeeperConfiguration]  Unknown KeeperDataStoreAdminService "
-                                 "configuration: " << key << std::endl;
+                                 "configuration: "
+                              << key << std::endl;
                 }
             }
         }
         else if(strcmp(key, "VisorKeeperRegistryService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *visor_keeper_registry_service_conf = json_object_object_get(json_conf
-                                                                                     , "VisorKeeperRegistryService");
+            json_object* visor_keeper_registry_service_conf =
+                    json_object_object_get(json_conf, "VisorKeeperRegistryService");
             json_object_object_foreach(visor_keeper_registry_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -321,8 +324,8 @@ int chronolog::KeeperConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "KeeperGrapherDrainService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *keeper_grapher_drain_service_conf = json_object_object_get(json_conf
-                                                                                    , "KeeperGrapherDrainService");
+            json_object* keeper_grapher_drain_service_conf =
+                    json_object_object_get(json_conf, "KeeperGrapherDrainService");
             json_object_object_foreach(keeper_grapher_drain_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -339,7 +342,7 @@ int chronolog::KeeperConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "Monitoring") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *keeper_monitor = json_object_object_get(json_conf, "Monitoring");
+            json_object* keeper_monitor = json_object_object_get(json_conf, "Monitoring");
             LOG_CONF.parseJsonConf(keeper_monitor);
             /* json_object_object_foreach(chronokeeper_log, key, val)
              {
@@ -357,13 +360,13 @@ int chronolog::KeeperConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "DataStoreInternals") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *data_store_conf = json_object_object_get(json_conf, "DataStoreInternals");
+            json_object* data_store_conf = json_object_object_get(json_conf, "DataStoreInternals");
             DATA_STORE_CONF.parseJsonConf(data_store_conf);
         }
         else if(strcmp(key, "Extractors") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *extractors = json_object_object_get(json_conf, "Extractors");
+            json_object* extractors = json_object_object_get(json_conf, "Extractors");
             json_object_object_foreach(extractors, key, val)
             {
                 if(strcmp(key, "story_files_dir") == 0)
@@ -386,7 +389,7 @@ int chronolog::KeeperConfiguration::parseJsonConf(json_object *json_conf)
     return 1;
 }
 
-int chronolog::GrapherConfiguration::parseJsonConf(json_object *json_conf)
+int chronolog::GrapherConfiguration::parseJsonConf(json_object* json_conf)
 {
     json_object_object_foreach(json_conf, key, val)
     {
@@ -399,8 +402,8 @@ int chronolog::GrapherConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "KeeperGrapherDrainService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *keeper_grapher_drain_service_conf = json_object_object_get(json_conf
-                                                                                    , "KeeperGrapherDrainService");
+            json_object* keeper_grapher_drain_service_conf =
+                    json_object_object_get(json_conf, "KeeperGrapherDrainService");
             json_object_object_foreach(keeper_grapher_drain_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -409,17 +412,15 @@ int chronolog::GrapherConfiguration::parseJsonConf(json_object *json_conf)
                 }
                 else
                 {
-                    std::cerr
-                            << "[GrapherConfiguration] Unknown KeeperGrapherDrainService configuration: "
-                            << key << std::endl;
+                    std::cerr << "[GrapherConfiguration] Unknown KeeperGrapherDrainService configuration: " << key
+                              << std::endl;
                 }
             }
         }
         else if(strcmp(key, "DataStoreAdminService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object* data_store_admin_service_conf = json_object_object_get(json_conf
-                                                                                , "DataStoreAdminService");
+            json_object* data_store_admin_service_conf = json_object_object_get(json_conf, "DataStoreAdminService");
             json_object_object_foreach(data_store_admin_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -428,15 +429,15 @@ int chronolog::GrapherConfiguration::parseJsonConf(json_object *json_conf)
                 }
                 else
                 {
-                    std::cerr << "[GrapherConfiguration] Unknown DataStoreAdminService configuration: "
-                              << key << std::endl;
+                    std::cerr << "[GrapherConfiguration] Unknown DataStoreAdminService configuration: " << key
+                              << std::endl;
                 }
             }
         }
         else if(strcmp(key, "VisorRegistryService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object*visor_keeper_registry_service_conf = json_object_object_get(json_conf, "VisorRegistryService");
+            json_object* visor_keeper_registry_service_conf = json_object_object_get(json_conf, "VisorRegistryService");
             json_object_object_foreach(visor_keeper_registry_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -445,15 +446,15 @@ int chronolog::GrapherConfiguration::parseJsonConf(json_object *json_conf)
                 }
                 else
                 {
-                    std::cerr << "[GrapherConfiguration] Unknown VisorRegistryService configuration: "
-                              << key << std::endl;
+                    std::cerr << "[GrapherConfiguration] Unknown VisorRegistryService configuration: " << key
+                              << std::endl;
                 }
             }
         }
         else if(strcmp(key, "Monitoring") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *grapher_monitor = json_object_object_get(json_conf, "Monitoring");
+            json_object* grapher_monitor = json_object_object_get(json_conf, "Monitoring");
             LOG_CONF.parseJsonConf(grapher_monitor);
             /*
             json_object_object_foreach(chrono_logging, key, val)
@@ -472,13 +473,13 @@ int chronolog::GrapherConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "DataStoreInternals") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object*data_store_conf = json_object_object_get(json_conf, "DataStoreInternals");
+            json_object* data_store_conf = json_object_object_get(json_conf, "DataStoreInternals");
             DATA_STORE_CONF.parseJsonConf(data_store_conf);
         }
         else if(strcmp(key, "Extractors") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object*extractors = json_object_object_get(json_conf, "Extractors");
+            json_object* extractors = json_object_object_get(json_conf, "Extractors");
             json_object_object_foreach(extractors, key, val)
             {
                 if(strcmp(key, "story_files_dir") == 0)
@@ -488,8 +489,7 @@ int chronolog::GrapherConfiguration::parseJsonConf(json_object *json_conf)
                 }
                 else
                 {
-                    std::cerr << "[GrapherConfiguration] Unknown Extractors configuration " << key
-                              << std::endl;
+                    std::cerr << "[GrapherConfiguration] Unknown Extractors configuration " << key << std::endl;
                 }
             }
         }
@@ -501,7 +501,7 @@ int chronolog::GrapherConfiguration::parseJsonConf(json_object *json_conf)
     return 1;
 }
 
-int chronolog::PlayerConfiguration::parseJsonConf(json_object *json_conf)
+int chronolog::PlayerConfiguration::parseJsonConf(json_object* json_conf)
 {
     json_object_object_foreach(json_conf, key, val)
     {
@@ -514,8 +514,7 @@ int chronolog::PlayerConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "PlayerStoreAdminService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object* data_store_admin_service_conf = json_object_object_get(json_conf
-                                                                                , "PlayerStoreAdminService");
+            json_object* data_store_admin_service_conf = json_object_object_get(json_conf, "PlayerStoreAdminService");
             json_object_object_foreach(data_store_admin_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -533,8 +532,7 @@ int chronolog::PlayerConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "PlaybackQueryService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object* data_store_admin_service_conf = json_object_object_get(json_conf
-                                                                                , "PlaybackQueryService");
+            json_object* data_store_admin_service_conf = json_object_object_get(json_conf, "PlaybackQueryService");
             json_object_object_foreach(data_store_admin_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -551,7 +549,7 @@ int chronolog::PlayerConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "VisorRegistryService") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *visor_keeper_registry_service_conf = json_object_object_get(json_conf, "VisorRegistryService");
+            json_object* visor_keeper_registry_service_conf = json_object_object_get(json_conf, "VisorRegistryService");
             json_object_object_foreach(visor_keeper_registry_service_conf, key, val)
             {
                 if(strcmp(key, "rpc") == 0)
@@ -568,7 +566,7 @@ int chronolog::PlayerConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "Monitoring") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *player_monitor = json_object_object_get(json_conf, "Monitoring");
+            json_object* player_monitor = json_object_object_get(json_conf, "Monitoring");
             LOG_CONF.parseJsonConf(player_monitor);
             /*json_object_object_foreach(chrono_logging, key, val)
             {
@@ -586,13 +584,13 @@ int chronolog::PlayerConfiguration::parseJsonConf(json_object *json_conf)
         else if(strcmp(key, "DataStoreInternals") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *data_store_conf = json_object_object_get(json_conf, "DataStoreInternals");
-            DATA_STORE_CONF.parseJsonConf(data_store_conf);//, key, val)
+            json_object* data_store_conf = json_object_object_get(json_conf, "DataStoreInternals");
+            DATA_STORE_CONF.parseJsonConf(data_store_conf); //, key, val)
         }
         else if(strcmp(key, "ArchiveReaders") == 0)
         {
             assert(json_object_is_type(val, json_type_object));
-            json_object *archive_readers = json_object_object_get(json_conf, "ArchiveReaders");
+            json_object* archive_readers = json_object_object_get(json_conf, "ArchiveReaders");
             json_object_object_foreach(archive_readers, key, val)
             {
                 if(strcmp(key, "story_files_dir") == 0)
@@ -615,7 +613,7 @@ int chronolog::PlayerConfiguration::parseJsonConf(json_object *json_conf)
     return 1;
 }
 
-int chronolog::DataStoreConf::parseJsonConf(json_object *data_store_json_conf)
+int chronolog::DataStoreConf::parseJsonConf(json_object* data_store_json_conf)
 {
     json_object_object_foreach(data_store_json_conf, key, val)
     {

--- a/chrono_common/src/StoryChunk.cpp
+++ b/chrono_common/src/StoryChunk.cpp
@@ -1,4 +1,5 @@
 #include <chronolog_client.h>
+
 #include <StoryChunk.h>
 
 

--- a/chrono_common/src/StoryChunkExtractor.cpp
+++ b/chrono_common/src/StoryChunkExtractor.cpp
@@ -22,14 +22,14 @@ void chronolog::StoryChunkExtractorBase::startExtractionThreads(int stream_count
 
     for(int i = 0; i < stream_count; ++i)
     {
-        tl::managed <tl::xstream> es = tl::xstream::create();
+        tl::managed<tl::xstream> es = tl::xstream::create();
         extractionStreams.push_back(std::move(es));
     }
 
     for(int i = 0; i < stream_count; ++i)
     {
-        tl::managed <tl::thread> th = extractionStreams[i % extractionStreams.size()]->make_thread([p = this]()
-                                                                                                   { p->drainExtractionQueue(); });
+        tl::managed<tl::thread> th = extractionStreams[i % extractionStreams.size()]->make_thread(
+                [p = this]() { p->drainExtractionQueue(); });
         extractionThreads.push_back(std::move(th));
     }
     LOG_DEBUG("[StoryChunkExtractionBase] Started extraction threads.");
@@ -50,15 +50,9 @@ void chronolog::StoryChunkExtractorBase::shutdownExtractionThreads()
     LOG_DEBUG("[StoryChunkExtractionBase] Initiating shutdown. Queue size: {}", chunkExtractionQueue.size());
 
     // join threads & executionstreams while holding stateMutex
-    for(auto &eth: extractionThreads)
-    {
-        eth->join();
-    }
+    for(auto& eth: extractionThreads) { eth->join(); }
     LOG_DEBUG("[StoryChunkExtractionBase] Extraction threads successfully shut down.");
-    for(auto &es: extractionStreams)
-    {
-        es->join();
-    }
+    for(auto& es: extractionStreams) { es->join(); }
     LOG_DEBUG("[StoryChunkExtractionBase] Streams have been successfully closed.");
 }
 
@@ -82,33 +76,41 @@ void chronolog::StoryChunkExtractorBase::drainExtractionQueue()
     // and untill the extractionQueue is drained in shutdown mode
     while((extractorState == RUNNING) || !chunkExtractionQueue.empty())
     {
-        LOG_DEBUG("[StoryChunkExtractionBase] Draining queue. ES Rank: {}, ULT ID: {}, Queue Size: {}", es.get_rank()
-                  , thallium::thread::self_id(), chunkExtractionQueue.size());
+        LOG_DEBUG("[StoryChunkExtractionBase] Draining queue. ES Rank: {}, ULT ID: {}, Queue Size: {}",
+                  es.get_rank(),
+                  thallium::thread::self_id(),
+                  chunkExtractionQueue.size());
 
         while(!chunkExtractionQueue.empty())
         {
             StoryChunk* storyChunk = chunkExtractionQueue.ejectStoryChunk();
             if(storyChunk == nullptr)
-                //the queue might have been drained by another thread before the current thread acquired extractionQueue mutex
+            //the queue might have been drained by another thread before the current thread acquired extractionQueue mutex
             {
                 LOG_WARNING("[StoryChunkExtractionBase] Failed to acquire a story chunk from the queue.");
                 break;
             }
-            int ret = processStoryChunk(storyChunk);  // INNA: should add return type and handle the failure properly
+            int ret = processStoryChunk(storyChunk); // INNA: should add return type and handle the failure properly
             // free the memory or reset the startTime and return to the pool of prealocated chunks
             if(ret == chronolog::CL_SUCCESS)
             {
-                LOG_DEBUG("[StoryChunkExtractionBase] StoryChunk processed successfully. ES Rank: {}, ULT ID: {}"
-                          , es.get_rank(), thallium::thread::self_id());
+                LOG_DEBUG("[StoryChunkExtractionBase] StoryChunk processed successfully. ES Rank: {}, ULT ID: {}",
+                          es.get_rank(),
+                          thallium::thread::self_id());
                 delete storyChunk;
             }
             else
             {
                 LOG_ERROR("[StoryChunkExtractionBase] Failed to process a story chunk, Error Code: {}. ES Rank: {}, "
-                          "ULT ID: {}", ret, es.get_rank(), thallium::thread::self_id());
+                          "ULT ID: {}",
+                          ret,
+                          es.get_rank(),
+                          thallium::thread::self_id());
                 LOG_ERROR(
                         "[StoryChunkExtractionBase] Stashing the story chunk for later processing... ES Rank: {}, ULT "
-                        "ID: {}", es.get_rank(), thallium::thread::self_id());
+                        "ID: {}",
+                        es.get_rank(),
+                        thallium::thread::self_id());
                 chunkExtractionQueue.stashStoryChunk(storyChunk);
             }
         }

--- a/chrono_common/src/StoryChunkExtractor.cpp
+++ b/chrono_common/src/StoryChunkExtractor.cpp
@@ -1,5 +1,6 @@
 #include <unistd.h>
 #include <thallium.hpp>
+
 #include <StoryChunkExtractor.h>
 
 

--- a/chrono_common/src/StoryChunkWriter.cpp
+++ b/chrono_common/src/StoryChunkWriter.cpp
@@ -9,14 +9,11 @@ namespace fs = std::filesystem;
 
 namespace chronolog
 {
-hsize_t StoryChunkWriter::writeStoryChunk(StoryChunkHVL &story_chunk)
+hsize_t StoryChunkWriter::writeStoryChunk(StoryChunkHVL& story_chunk)
 {
-    std::vector <LogEventHVL> data;
+    std::vector<LogEventHVL> data;
     data.reserve(story_chunk.getEventCount());
-    for(const auto &start: story_chunk)
-    {
-        data.push_back(start.second);
-    }
+    for(const auto& start: story_chunk) { data.push_back(start.second); }
     std::string file_name = rootDirectory + story_chunk.getChronicleName() + "." + story_chunk.getStoryName() + "." +
                             std::to_string(story_chunk.getStartTime() / 1000000000) + ".vlen.h5";
     hsize_t ret = 0;
@@ -40,7 +37,7 @@ hsize_t StoryChunkWriter::writeStoryChunk(StoryChunkHVL &story_chunk)
         LOG_DEBUG("[StoryChunkWriter] Finished writing StoryChunk to file.");
         return file_size;
     }
-    catch(H5::FileIException &error)
+    catch(H5::FileIException& error)
     {
         LOG_ERROR("[StoryChunkWriter] FileIException: {}", error.getCDetailMsg());
         H5::FileIException::printErrorStack();
@@ -48,11 +45,11 @@ hsize_t StoryChunkWriter::writeStoryChunk(StoryChunkHVL &story_chunk)
     return ret;
 }
 
-std::string StoryChunkWriter::getStoryChunkFileName(std::string const &root_dir, std::string const &base_file_name)
+std::string StoryChunkWriter::getStoryChunkFileName(std::string const& root_dir, std::string const& base_file_name)
 {
     const std::string base_file_name_no_ext = fs::path(base_file_name).stem().make_preferred().string();
-    const std::string escaped_base_file_name_no_ext = std::regex_replace(base_file_name_no_ext, std::regex(
-            R"([.^$|()\\*+?{}\[\]])"), R"(\$&)");
+    const std::string escaped_base_file_name_no_ext =
+            std::regex_replace(base_file_name_no_ext, std::regex(R"([.^$|()\\*+?{}\[\]])"), R"(\$&)");
     const std::string rotated_prefix = escaped_base_file_name_no_ext + "\\.";
     const std::string ext = fs::path(base_file_name).extension().string();
 
@@ -62,7 +59,7 @@ std::string StoryChunkWriter::getStoryChunkFileName(std::string const &root_dir,
     bool base_exists = false;
 
     std::error_code ec;
-    for(const auto &entry: fs::directory_iterator(root_dir, ec))
+    for(const auto& entry: fs::directory_iterator(root_dir, ec))
     {
         if(!entry.is_regular_file(ec))
         {
@@ -90,7 +87,7 @@ std::string StoryChunkWriter::getStoryChunkFileName(std::string const &root_dir,
                     long long current_n = std::stoll(match[1].str());
                     max_n = std::max(max_n, current_n);
                 }
-                catch(const std::out_of_range &)
+                catch(const std::out_of_range&)
                 {
                     LOG_ERROR("[StoryChunkWriter] Number in file name '{}' is out of range.", match[1].str());
                 }
@@ -114,21 +111,24 @@ std::string StoryChunkWriter::getStoryChunkFileName(std::string const &root_dir,
     return (root_dir / next_filename_no_ext).make_preferred();
 }
 
-hsize_t StoryChunkWriter::writeStoryChunk(StoryChunk &story_chunk)
+hsize_t StoryChunkWriter::writeStoryChunk(StoryChunk& story_chunk)
 {
-    std::vector <LogEventHVL> data;
+    std::vector<LogEventHVL> data;
     data.reserve(story_chunk.getEventCount());
-    for(const auto &event: story_chunk)
+    for(const auto& event: story_chunk)
     {
         hvl_t log_record;
         log_record.len = event.second.logRecord.size();
         log_record.p = (void*)event.second.logRecord.data();
-        data.emplace_back(event.second.getStoryId(), event.second.time(), event.second.getClientId()
-                          ,event.second.index(), log_record);
+        data.emplace_back(event.second.getStoryId(),
+                          event.second.time(),
+                          event.second.getClientId(),
+                          event.second.index(),
+                          log_record);
     }
     std::string file_name = story_chunk.getChronicleName() + "." + story_chunk.getStoryName() + "." +
                             std::to_string(story_chunk.getStartTime() / 1000000000) + ".vlen.h5";
-//    file_name = fs::path(rootDirectory) / fs::path(file_name);
+    //    file_name = fs::path(rootDirectory) / fs::path(file_name);
     hsize_t ret = 0;
     std::unique_ptr<H5::H5File> file;
     try
@@ -153,7 +153,7 @@ hsize_t StoryChunkWriter::writeStoryChunk(StoryChunk &story_chunk)
         LOG_DEBUG("[StoryChunkWriter] Finished writing StoryChunk to file.");
         ret = file_size;
     }
-    catch(H5::FileIException &error)
+    catch(H5::FileIException& error)
     {
         LOG_ERROR("[StoryChunkWriter] FileIException: {}", error.getCDetailMsg());
         H5::FileIException::printErrorStack();
@@ -161,7 +161,7 @@ hsize_t StoryChunkWriter::writeStoryChunk(StoryChunk &story_chunk)
     return ret;
 }
 
-hsize_t StoryChunkWriter::writeEvents(std::unique_ptr<H5::H5File> &file, std::vector <LogEventHVL> &data)
+hsize_t StoryChunkWriter::writeEvents(std::unique_ptr<H5::H5File>& file, std::vector<LogEventHVL>& data)
 {
     int ret = 0;
     try
@@ -170,18 +170,18 @@ hsize_t StoryChunkWriter::writeEvents(std::unique_ptr<H5::H5File> &file, std::ve
          * Create a group in the file
         */
         LOG_DEBUG("[StoryChunkWriter] Creating group: {}", groupName);
-        auto *group = new H5::Group(file->createGroup(groupName));
+        auto* group = new H5::Group(file->createGroup(groupName));
 
         hsize_t dim_size = data.size();
         LOG_DEBUG("[StoryChunkWriter] Creating dataspace with size: {}", dim_size);
-        auto *dataspace = new H5::DataSpace(numDims, &dim_size);
+        auto* dataspace = new H5::DataSpace(numDims, &dim_size);
 
         // target dtype for the file
         LOG_DEBUG("[StoryChunkWriter] Creating data type for events...");
         H5::CompType data_type = createEventCompoundType();
 
         LOG_DEBUG("[StoryChunkWriter] Creating dataset: {}", dsetName);
-        auto *dataset = new H5::DataSet(
+        auto* dataset = new H5::DataSet(
                 file->createDataSet("/" + groupName + "/" + dsetName + ".vlen_bytes", data_type, *dataspace));
 
         LOG_DEBUG("[StoryChunkWriter] Writing data to dataset...");
@@ -193,22 +193,22 @@ hsize_t StoryChunkWriter::writeEvents(std::unique_ptr<H5::H5File> &file, std::ve
 
         return data.size();
     }
-    catch(H5::FileIException &error)
+    catch(H5::FileIException& error)
     {
         LOG_ERROR("[StoryChunkWriter] FileIException: {}", error.getCDetailMsg());
         H5::FileIException::printErrorStack();
     }
-    catch(H5::DataSetIException &error)
+    catch(H5::DataSetIException& error)
     {
         LOG_ERROR("[StoryChunkWriter] DataSetIException: {}", error.getCDetailMsg());
         H5::DataSetIException::printErrorStack();
     }
-    catch(H5::DataSpaceIException &error)
+    catch(H5::DataSpaceIException& error)
     {
         LOG_ERROR("[StoryChunkWriter] DataSpaceIException: {}", error.getCDetailMsg());
         H5::DataSpaceIException::printErrorStack();
     }
-    catch(H5::DataTypeIException &error)
+    catch(H5::DataTypeIException& error)
     {
         LOG_ERROR("[StoryChunkWriter] DataTypeIException: {}", error.getCDetailMsg());
         H5::DataTypeIException::printErrorStack();
@@ -216,4 +216,4 @@ hsize_t StoryChunkWriter::writeEvents(std::unique_ptr<H5::H5File> &file, std::ve
     return ret;
 }
 
-}
+} // namespace chronolog

--- a/chrono_common/src/StoryChunkWriter.cpp
+++ b/chrono_common/src/StoryChunkWriter.cpp
@@ -1,5 +1,7 @@
+#include <algorithm>
 #include <filesystem>
 #include <regex>
+#include <stdexcept>
 
 #include <StoryChunkWriter.h>
 

--- a/chrono_common/src/StoryPipeline.cpp
+++ b/chrono_common/src/StoryPipeline.cpp
@@ -19,50 +19,64 @@ namespace chl = chronolog;
 
 ////////////////////////
 
-chronolog::StoryPipeline::StoryPipeline(StoryChunkExtractionQueue &extractionQueue, chronolog::ChronicleName const &chronicle_name
-                                        , chronolog::StoryName const &story_name, chronolog::StoryId const &story_id
-                                        , uint64_t story_start_time, uint32_t chunk_granularity
-                                        , uint32_t acceptance_window)
-        : theExtractionQueue(extractionQueue)
-        , storyId(story_id), chronicleName(chronicle_name), storyName(story_name)
-        , chunkGranularity(chunk_granularity), acceptanceWindow(acceptance_window)
-        , activeIngestionHandle(nullptr)
+chronolog::StoryPipeline::StoryPipeline(StoryChunkExtractionQueue& extractionQueue,
+                                        chronolog::ChronicleName const& chronicle_name,
+                                        chronolog::StoryName const& story_name,
+                                        chronolog::StoryId const& story_id,
+                                        uint64_t story_start_time,
+                                        uint32_t chunk_granularity,
+                                        uint32_t acceptance_window)
+    : theExtractionQueue(extractionQueue)
+    , storyId(story_id)
+    , chronicleName(chronicle_name)
+    , storyName(story_name)
+    , chunkGranularity(chunk_granularity)
+    , acceptanceWindow(acceptance_window)
+    , activeIngestionHandle(nullptr)
 {
     activeIngestionHandle = new chl::StoryChunkIngestionHandle(ingestionMutex, &chunkQueue1, &chunkQueue2);
 
-    //pre-initialize the pipeline map with the StoryChunks of chunkGranulary 
+    //pre-initialize the pipeline map with the StoryChunks of chunkGranulary
     // (merging logic assumes at least 2 chunks in the active pipeline)
 
-    chunkGranularity *= 1000000000;    // seconds =>nanoseconds
-    acceptanceWindow *= 1000000000;    // seconds =>nanoseconds
+    chunkGranularity *= 1000000000; // seconds =>nanoseconds
+    acceptanceWindow *= 1000000000; // seconds =>nanoseconds
 
     //adjust the timeline start to the closest previous boundary of chunkGranularity
     story_start_time -= (story_start_time % chunkGranularity);
 
-    for(int i=0; i<3; ++i)
+    for(int i = 0; i < 3; ++i)
     {
-        StoryChunk * new_chunk = new chronolog::StoryChunk(chronicleName, storyName, storyId, (story_start_time + chunkGranularity*i), (story_start_time + chunkGranularity*(i+1)));
-        storyTimelineMap.insert( std::pair <uint64_t, chronolog::StoryChunk*>(new_chunk->getStartTime(), new_chunk));
+        StoryChunk* new_chunk = new chronolog::StoryChunk(chronicleName,
+                                                          storyName,
+                                                          storyId,
+                                                          (story_start_time + chunkGranularity * i),
+                                                          (story_start_time + chunkGranularity * (i + 1)));
+        storyTimelineMap.insert(std::pair<uint64_t, chronolog::StoryChunk*>(new_chunk->getStartTime(), new_chunk));
     }
 
-    auto timeline_start_point = std::chrono::time_point<std::chrono::system_clock,std::chrono::nanoseconds>{} // epoch_time_point{};
-        + std::chrono::nanoseconds(TimelineStart());
+    auto timeline_start_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>{}
+                                // epoch_time_point{};
+                                + std::chrono::nanoseconds(TimelineStart());
     std::time_t time_t_story_start = std::chrono::high_resolution_clock::to_time_t(timeline_start_point);
-    auto timeline_end_point = std::chrono::time_point<std::chrono::system_clock,std::chrono::nanoseconds>{}
-        + std::chrono::nanoseconds(TimelineEnd());
+    auto timeline_end_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>{} +
+                              std::chrono::nanoseconds(TimelineEnd());
     std::time_t time_t_story_end = std::chrono::high_resolution_clock::to_time_t(timeline_end_point);
     LOG_INFO("[StoryPipeline] Initialized StoryPipleine StoryID={}, {}-{} timeline {}-{} Start {} End {} "
-             "ChunkGranularity={} seconds, AcceptanceWindow={} seconds", storyId, chronicleName, storyName, TimelineStart(), TimelineEnd()
-            , std::ctime(&time_t_story_start), std::ctime(&time_t_story_end), chunkGranularity / 1000000000, acceptanceWindow / 1000000000);
-
-    
+             "ChunkGranularity={} seconds, AcceptanceWindow={} seconds",
+             storyId,
+             chronicleName,
+             storyName,
+             TimelineStart(),
+             TimelineEnd(),
+             std::ctime(&time_t_story_start),
+             std::ctime(&time_t_story_end),
+             chunkGranularity / 1000000000,
+             acceptanceWindow / 1000000000);
 }
 ///////////////////////
 
-chl::StoryChunkIngestionHandle*chl::StoryPipeline::getActiveIngestionHandle()
-{
-    return activeIngestionHandle;
-}
+chl::StoryChunkIngestionHandle* chl::StoryPipeline::getActiveIngestionHandle() { return activeIngestionHandle; }
 
 ///////////////////////
 chronolog::StoryPipeline::~StoryPipeline()
@@ -74,7 +88,7 @@ chronolog::StoryPipeline::~StoryPipeline()
 
 void chronolog::StoryPipeline::finalize()
 {
-    //by this time activeIngestionHandle is disengaged from the IngestionQueue 
+    //by this time activeIngestionHandle is disengaged from the IngestionQueue
     // as part of KeeperDataStore::shutdown
     if(activeIngestionHandle != nullptr)
     {
@@ -83,14 +97,14 @@ void chronolog::StoryPipeline::finalize()
             StoryChunk* next_chunk = activeIngestionHandle->getPassiveDeque().front();
             activeIngestionHandle->getPassiveDeque().pop_front();
             mergeEvents(*next_chunk);
-            delete next_chunk; 
+            delete next_chunk;
         }
         while(!activeIngestionHandle->getActiveDeque().empty())
         {
             StoryChunk* next_chunk = activeIngestionHandle->getActiveDeque().front();
             activeIngestionHandle->getActiveDeque().pop_front();
             mergeEvents(*next_chunk);
-            delete next_chunk; 
+            delete next_chunk;
         }
         delete activeIngestionHandle;
         // Added explicitly to avoid segfault in case of double free during manual calls to finalize
@@ -101,19 +115,21 @@ void chronolog::StoryPipeline::finalize()
     //extract any remianing non-empty StoryChunks regardless of decay_time
     // an active pipeline is guaranteed to have at least 2 chunks at any moment...
     {
-        std::lock_guard <std::mutex> lock(sequencingMutex);
+        std::lock_guard<std::mutex> lock(sequencingMutex);
         while(!storyTimelineMap.empty())
         {
-            StoryChunk*extractedChunk = nullptr;
+            StoryChunk* extractedChunk = nullptr;
 
             extractedChunk = (*storyTimelineMap.begin()).second;
             storyTimelineMap.erase(storyTimelineMap.begin());
 
-            LOG_DEBUG("[StoryPipeline] Finalized chunk for StoryId {} startTime {} eventCount {}", storyId, 
-                    extractedChunk->getStartTime(), extractedChunk->getEventCount());
+            LOG_DEBUG("[StoryPipeline] Finalized chunk for StoryId {} startTime {} eventCount {}",
+                      storyId,
+                      extractedChunk->getStartTime(),
+                      extractedChunk->getEventCount());
 
             if(extractedChunk->empty())
-            {  // no need to carry an empty chunk any further...
+            { // no need to carry an empty chunk any further...
                 delete extractedChunk;
             }
             else
@@ -127,20 +143,28 @@ void chronolog::StoryPipeline::finalize()
 
 /////////////////////
 
-std::map <uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::prependStoryChunk()
+std::map<uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::prependStoryChunk()
 {
     // prepend a storyChunk at the begining of  storyTimeline and return the iterator to the new node
 #ifdef TRACE_CHUNKING
-    std::chrono::time_point<std::chrono::system_clock,std::chrono::nanoseconds> epoch_time_point{};
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> epoch_time_point{};
     auto chunk_start_point = epoch_time_point + std::chrono::nanoseconds(TimelineStart());
     std::time_t time_t_chunk_start = std::chrono::high_resolution_clock::to_time_t(chunk_start_point);
-    auto chunk_end_point = epoch_time_point + std::chrono::nanoseconds(TimelineStart()-chunkGranularity);
+    auto chunk_end_point = epoch_time_point + std::chrono::nanoseconds(TimelineStart() - chunkGranularity);
     std::time_t time_t_chunk_end = std::chrono::high_resolution_clock::to_time_t(chunk_end_point);
-    LOG_TRACE("[StoryPipeline] Prepending new chunk for StoryId {} timeline {}-{} ", storyId, TimelineStart(), TimelineEnd());
+    LOG_TRACE("[StoryPipeline] Prepending new chunk for StoryId {} timeline {}-{} ",
+              storyId,
+              TimelineStart(),
+              TimelineEnd());
 #endif
-    StoryChunk * new_chunk = new chronolog::StoryChunk(chronicleName, storyName, storyId, TimelineStart() - chunkGranularity, TimelineStart());
+    StoryChunk* new_chunk = new chronolog::StoryChunk(chronicleName,
+                                                      storyName,
+                                                      storyId,
+                                                      TimelineStart() - chunkGranularity,
+                                                      TimelineStart());
 
-    auto result = storyTimelineMap.insert( std::pair <uint64_t, chronolog::StoryChunk*>(new_chunk->getStartTime(), new_chunk));
+    auto result =
+            storyTimelineMap.insert(std::pair<uint64_t, chronolog::StoryChunk*>(new_chunk->getStartTime(), new_chunk));
 
     if(!result.second)
     {
@@ -154,21 +178,28 @@ std::map <uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::
 }
 /////////////////////////////
 
-std::map <uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::appendStoryChunk()
+std::map<uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::appendStoryChunk()
 {
     // append the next storyChunk at the end of storyTimeline and return the iterator to the new node
 #ifdef TRACE_CHUNKING
-    std::chrono::time_point<std::chrono::system_clock,std::chrono::nanoseconds> epoch_time_point{};
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> epoch_time_point{};
     auto chunk_start_point = epoch_time_point + std::chrono::nanoseconds(TimelineEnd());
     std::time_t time_t_chunk_start = std::chrono::high_resolution_clock::to_time_t(chunk_start_point);
-    auto chunk_end_point = epoch_time_point + std::chrono::nanoseconds(TimelineEnd()+chunkGranularity);
+    auto chunk_end_point = epoch_time_point + std::chrono::nanoseconds(TimelineEnd() + chunkGranularity);
     std::time_t time_t_chunk_end = std::chrono::high_resolution_clock::to_time_t(chunk_end_point);
-    LOG_TRACE("[StoryPipeline] Appending new chunk for StoryId {}  timeline {}-{}", storyId, TimelineStart(), TimelineEnd());
+    LOG_TRACE("[StoryPipeline] Appending new chunk for StoryId {}  timeline {}-{}",
+              storyId,
+              TimelineStart(),
+              TimelineEnd());
 
 #endif
 
-    chl::StoryChunk * new_chunk = new chronolog::StoryChunk(chronicleName, storyName, storyId, TimelineEnd(),TimelineEnd() + chunkGranularity);
-    auto result = storyTimelineMap.insert( std::pair <uint64_t, chronolog::StoryChunk*>(TimelineEnd(),new_chunk));
+    chl::StoryChunk* new_chunk = new chronolog::StoryChunk(chronicleName,
+                                                           storyName,
+                                                           storyId,
+                                                           TimelineEnd(),
+                                                           TimelineEnd() + chunkGranularity);
+    auto result = storyTimelineMap.insert(std::pair<uint64_t, chronolog::StoryChunk*>(TimelineEnd(), new_chunk));
 
     if(!result.second)
     {
@@ -185,12 +216,12 @@ std::map <uint64_t, chronolog::StoryChunk*>::iterator chronolog::StoryPipeline::
 void chronolog::StoryPipeline::collectIngestedEvents()
 {
     activeIngestionHandle->swapActiveDeque();
-    StoryChunk * next_chunk = nullptr;
+    StoryChunk* next_chunk = nullptr;
     while(!activeIngestionHandle->getPassiveDeque().empty())
     {
         next_chunk = activeIngestionHandle->getPassiveDeque().front();
         activeIngestionHandle->getPassiveDeque().pop_front();
-        if( next_chunk != nullptr)
+        if(next_chunk != nullptr)
         {
             mergeEvents(*next_chunk);
             delete next_chunk;
@@ -201,43 +232,51 @@ void chronolog::StoryPipeline::collectIngestedEvents()
 void chronolog::StoryPipeline::extractDecayedStoryChunks(uint64_t current_time)
 {
 #ifdef TRACE_CHUNK_EXTRACTION
-    auto current_point =
-            std::chrono::time_point <std::chrono::system_clock, std::chrono::nanoseconds>{} // epoch_time_point{};
-            + std::chrono::nanoseconds(current_time);
+    auto current_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>{}
+                         // epoch_time_point{};
+                         + std::chrono::nanoseconds(current_time);
     std::time_t time_t_current_time = std::chrono::high_resolution_clock::to_time_t(current_point);
     uint64_t head_chunk_end_time = (*storyTimelineMap.begin()).second->getEndTime();
-    auto decay_point =
-            std::chrono::time_point <std::chrono::system_clock, std::chrono::nanoseconds>{} // epoch_time_point{};
-            + std::chrono::nanoseconds(head_chunk_end_time + acceptanceWindow);
+    auto decay_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>{}
+                       // epoch_time_point{};
+                       + std::chrono::nanoseconds(head_chunk_end_time + acceptanceWindow);
     std::time_t time_t_decay = std::chrono::high_resolution_clock::to_time_t(decay_point);
-    LOG_TRACE("[StoryPipeline] StoryId: {} - Current time: {} - TimelineMap-size: {} - Head chunk decay time: {}", storyId
-         , std::ctime(&time_t_current_time), storyTimelineMap.size(), std::ctime(&time_t_decay));
+    LOG_TRACE("[StoryPipeline] StoryId: {} - Current time: {} - TimelineMap-size: {} - Head chunk decay time: {}",
+              storyId,
+              std::ctime(&time_t_current_time),
+              storyTimelineMap.size(),
+              std::ctime(&time_t_decay));
 #endif
 
     while(current_time >= acceptanceWindow + (*storyTimelineMap.begin()).second->getEndTime())
     {
-        StoryChunk*extractedChunk = nullptr;
+        StoryChunk* extractedChunk = nullptr;
 
         {
             // lock the TimelineMap & check that the decayed storychunk is still there
-            std::lock_guard <std::mutex> lock(sequencingMutex);
+            std::lock_guard<std::mutex> lock(sequencingMutex);
             if(current_time > acceptanceWindow + (*storyTimelineMap.begin()).second->getEndTime())
             {
                 extractedChunk = (*storyTimelineMap.begin()).second;
                 storyTimelineMap.erase(storyTimelineMap.begin());
                 if(storyTimelineMap.size() < 2)
-                    //keep at least 2 chunks in the map of active pipeline as merging relies on it ...
-                { appendStoryChunk(); }
+                //keep at least 2 chunks in the map of active pipeline as merging relies on it ...
+                {
+                    appendStoryChunk();
+                }
             }
         }
 
         if(extractedChunk != nullptr)
         {
-            LOG_TRACE("[StoryPipeline] StoryId: {} - Extracted chunk {}-{} eventCount {}", storyId
-                 , extractedChunk->getStartTime(), extractedChunk->getEndTime(), extractedChunk->getEventCount());
+            LOG_TRACE("[StoryPipeline] StoryId: {} - Extracted chunk {}-{} eventCount {}",
+                      storyId,
+                      extractedChunk->getStartTime(),
+                      extractedChunk->getEndTime(),
+                      extractedChunk->getEventCount());
 
             if(extractedChunk->empty())
-            {   // there's no need to carry an empty chunk any further...  
+            { // there's no need to carry an empty chunk any further...
                 delete extractedChunk;
             }
             else
@@ -247,45 +286,65 @@ void chronolog::StoryPipeline::extractDecayedStoryChunks(uint64_t current_time)
         }
     }
 
-    LOG_TRACE("[StoryPipeline] Extracting decayed chunks for StoryId {} ExtractionQueue size {}", storyId
-         , theExtractionQueue.size());
-
+    LOG_TRACE("[StoryPipeline] Extracting decayed chunks for StoryId {} ExtractionQueue size {}",
+              storyId,
+              theExtractionQueue.size());
 }
 
 //////////////////////
 // Merge the StoryChunk obtained from external source into the StoryPipeline
-// Note that the granularity of the StoryChunk being merged may be 
+// Note that the granularity of the StoryChunk being merged may be
 // different from that of the StoryPipeline
 //
-void chronolog::StoryPipeline::mergeEvents(chronolog::StoryChunk &other_chunk)
+void chronolog::StoryPipeline::mergeEvents(chronolog::StoryChunk& other_chunk)
 {
     // we make no assumptions about the startTime or the granularity of the other_chunk
 
     if(other_chunk.empty())
-    { return; }
+    {
+        return;
+    }
 
-    std::lock_guard <std::mutex> lock(sequencingMutex);
+    std::lock_guard<std::mutex> lock(sequencingMutex);
 
-    LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} eventCount {} 1stEventTime {}", storyId, TimelineStart(), TimelineEnd()
-            ,  other_chunk.getStartTime(), other_chunk.getEndTime(), other_chunk.getEventCount(), other_chunk.firstEventTime());
+    LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} eventCount {} 1stEventTime {}",
+              storyId,
+              TimelineStart(),
+              TimelineEnd(),
+              other_chunk.getStartTime(),
+              other_chunk.getEndTime(),
+              other_chunk.getEventCount(),
+              other_chunk.firstEventTime());
 
     // locate the storyChunk in the existing StoryPipeline with the time Key not less than
-    // other_chunk.startTime, and start merging 
+    // other_chunk.startTime, and start merging
     // or extend the StoryPipeline in time so that the other chunk can be merged in
 
-    std::map <uint64_t, chronolog::StoryChunk*>::iterator chunk_to_merge_iter;
+    std::map<uint64_t, chronolog::StoryChunk*>::iterator chunk_to_merge_iter;
 
     if(other_chunk.firstEventTime() < TimelineStart())
     {
         // it's unlikely but possible that we get some delayed events and need to prepend some chunks
         // extending the timeline back into the past
-        LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} 1stEventTime {} - need to prepend chunks ", storyId, TimelineStart(), TimelineEnd(), other_chunk.getStartTime(), other_chunk.getEndTime(),other_chunk.firstEventTime());
+        LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} 1stEventTime {} - need to "
+                  "prepend chunks ",
+                  storyId,
+                  TimelineStart(),
+                  TimelineEnd(),
+                  other_chunk.getStartTime(),
+                  other_chunk.getEndTime(),
+                  other_chunk.firstEventTime());
 
-        //we also increase the acceptance window for the slow story environment so that we do not have to keep prepending StoryChunks 
+        //we also increase the acceptance window for the slow story environment so that we do not have to keep prepending StoryChunks
         // and deal with auxiliary files if recording of this particular Story turns to be slow...
-        acceptanceWindow = (TimelineStart() - other_chunk.firstEventTime()) + 3000; //current delay + 3 microseconds buffer
+        acceptanceWindow =
+                (TimelineStart() - other_chunk.firstEventTime()) + 3000; //current delay + 3 microseconds buffer
 
-        LOG_INFO("[StoryPipeline] StoryId {} timeline {}-{} : increasing acceptanceWindow to {} seconds", storyId, TimelineStart(), TimelineEnd(), acceptanceWindow/1000000000);
+        LOG_INFO("[StoryPipeline] StoryId {} timeline {}-{} : increasing acceptanceWindow to {} seconds",
+                 storyId,
+                 TimelineStart(),
+                 TimelineEnd(),
+                 acceptanceWindow / 1000000000);
 
         while(other_chunk.firstEventTime() < TimelineStart())
         {
@@ -293,49 +352,78 @@ void chronolog::StoryPipeline::mergeEvents(chronolog::StoryChunk &other_chunk)
             if(chunk_to_merge_iter == storyTimelineMap.end())
             {
                 // if prepend fails we have no choice but to discard the events we can't merge !!
-                LOG_ERROR("[StoryPipeline] StoryId {} timeline {}-{} : Merging operation discards events between timestamps: {} and {}"
-                     , storyId, TimelineStart(), TimelineEnd(), other_chunk.getStartTime(), TimelineStart());
+                LOG_ERROR("[StoryPipeline] StoryId {} timeline {}-{} : Merging operation discards events between "
+                          "timestamps: {} and {}",
+                          storyId,
+                          TimelineStart(),
+                          TimelineEnd(),
+                          other_chunk.getStartTime(),
+                          TimelineStart());
                 other_chunk.eraseEvents(other_chunk.firstEventTime(), TimelineStart());
                 chunk_to_merge_iter = storyTimelineMap.begin();
             }
         }
-        
     }
     else if((other_chunk.firstEventTime() >= TimelineStart()) && (other_chunk.firstEventTime() < TimelineEnd()))
     {
         // we are looking for the lower_bound StoryChunk that is the chunk with the StartTime equal or greater than other_chunk-getStartTime()
-        
+
         chunk_to_merge_iter = storyTimelineMap.lower_bound(other_chunk.firstEventTime());
-        
+
         if(chunk_to_merge_iter == storyTimelineMap.end())
         {
             // the last chunk is the one to merge into because we know that other_chunk.firstEventTime() is within TimelineStart/End boundaries
             chunk_to_merge_iter--;
-            LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} into the last chunk {}-{}", storyId, TimelineStart(), TimelineEnd(),
-                    other_chunk.getStartTime(), other_chunk.getEndTime(), (*chunk_to_merge_iter).second->getStartTime(), (*chunk_to_merge_iter).second->getEndTime());
-            
+            LOG_DEBUG(
+                    "[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} into the last chunk {}-{}",
+                    storyId,
+                    TimelineStart(),
+                    TimelineEnd(),
+                    other_chunk.getStartTime(),
+                    other_chunk.getEndTime(),
+                    (*chunk_to_merge_iter).second->getStartTime(),
+                    (*chunk_to_merge_iter).second->getEndTime());
         }
-        else if( other_chunk.firstEventTime() == (*chunk_to_merge_iter).second->getStartTime())
+        else if(other_chunk.firstEventTime() == (*chunk_to_merge_iter).second->getStartTime())
         {
-          // we start merging with chunk_to_merge_iter
-        
-            LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} starts with chunk {} - exact lower_bound", storyId, TimelineStart(), TimelineEnd(), other_chunk.getStartTime(), other_chunk.getEndTime(), (*chunk_to_merge_iter).second->getStartTime());
+            // we start merging with chunk_to_merge_iter
+
+            LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} starts with chunk {} - "
+                      "exact lower_bound",
+                      storyId,
+                      TimelineStart(),
+                      TimelineEnd(),
+                      other_chunk.getStartTime(),
+                      other_chunk.getEndTime(),
+                      (*chunk_to_merge_iter).second->getStartTime());
         }
-        else if( other_chunk.firstEventTime() < (*chunk_to_merge_iter).second->getStartTime())
+        else if(other_chunk.firstEventTime() < (*chunk_to_merge_iter).second->getStartTime())
         {
             // we are looking for the chunk preceeding the lower bound chunk
 
             if(chunk_to_merge_iter != storyTimelineMap.begin())
             {
                 chunk_to_merge_iter--;
-                LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} starts with chunk {} preceeeds lower_bound", storyId, TimelineStart(), TimelineEnd(), other_chunk.getStartTime(), other_chunk.getEndTime(), (*chunk_to_merge_iter).second->getStartTime());
+                LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} starts with chunk "
+                          "{} preceeeds lower_bound",
+                          storyId,
+                          TimelineStart(),
+                          TimelineEnd(),
+                          other_chunk.getStartTime(),
+                          other_chunk.getEndTime(),
+                          (*chunk_to_merge_iter).second->getStartTime());
             }
             else
             {
-                LOG_ERROR("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} - attempt to decrement map.begin", storyId, TimelineStart(), TimelineEnd(),
-                    other_chunk.getStartTime(), other_chunk.getEndTime());
+                LOG_ERROR("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} - attempt to "
+                          "decrement map.begin",
+                          storyId,
+                          TimelineStart(),
+                          TimelineEnd(),
+                          other_chunk.getStartTime(),
+                          other_chunk.getEndTime());
             }
-        } 
+        }
     }
     else //case other_chunk.getFirstEventTime() > TimelineEnd()
     {
@@ -343,12 +431,19 @@ void chronolog::StoryPipeline::mergeEvents(chronolog::StoryChunk &other_chunk)
     }
 
 
-    // if we found a valid StoryChunk in the pipeline to merge into start merging... 
+    // if we found a valid StoryChunk in the pipeline to merge into start merging...
     // iterate through the storyTimelineMap draining the other_chunk events
-    while(chunk_to_merge_iter != storyTimelineMap.end() && !other_chunk.empty() && (other_chunk.firstEventTime() < TimelineEnd()))
+    while(chunk_to_merge_iter != storyTimelineMap.end() && !other_chunk.empty() &&
+          (other_chunk.firstEventTime() < TimelineEnd()))
     {
-        LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} into chunk {}-{}", storyId, TimelineStart(), TimelineEnd(), 
-                other_chunk.getStartTime(),other_chunk.getEndTime(), (*chunk_to_merge_iter).second->getStartTime(),(*chunk_to_merge_iter).second->getEndTime());
+        LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} into chunk {}-{}",
+                  storyId,
+                  TimelineStart(),
+                  TimelineEnd(),
+                  other_chunk.getStartTime(),
+                  other_chunk.getEndTime(),
+                  (*chunk_to_merge_iter).second->getStartTime(),
+                  (*chunk_to_merge_iter).second->getEndTime());
         (*chunk_to_merge_iter).second->mergeEvents(other_chunk);
         chunk_to_merge_iter++;
     }
@@ -358,15 +453,28 @@ void chronolog::StoryPipeline::mergeEvents(chronolog::StoryChunk &other_chunk)
 
     while(!other_chunk.empty() && (other_chunk.getEndTime() >= TimelineEnd()))
     {
-        LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging StoryChunk {}-{} events {} - appending chunks", storyId, TimelineStart(), TimelineEnd(),
-                other_chunk.getStartTime(), other_chunk.getEndTime(), other_chunk.getEventCount());
+        LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging StoryChunk {}-{} events {} - appending chunks",
+                  storyId,
+                  TimelineStart(),
+                  TimelineEnd(),
+                  other_chunk.getStartTime(),
+                  other_chunk.getEndTime(),
+                  other_chunk.getEventCount());
         chunk_to_merge_iter = appendStoryChunk();
         if(chunk_to_merge_iter == storyTimelineMap.end())
-        { break; }
-        else if( other_chunk.firstEventTime() < TimelineEnd())
-        { 
-            LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} into chunk {}-{}", storyId, TimelineStart(), TimelineEnd(), 
-                other_chunk.getStartTime(),other_chunk.getEndTime(), (*chunk_to_merge_iter).second->getStartTime(),(*chunk_to_merge_iter).second->getEndTime());
+        {
+            break;
+        }
+        else if(other_chunk.firstEventTime() < TimelineEnd())
+        {
+            LOG_DEBUG("[StoryPipeline] StoryId {} timeline {}-{} : Merging in StoryChunk {}-{} into chunk {}-{}",
+                      storyId,
+                      TimelineStart(),
+                      TimelineEnd(),
+                      other_chunk.getStartTime(),
+                      other_chunk.getEndTime(),
+                      (*chunk_to_merge_iter).second->getStartTime(),
+                      (*chunk_to_merge_iter).second->getEndTime());
             (*chunk_to_merge_iter).second->mergeEvents(other_chunk);
         }
     }
@@ -375,13 +483,22 @@ void chronolog::StoryPipeline::mergeEvents(chronolog::StoryChunk &other_chunk)
     if(!other_chunk.empty())
     {
         // if merging fails we have no choice but to discard the events we can't merge !!
-        LOG_ERROR("[StoryPipeline] StoryId {} timeline {}-{} : Merge operation discards {} events in chunk {}-{}"
-                     , storyId, TimelineStart(), TimelineEnd(), other_chunk.getEventCount(), other_chunk.getStartTime(), other_chunk.getEndTime());
+        LOG_ERROR("[StoryPipeline] StoryId {} timeline {}-{} : Merge operation discards {} events in chunk {}-{}",
+                  storyId,
+                  TimelineStart(),
+                  TimelineEnd(),
+                  other_chunk.getEventCount(),
+                  other_chunk.getStartTime(),
+                  other_chunk.getEndTime());
 #ifdef TRACE_MERGING
-        LOG_ERROR("[StoryPipeline] StoryId {} timeline {}-{} : Merge operation discards {} events in chunk {}"
-                     , storyId, TimelineStart(), TimelineEnd(), other_chunk.getEventCount(), other_chunk.to_string());
+        LOG_ERROR("[StoryPipeline] StoryId {} timeline {}-{} : Merge operation discards {} events in chunk {}",
+                  storyId,
+                  TimelineStart(),
+                  TimelineEnd(),
+                  other_chunk.getEventCount(),
+                  other_chunk.to_string());
 #endif
-                other_chunk.eraseEvents(other_chunk.getStartTime(), other_chunk.getEndTime());
+        other_chunk.eraseEvents(other_chunk.getStartTime(), other_chunk.getEndTime());
     }
 
     return;

--- a/chrono_common/src/StoryPipeline.cpp
+++ b/chrono_common/src/StoryPipeline.cpp
@@ -1,6 +1,9 @@
+#include <chrono>
+#include <ctime>
 #include <deque>
 #include <map>
 #include <mutex>
+#include <utility>
 
 #include <chrono_monitor.h>
 #include <StoryChunk.h>

--- a/test/communication/thallium_client.cpp
+++ b/test/communication/thallium_client.cpp
@@ -4,6 +4,10 @@
 
 #include <iostream>
 #include <iomanip>
+#include <string>
+#include <vector>
+#include <cstdlib>
+#include <cstring>
 #include <chrono>
 #include <thallium.hpp>
 #include <array>

--- a/test/communication/thallium_client.cpp
+++ b/test/communication/thallium_client.cpp
@@ -20,11 +20,12 @@ namespace tl = thallium;
 using namespace std::chrono;
 using my_clock = steady_clock;
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     if(argc < 5)
     {
-        LOG_ERROR("Insufficient arguments provided. Usage: {} <address> <sendrecv|rdma> <msg_size> [repetition]", argv[0]);
+        LOG_ERROR("Insufficient arguments provided. Usage: {} <address> <sendrecv|rdma> <msg_size> [repetition]",
+                  argv[0]);
         exit(0);
     }
     std::string server_address = argv[1];
@@ -34,7 +35,7 @@ int main(int argc, char**argv)
     long repetition = 1;
     if(argc > 4)
         repetition = strtol(argv[4], nullptr, 10);
-    time_point <my_clock, nanoseconds> t_bigbang, t_local_init, t_local_finish, t_global_finish;
+    time_point<my_clock, nanoseconds> t_bigbang, t_local_init, t_local_finish, t_global_finish;
 
     LOG_INFO("[Thallium Client] Configurations:");
     LOG_INFO(" - Server Address: {}", server_address);
@@ -43,7 +44,7 @@ int main(int argc, char**argv)
     LOG_INFO(" - Message Size: {} bytes", msg_size);
     LOG_INFO(" - Repetition Count: {}", repetition);
 
-    std::vector <char> data(msg_size, 'Z');
+    std::vector<char> data(msg_size, 'Z');
 
     t_bigbang = my_clock::now();
     tl::engine myEngine(protocol, THALLIUM_CLIENT_MODE);
@@ -58,8 +59,7 @@ int main(int argc, char**argv)
         tl::provider_handle ph(server);
         LOG_INFO("[Thallium Client] Initiating send/recv mode.");
         t_local_init = my_clock::now();
-        for(int i = 0; i < repetition; i++)
-            repeater.on(server)(data);
+        for(int i = 0; i < repetition; i++) repeater.on(server)(data);
         t_local_finish = my_clock::now();
     }
     else if(!strcmp(mode.c_str(), "rdma"))
@@ -68,16 +68,15 @@ int main(int argc, char**argv)
         std::string rpc_name = "rdma_put";
         LOG_INFO("[Thallium Client] Initiating RDMA mode.");
         LOG_INFO("[Thallium Client] Searching for RPC with name {} on {}", rpc_name, server_address);
-        tl::remote_procedure rdma_put = myEngine.define(rpc_name);//.disable_response();
+        tl::remote_procedure rdma_put = myEngine.define(rpc_name); //.disable_response();
         tl::endpoint server = myEngine.lookup(server_address);
-        std::vector <std::pair <void*, std::size_t>> segments(1);
+        std::vector<std::pair<void*, std::size_t>> segments(1);
         segments[0].first = (void*)(&data[0]);
         segments[0].second = data.size() + 1;
         tl::bulk myBulk = myEngine.expose(segments, tl::bulk_mode::read_only);
         LOG_INFO("[Thallium Client] Sending {} bytes of data to {}", data.size(), server_address);
         t_local_init = my_clock::now();
-        for(int i = 0; i < repetition; i++)
-            rdma_put.on(server)(myBulk);
+        for(int i = 0; i < repetition; i++) rdma_put.on(server)(myBulk);
         t_local_finish = my_clock::now();
     }
     else
@@ -89,7 +88,7 @@ int main(int argc, char**argv)
     myEngine.finalize();
     // sleep(100);
 
-    double duration = std::chrono::duration <double>(t_local_finish - t_bigbang).count();
+    double duration = std::chrono::duration<double>(t_local_finish - t_bigbang).count();
     LOG_INFO("[Thallium Client] Total execution time: {:>10} seconds", duration);
 
     return 0;

--- a/test/communication/thallium_client_mpi.cpp
+++ b/test/communication/thallium_client_mpi.cpp
@@ -25,30 +25,51 @@ namespace tl = thallium;
 using namespace std::chrono;
 using my_clock = steady_clock;
 
-void report_results(double duration_ave, double duration_min, double duration_max, double duration_wall
-                    , double duration_init_ave, double duration_comm_ave)
+void report_results(double duration_ave,
+                    double duration_min,
+                    double duration_max,
+                    double duration_wall,
+                    double duration_init_ave,
+                    double duration_comm_ave)
 {
     // Logging the results with descriptive headers for better context.
     LOG_INFO("[Performance Metrics Report (msg_size={}MB)(us)]", MSG_SIZE / (1024.0 * 1024.0));
     LOG_INFO("-------------------------------------------------------------------------------------------------------");
-    LOG_INFO("{:>16} {:>16} {:>16} {:>16} {:>16} {:>16}", "Ave Time", "Min Time", "Max Time", "Wall Time"
-             , "Ave Init Time", "Ave Comm Time");
+    LOG_INFO("{:>16} {:>16} {:>16} {:>16} {:>16} {:>16}",
+             "Ave Time",
+             "Min Time",
+             "Max Time",
+             "Wall Time",
+             "Ave Init Time",
+             "Ave Comm Time");
     LOG_INFO("-------------------------------------------------------------------------------------------------------");
-    LOG_INFO("{:>16.4f} {:>16.4f} {:>16.4f} {:>16.4f} {:>16.4f} {:>16.4f}", duration_ave, duration_min, duration_max
-             , duration_wall, duration_init_ave, duration_comm_ave);
+    LOG_INFO("{:>16.4f} {:>16.4f} {:>16.4f} {:>16.4f} {:>16.4f} {:>16.4f}",
+             duration_ave,
+             duration_min,
+             duration_max,
+             duration_wall,
+             duration_init_ave,
+             duration_comm_ave);
 }
 
 
-void calculate_time(time_point <my_clock, nanoseconds> &t_bigbang, time_point <my_clock, nanoseconds> &t_local_init
-                    , time_point <my_clock, nanoseconds> &t_local_finish
-                    , time_point <my_clock, nanoseconds> &t_global_finish, int nprocs, double &duration_ave
-                    , double &duration_min, double &duration_max, double &duration_wall, double &duration_init_ave
-                    , double &duration_comm_ave, long repetition)
+void calculate_time(time_point<my_clock, nanoseconds>& t_bigbang,
+                    time_point<my_clock, nanoseconds>& t_local_init,
+                    time_point<my_clock, nanoseconds>& t_local_finish,
+                    time_point<my_clock, nanoseconds>& t_global_finish,
+                    int nprocs,
+                    double& duration_ave,
+                    double& duration_min,
+                    double& duration_max,
+                    double& duration_wall,
+                    double& duration_init_ave,
+                    double& duration_comm_ave,
+                    long repetition)
 {
-    double duration_e2e = duration_cast <nanoseconds>(t_local_finish - t_bigbang).count() / 1000.0;
-    double duration_init = duration_cast <nanoseconds>(t_local_init - t_bigbang).count() / 1000.0;
-    double duration_comm = duration_cast <nanoseconds>(t_local_finish - t_local_init).count() / 1000.0;
-    duration_wall = duration_cast <nanoseconds>(t_global_finish - t_bigbang).count() / 1000.0;
+    double duration_e2e = duration_cast<nanoseconds>(t_local_finish - t_bigbang).count() / 1000.0;
+    double duration_init = duration_cast<nanoseconds>(t_local_init - t_bigbang).count() / 1000.0;
+    double duration_comm = duration_cast<nanoseconds>(t_local_finish - t_local_init).count() / 1000.0;
+    duration_wall = duration_cast<nanoseconds>(t_global_finish - t_bigbang).count() / 1000.0;
     duration_min = 0;
     duration_max = 0;
     duration_ave = 0;
@@ -65,7 +86,7 @@ void calculate_time(time_point <my_clock, nanoseconds> &t_bigbang, time_point <m
     duration_comm_ave /= (double)(repetition - WARM_UP_REPS);
 }
 
-std::string get_server_address(const std::string &base_address, long num_servers, int rank)
+std::string get_server_address(const std::string& base_address, long num_servers, int rank)
 {
     std::string host_ip = base_address.substr(0, base_address.rfind(':'));
     std::string base_port = base_address.substr(base_address.rfind(':') + 1);
@@ -77,7 +98,7 @@ std::string get_server_address(const std::string &base_address, long num_servers
     return new_addr_str;
 }
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     if(argc < 4)
     {
@@ -90,8 +111,13 @@ int main(int argc, char**argv)
     MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
 
-    int result = chronolog::chrono_monitor::initialize("console", "thallium_client_mpi.log", spdlog::level::debug
-                                                       , "thallium_client_mpi", 1048576, 5, spdlog::level::debug);
+    int result = chronolog::chrono_monitor::initialize("console",
+                                                       "thallium_client_mpi.log",
+                                                       spdlog::level::debug,
+                                                       "thallium_client_mpi",
+                                                       1048576,
+                                                       5,
+                                                       spdlog::level::debug);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
@@ -106,18 +132,15 @@ int main(int argc, char**argv)
     std::string server_address;
 
     std::string proto = base_address.substr(0, base_address.find_first_of(':'));
-    std::vector <char> send_vec, ret_vec;
+    std::vector<char> send_vec, ret_vec;
     send_vec.reserve(MSG_SIZE);
     static const char alphanum[] = "0123456789"
                                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                    "abcdefghijklmnopqrstuvwxyz";
-    for(int i = 0; i < MSG_SIZE; ++i)
-    {
-        send_vec.push_back(alphanum[dist(mt) % (sizeof(alphanum) - 1)]);
-    }
+    for(int i = 0; i < MSG_SIZE; ++i) { send_vec.push_back(alphanum[dist(mt) % (sizeof(alphanum) - 1)]); }
     double duration_min, duration_max, duration_ave, duration_wall;
     double duration_init_ave, duration_comm_ave;
-    time_point <my_clock, nanoseconds> t_bigbang, t_local_init, t_local_finish, t_global_finish;
+    time_point<my_clock, nanoseconds> t_bigbang, t_local_init, t_local_finish, t_global_finish;
 
     if(!strcmp(mode.c_str(), "sendrecv"))
     {
@@ -127,21 +150,21 @@ int main(int argc, char**argv)
         tl::engine myEngine(proto, THALLIUM_CLIENT_MODE);
         server_address = get_server_address(base_address, num_servers, my_rank);
         std::string rpc_name = "repeater";
-        LOG_DEBUG("[ThalliumClientMPI] Attempting to establish RPC connection for sendrecv mode with server at: {}"
-                  , server_address);
+        LOG_DEBUG("[ThalliumClientMPI] Attempting to establish RPC connection for sendrecv mode with server at: {}",
+                  server_address);
         tl::remote_procedure repeater = myEngine.define(rpc_name);
         tl::endpoint server = myEngine.lookup(server_address);
         tl::provider_handle ph(server);
         for(int i = 0; i < WARM_UP_REPS; i++)
-            ret_vec = repeater.on(server)(send_vec).as <std::vector <char>>(); // warm up
+            ret_vec = repeater.on(server)(send_vec).as<std::vector<char>>(); // warm up
         t_local_init = my_clock::now();
         for(int i = WARM_UP_REPS; i < repetition; i++)
         {
-            ret_vec = repeater.on(server)(send_vec).as <std::vector <char>>();
-//            if(ret_vec != send_vec)
-//            {
-//                LOG_ERROR("[ThalliumClientMPI] Mismatch detected: The server's response does not match the sent data.");
-//            }
+            ret_vec = repeater.on(server)(send_vec).as<std::vector<char>>();
+            //            if(ret_vec != send_vec)
+            //            {
+            //                LOG_ERROR("[ThalliumClientMPI] Mismatch detected: The server's response does not match the sent data.");
+            //            }
         }
         t_local_finish = my_clock::now();
         MPI_Barrier(MPI_COMM_WORLD);
@@ -155,20 +178,18 @@ int main(int argc, char**argv)
         tl::engine myEngine(proto, THALLIUM_CLIENT_MODE);
         server_address = get_server_address(base_address, num_servers, my_rank);
         std::string rpc_name = "rdma_put";
-        LOG_DEBUG("[ThalliumClientMPI] Attempting to establish RPC connection for RDMA mode with server at: {}"
-                  , server_address);
+        LOG_DEBUG("[ThalliumClientMPI] Attempting to establish RPC connection for RDMA mode with server at: {}",
+                  server_address);
         tl::remote_procedure rdma_put = myEngine.define(rpc_name); //.disable_response();
         tl::endpoint server = myEngine.lookup(server_address);
-        std::vector <std::pair <void*, std::size_t>> segments(1);
+        std::vector<std::pair<void*, std::size_t>> segments(1);
         segments[0].first = (void*)(&send_vec[0]);
         segments[0].second = send_vec.size() + 1;
         LOG_DEBUG("[ThalliumClientMPI] Exposing memory segments of size {} for RDMA mode.", send_vec.size() + 1);
         tl::bulk myBulk = myEngine.expose(segments, tl::bulk_mode::read_only);
-        for(int i = 0; i < WARM_UP_REPS; i++)
-            rdma_put.on(server)(myBulk);
+        for(int i = 0; i < WARM_UP_REPS; i++) rdma_put.on(server)(myBulk);
         t_local_init = my_clock::now();
-        for(int i = WARM_UP_REPS; i < repetition; i++)
-            rdma_put.on(server)(myBulk);
+        for(int i = WARM_UP_REPS; i < repetition; i++) rdma_put.on(server)(myBulk);
         t_local_finish = my_clock::now();
         MPI_Barrier(MPI_COMM_WORLD);
         t_global_finish = my_clock::now();
@@ -179,8 +200,18 @@ int main(int argc, char**argv)
         exit(0);
     }
 
-    calculate_time(t_bigbang, t_local_init, t_local_finish, t_global_finish, nprocs, duration_ave, duration_min
-                   , duration_max, duration_wall, duration_init_ave, duration_comm_ave, repetition);
+    calculate_time(t_bigbang,
+                   t_local_init,
+                   t_local_finish,
+                   t_global_finish,
+                   nprocs,
+                   duration_ave,
+                   duration_min,
+                   duration_max,
+                   duration_wall,
+                   duration_init_ave,
+                   duration_comm_ave,
+                   repetition);
 
     if(my_rank == 0)
     {

--- a/test/communication/thallium_client_mpi.cpp
+++ b/test/communication/thallium_client_mpi.cpp
@@ -3,7 +3,12 @@
 //
 
 #include <iostream>
+#include <string>
+#include <vector>
+#include <cstdlib>
+#include <cstring>
 #include <chrono>
+#include <random>
 #include <thallium.hpp>
 #include <array>
 #include <thallium/serialization/stl/vector.hpp>

--- a/test/communication/thallium_server.cpp
+++ b/test/communication/thallium_server.cpp
@@ -3,9 +3,13 @@
 //
 
 #include <iostream>
+#include <string>
+#include <vector>
+#include <cstdlib>
+#include <utility>
+#include <functional>
 #include <thallium.hpp>
 #include <array>
-#include <string>
 #include <thallium/serialization/stl/vector.hpp>
 #include <thread>
 #include <algorithm>

--- a/test/communication/thallium_server.cpp
+++ b/test/communication/thallium_server.cpp
@@ -22,7 +22,7 @@
 
 namespace tl = thallium;
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     if(argc != 4)
     {
@@ -41,14 +41,19 @@ int main(int argc, char**argv)
         exit(1);
     }
 
-    int result = chronolog::chrono_monitor::initialize("console", "thallium_server.log", spdlog::level::debug
-                                                       , "thallium_server", 1048576, 5, spdlog::level::debug);
+    int result = chronolog::chrono_monitor::initialize("console",
+                                                       "thallium_server.log",
+                                                       spdlog::level::debug,
+                                                       "thallium_server",
+                                                       1048576,
+                                                       5,
+                                                       spdlog::level::debug);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
     }
 
-    std::vector <std::thread> server_thrd_vec;
+    std::vector<std::thread> server_thrd_vec;
     server_thrd_vec.reserve(nPorts);
 
     tl::abt scope;
@@ -61,19 +66,19 @@ int main(int argc, char**argv)
         "argobots" : {"abt_mem_max_num_stacks" : 8, "abt_thread_stacksize" : 2097152}})";
     margo_set_environment(argobots_conf_str.c_str());
 
-    std::vector <tl::managed <tl::xstream>> ess;
+    std::vector<tl::managed<tl::xstream>> ess;
     LOG_INFO("Vector of streams created");
-    tl::managed <tl::pool> myPool = tl::pool::create(tl::pool::access::spmc);
+    tl::managed<tl::pool> myPool = tl::pool::create(tl::pool::access::spmc);
     LOG_INFO("Pool created");
     for(int j = 0; j < nStreams; j++)
     {
-        tl::managed <tl::xstream> es = tl::xstream::create(tl::scheduler::predef::deflt, *myPool);
+        tl::managed<tl::xstream> es = tl::xstream::create(tl::scheduler::predef::deflt, *myPool);
         LOG_INFO("A new stream is created");
         ess.push_back(std::move(es));
     }
 
-    std::vector <tl::engine> engine_vec;
-    std::vector <margo_instance_id> mid_vec;
+    std::vector<tl::engine> engine_vec;
+    std::vector<margo_instance_id> mid_vec;
     engine_vec.reserve(nPorts);
     mid_vec.reserve(nPorts);
     for(int j = 0; j < nPorts; j++)
@@ -117,10 +122,10 @@ int main(int argc, char**argv)
 
         // Define send/recv version
         LOG_INFO("Defining RPC routines in send/recv mode");
-        std::function <void(const tl::request &, std::vector <std::byte> &)> repeater = [](const tl::request &req
-                                                                                           , std::vector <std::byte> &data)
+        std::function<void(const tl::request&, std::vector<std::byte>&)> repeater =
+                [](const tl::request& req, std::vector<std::byte>& data)
         {
-            std::vector <std::byte> mem_vec(data.size());
+            std::vector<std::byte> mem_vec(data.size());
             std::copy(data.begin(), data.end(), mem_vec.begin());
             LOG_DEBUG("Received {} bytes of data in send/recv mode", data.size());
             req.respond(mem_vec);
@@ -130,15 +135,15 @@ int main(int argc, char**argv)
         // Define RDMA version
         LOG_INFO("Defining RPC routines in RDMA mode");
         /*std::cout << "Defining RPC routines in RDMA mode" << std::endl;*/
-        std::function <void(const tl::request &, tl::bulk &)> f = [j, &engine_vec](const tl::request &req, tl::bulk &b)
+        std::function<void(const tl::request&, tl::bulk&)> f = [j, &engine_vec](const tl::request& req, tl::bulk& b)
         {
             LOG_DEBUG("RDMA rpc invoked");
             tl::endpoint ep = req.get_endpoint();
             LOG_DEBUG("endpoint obtained");
-            std::vector <char> mem_vec(MAX_BULK_MEM_SIZE);
+            std::vector<char> mem_vec(MAX_BULK_MEM_SIZE);
             mem_vec.reserve(MAX_BULK_MEM_SIZE);
             mem_vec.resize(MAX_BULK_MEM_SIZE);
-            std::vector <std::pair <void*, std::size_t>> segments(1);
+            std::vector<std::pair<void*, std::size_t>> segments(1);
             segments[0].first = (void*)(&mem_vec[0]);
             segments[0].second = mem_vec.size();
             LOG_DEBUG("RDMA memory prepared, size: {}", mem_vec.size());
@@ -151,18 +156,14 @@ int main(int argc, char**argv)
             //std::cout << std::endl;
             req.respond(b.size());
         };
-        myEngine.define("rdma_put", f);//.disable_response();
+        myEngine.define("rdma_put", f); //.disable_response();
 
         engine_vec.emplace_back(std::move(myEngine));
         mid_vec.emplace_back(mid);
     }
-    for(auto engine: engine_vec)
-        engine.wait_for_finalize();
+    for(auto engine: engine_vec) engine.wait_for_finalize();
 
-    for(int j = 0; j < nStreams; j++)
-    {
-        ess[j]->join();
-    }
+    for(int j = 0; j < nStreams; j++) { ess[j]->join(); }
 
     return 0;
 }

--- a/test/integration/Client/client_lib_connect_rpc_test.cpp
+++ b/test/integration/Client/client_lib_connect_rpc_test.cpp
@@ -1,6 +1,10 @@
 #include <chrono>
-#include <unordered_map>
 #include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include <cmd_arg_parse.h>
 #include <chronolog_client.h>

--- a/test/integration/Client/client_lib_connect_rpc_test.cpp
+++ b/test/integration/Client/client_lib_connect_rpc_test.cpp
@@ -19,13 +19,21 @@ int main(int argc, char** argv)
     // Load configuration
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[ClientLibConnectRPCTest] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[ClientLibConnectRPCTest] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[ClientLibConnectRPCTest] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
+        else
+        {
+            std::cout << "[ClientLibConnectRPCTest] Configuration file loaded successfully from '" << conf_file_path
+                      << "'." << std::endl;
+        }
+    }
+    else
+    {
         std::cout << "[ClientLibConnectRPCTest] No configuration file provided. Using default values." << std::endl;
     }
     confManager.log_configuration(std::cout);
@@ -38,7 +46,8 @@ int main(int argc, char** argv)
                                                        confManager.LOG_CONF.LOGFILESIZE,
                                                        confManager.LOG_CONF.LOGFILENUM,
                                                        confManager.LOG_CONF.FLUSHLEVEL);
-    if (result == 1) {
+    if(result == 1)
+    {
         return EXIT_FAILURE;
     }
 
@@ -66,14 +75,13 @@ int main(int argc, char** argv)
     std::chrono::duration<double, std::nano> duration_connect{}, duration_disconnect{};
 
     client_ids.reserve(NUM_CONNECTION);
-    for (int i = 0; i < NUM_CONNECTION; i++) {
-        client_ids.emplace_back(gen_random(8));
-    }
+    for(int i = 0; i < NUM_CONNECTION; i++) { client_ids.emplace_back(gen_random(8)); }
 
-    for (int i = 0; i < NUM_CONNECTION; i++) {
+    for(int i = 0; i < NUM_CONNECTION; i++)
+    {
         server_uri = portalConf.PROTO_CONF + "://" + server_ip + ":" + std::to_string(base_port + i);
         t1 = std::chrono::steady_clock::now();
-        ret = client.Connect();//server_uri, client_ids[i], flags); //, offset);
+        ret = client.Connect(); //server_uri, client_ids[i], flags); //, offset);
         assert(ret == chronolog::CL_SUCCESS);
         t2 = std::chrono::steady_clock::now();
         duration_connect += (t2 - t1);
@@ -90,7 +98,7 @@ int main(int argc, char** argv)
 
     LOG_INFO("[ClientLibConnectRPCTest] Average connection time: {} ns", duration_connect.count() / NUM_CONNECTION);
     LOG_INFO("[ClientLibConnectRPCTest] Average disconnection time: {} ns",
-            duration_disconnect.count() / NUM_CONNECTION);
+             duration_disconnect.count() / NUM_CONNECTION);
 
     return 0;
 }

--- a/test/integration/Client/client_lib_hybrid_argobots_test.cpp
+++ b/test/integration/Client/client_lib_hybrid_argobots_test.cpp
@@ -14,14 +14,14 @@
 #include <chrono_monitor.h>
 #include <common.h>
 
-chronolog::Client*client;
+chronolog::Client* client;
 
 struct thread_arg
 {
     int tid;
 };
 
-void thread_function(void*t)
+void thread_function(void* t)
 {
     LOG_INFO("[ClientLibHybridArgobotsTest] Starting thread function for thread ID: {}", ((thread_arg*)t)->tid);
 
@@ -35,23 +35,23 @@ void thread_function(void*t)
     int ret = client->Connect(); // Connect to server using client_id and flags
     if(ret == chronolog::CL_SUCCESS)
     {
-        LOG_INFO("[ClientLibHybridArgobotsTest] Successfully connected to server for thread ID: {}"
-                 , ((thread_arg*)t)->tid);
+        LOG_INFO("[ClientLibHybridArgobotsTest] Successfully connected to server for thread ID: {}",
+                 ((thread_arg*)t)->tid);
     }
 
     ret = client->Disconnect(); // Disconnect from server using client_id and flags
     if(ret == chronolog::CL_SUCCESS)
     {
-        LOG_INFO("[ClientLibHybridArgobotsTest] Successfully disconnected from server for thread ID: {}"
-                 , ((thread_arg*)t)->tid);
+        LOG_INFO("[ClientLibHybridArgobotsTest] Successfully disconnected from server for thread ID: {}",
+                 ((thread_arg*)t)->tid);
     }
 }
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
-    std::vector <std::string> client_ids;
-    std::atomic <long> duration_connect{}, duration_disconnect{};
-    std::vector <std::thread> thread_vec;
+    std::vector<std::string> client_ids;
+    std::atomic<long> duration_connect{}, duration_disconnect{};
+    std::vector<std::thread> thread_vec;
     uint64_t offset;
     int provided;
 
@@ -60,13 +60,21 @@ int main(int argc, char**argv)
     // Load configuration
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[ClientLibHybridArgobotsTest] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[ClientLibHybridArgobotsTest] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[ClientLibHybridArgobotsTest] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
+        else
+        {
+            std::cout << "[ClientLibHybridArgobotsTest] Configuration file loaded successfully from '" << conf_file_path
+                      << "'." << std::endl;
+        }
+    }
+    else
+    {
         std::cout << "[ClientLibHybridArgobotsTest] No configuration file provided. Using default values." << std::endl;
     }
     confManager.log_configuration(std::cout);
@@ -79,7 +87,8 @@ int main(int argc, char**argv)
                                                        confManager.LOG_CONF.LOGFILESIZE,
                                                        confManager.LOG_CONF.LOGFILENUM,
                                                        confManager.LOG_CONF.FLUSHLEVEL);
-    if (result == 1) {
+    if(result == 1)
+    {
         return EXIT_FAILURE;
     }
 
@@ -99,26 +108,20 @@ int main(int argc, char**argv)
     int num_xstreams = 8;
     int num_threads = 8;
 
-    ABT_xstream*xstreams = (ABT_xstream*)malloc(sizeof(ABT_xstream) * num_xstreams);
-    ABT_pool*pools = (ABT_pool*)malloc(sizeof(ABT_pool) * num_xstreams);
-    ABT_thread*threads = (ABT_thread*)malloc(sizeof(ABT_thread) * num_threads);
-    struct thread_arg*t_args = (struct thread_arg*)malloc(num_threads * sizeof(struct thread_arg));
+    ABT_xstream* xstreams = (ABT_xstream*)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_pool* pools = (ABT_pool*)malloc(sizeof(ABT_pool) * num_xstreams);
+    ABT_thread* threads = (ABT_thread*)malloc(sizeof(ABT_thread) * num_threads);
+    struct thread_arg* t_args = (struct thread_arg*)malloc(num_threads * sizeof(struct thread_arg));
 
 
     ABT_init(argc, argv);
 
     ABT_xstream_self(&xstreams[0]);
 
-    for(int i = 1; i < num_xstreams; i++)
-    {
-        ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
-    }
+    for(int i = 1; i < num_xstreams; i++) { ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]); }
 
 
-    for(int i = 0; i < num_xstreams; i++)
-    {
-        ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
-    }
+    for(int i = 0; i < num_xstreams; i++) { ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]); }
 
 
     for(int i = 0; i < num_threads; i++)
@@ -126,8 +129,7 @@ int main(int argc, char**argv)
         ABT_thread_create(pools[i], thread_function, &t_args[i], ABT_THREAD_ATTR_NULL, &threads[i]);
     }
 
-    for(int i = 0; i < num_threads; i++)
-        ABT_thread_free(&threads[i]);
+    for(int i = 0; i < num_threads; i++) ABT_thread_free(&threads[i]);
 
     for(int i = 1; i < num_xstreams; i++)
     {

--- a/test/integration/Client/client_lib_hybrid_argobots_test.cpp
+++ b/test/integration/Client/client_lib_hybrid_argobots_test.cpp
@@ -1,5 +1,10 @@
 #include <atomic>
+#include <cstdlib>
+#include <iostream>
+#include <string>
 #include <thread>
+#include <vector>
+
 #include <abt.h>
 #include <mpi.h>
 

--- a/test/integration/Client/client_lib_metadata_rpc_test.cpp
+++ b/test/integration/Client/client_lib_metadata_rpc_test.cpp
@@ -1,8 +1,9 @@
 #include <chrono>
 #include <cassert>
+#include <iostream>
 #include <map>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <cmd_arg_parse.h>
 #include <chronolog_client.h>

--- a/test/integration/Client/client_lib_metadata_rpc_test.cpp
+++ b/test/integration/Client/client_lib_metadata_rpc_test.cpp
@@ -16,18 +16,27 @@
 #define CHRONICLE_NAME_LEN 32
 #define STORY_NAME_LEN 32
 
-int main(int argc, char** argv) {
-    
+int main(int argc, char** argv)
+{
+
     // Load configuration
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[ClientLibMetadataRPCTest] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[ClientLibMetadataRPCTest] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[ClientLibMetadataRPCTest] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
+        else
+        {
+            std::cout << "[ClientLibMetadataRPCTest] Configuration file loaded successfully from '" << conf_file_path
+                      << "'." << std::endl;
+        }
+    }
+    else
+    {
         std::cout << "[ClientLibMetadataRPCTest] No configuration file provided. Using default values." << std::endl;
     }
     confManager.log_configuration(std::cout);
@@ -40,7 +49,8 @@ int main(int argc, char** argv) {
                                                        confManager.LOG_CONF.LOGFILESIZE,
                                                        confManager.LOG_CONF.LOGFILENUM,
                                                        confManager.LOG_CONF.FLUSHLEVEL);
-    if (result == 1) {
+    if(result == 1)
+    {
         return EXIT_FAILURE;
     }
 
@@ -54,9 +64,11 @@ int main(int argc, char** argv) {
     LOG_INFO("[ClientLibMetadataRPCTest] Running test.");
 
     chronolog::Client client(portalConf);
-    std::vector <std::string> chronicle_names;
+    std::vector<std::string> chronicle_names;
     std::chrono::steady_clock::time_point t1, t2;
-    std::chrono::duration <double, std::nano> duration_create_chronicle{}, duration_edit_chronicle_attr{}, duration_acquire_story{}, duration_release_story{}, duration_destroy_story{}, duration_get_chronicle_attr{}, duration_destroy_chronicle{}, duration_show_chronicles{}, duration_show_stories{};
+    std::chrono::duration<double, std::nano> duration_create_chronicle{}, duration_edit_chronicle_attr{},
+            duration_acquire_story{}, duration_release_story{}, duration_destroy_story{}, duration_get_chronicle_attr{},
+            duration_destroy_chronicle{}, duration_show_chronicles{}, duration_show_stories{};
     int flags;
     int ret;
     uint64_t offset = 0;
@@ -77,7 +89,7 @@ int main(int argc, char** argv) {
     for(int i = 0; i < NUM_CHRONICLE; i++)
     {
         std::string attr = std::string("Priority=High");
-        std::map <std::string, std::string> chronicle_attrs;
+        std::map<std::string, std::string> chronicle_attrs;
         chronicle_attrs.emplace("Priority", "High");
         chronicle_attrs.emplace("Date", "2023-01-15");
         chronicle_attrs.emplace("IndexGranularity", "Millisecond");
@@ -91,12 +103,12 @@ int main(int argc, char** argv) {
 
 
     t1 = std::chrono::steady_clock::now();
-    std::vector <std::string> chronicle_names_retrieved;
+    std::vector<std::string> chronicle_names_retrieved;
     chronicle_names_retrieved = client.ShowChronicles(chronicle_names_retrieved);
     t2 = std::chrono::steady_clock::now();
     duration_show_chronicles += (t2 - t1);
     //std::sort(chronicle_names_retrieved.begin(), chronicle_names_retrieved.end());
-    std::vector <std::string> chronicle_names_sorted = chronicle_names;
+    std::vector<std::string> chronicle_names_sorted = chronicle_names;
     //std::sort(chronicle_names_sorted.begin(), chronicle_names_sorted.end());
     //assert(chronicle_names_retrieved == chronicle_names_sorted);
 
@@ -111,14 +123,14 @@ int main(int argc, char** argv) {
         //assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NO_KEEPERS);
         duration_edit_chronicle_attr += (t2 - t1);
 
-        std::vector <std::string> story_names;
+        std::vector<std::string> story_names;
         story_names.reserve(NUM_STORY);
         for(int j = 0; j < NUM_STORY; j++)
         {
             flags = 2;
             std::string story_name(gen_random(STORY_NAME_LEN));
             story_names.emplace_back(story_name);
-            std::map <std::string, std::string> story_attrs;
+            std::map<std::string, std::string> story_attrs;
             story_attrs.emplace("Priority", "High");
             story_attrs.emplace("IndexGranularity", "Millisecond");
             story_attrs.emplace("TieringPolicy", "Hot");
@@ -133,7 +145,7 @@ int main(int argc, char** argv) {
         assert(ret == chronolog::CL_ERR_NO_KEEPERS || ret == chronolog::CL_ERR_ACQUIRED);
 
         t1 = std::chrono::steady_clock::now();
-        std::vector <std::string> stories_names_retrieved;
+        std::vector<std::string> stories_names_retrieved;
         client.ShowStories(chronicle_names[i], stories_names_retrieved);
         t2 = std::chrono::steady_clock::now();
         duration_show_stories += (t2 - t1);
@@ -152,7 +164,7 @@ int main(int argc, char** argv) {
             duration_release_story += (t2 - t1);
         }
 
-            flags = 8;
+        flags = 8;
         for(int j = 0; j < NUM_STORY; j++)
         {
             t1 = std::chrono::steady_clock::now();
@@ -184,28 +196,30 @@ int main(int argc, char** argv) {
 
     for(int i = 0; i < NUM_STORY; i++)
     {
-        std::map <std::string, std::string> story_attrs;
+        std::map<std::string, std::string> story_attrs;
         std::string temp_str = gen_random(STORY_NAME_LEN);
         ret = client.AcquireStory(chronicle_names[i].append(temp_str), temp_str, story_attrs, flags).first;
         assert(ret == chronolog::CL_ERR_NOT_EXIST);
     }
 
-    LOG_INFO("[ClientLibMetadataRPCTest] CreateChronicle takes {} ns", duration_create_chronicle.count() / NUM_CHRONICLE);
+    LOG_INFO("[ClientLibMetadataRPCTest] CreateChronicle takes {} ns",
+             duration_create_chronicle.count() / NUM_CHRONICLE);
     LOG_INFO("[ClientLibMetadataRPCTest] EditChronicleAttr takes {} ns",
-            duration_edit_chronicle_attr.count() / NUM_CHRONICLE);
+             duration_edit_chronicle_attr.count() / NUM_CHRONICLE);
     LOG_INFO("[ClientLibMetadataRPCTest] AcquireStory takes {} ns",
-            duration_acquire_story.count() / (NUM_CHRONICLE * NUM_STORY));
+             duration_acquire_story.count() / (NUM_CHRONICLE * NUM_STORY));
     LOG_INFO("[ClientLibMetadataRPCTest] ReleaseStory takes {} ns",
-            duration_release_story.count() / (NUM_CHRONICLE * NUM_STORY));
+             duration_release_story.count() / (NUM_CHRONICLE * NUM_STORY));
     LOG_INFO("[ClientLibMetadataRPCTest] DestroyStory takes {} ns",
-            duration_destroy_story.count() / (NUM_CHRONICLE * NUM_STORY));
+             duration_destroy_story.count() / (NUM_CHRONICLE * NUM_STORY));
     LOG_INFO("[ClientLibMetadataRPCTest] GetChronileAttr(Date) takes {} ns",
-            duration_get_chronicle_attr.count() / NUM_CHRONICLE);
-    LOG_INFO("[ClientLibMetadataRPCTest] DestroyChronicle takes {} ns", duration_destroy_chronicle.count() / NUM_CHRONICLE);
+             duration_get_chronicle_attr.count() / NUM_CHRONICLE);
+    LOG_INFO("[ClientLibMetadataRPCTest] DestroyChronicle takes {} ns",
+             duration_destroy_chronicle.count() / NUM_CHRONICLE);
     LOG_INFO("[ClientLibMetadataRPCTest] ShowChronicles takes {} ns", duration_show_chronicles.count() / NUM_CHRONICLE);
     LOG_INFO("[ClientLibMetadataRPCTest] ShowStories takes {} ns", duration_show_stories.count() / NUM_CHRONICLE);
 
-    duration_create_chronicle = std::chrono::duration <double, std::nano>();
+    duration_create_chronicle = std::chrono::duration<double, std::nano>();
     chronicle_names.clear();
     flags = 1;
     for(int i = 0; i < NUM_CHRONICLE; i++)
@@ -214,7 +228,7 @@ int main(int argc, char** argv) {
         chronicle_names.emplace_back(chronicle_name);
         std::string attr = std::string("Priority=High");
         int ret;
-        std::map <std::string, std::string> chronicle_attrs;
+        std::map<std::string, std::string> chronicle_attrs;
         chronicle_attrs.emplace("Priority", "High");
         chronicle_attrs.emplace("IndexGranularity", "Millisecond");
         chronicle_attrs.emplace("TieringPolicy", "Hot");
@@ -226,11 +240,11 @@ int main(int argc, char** argv) {
     }
 
     flags = 32;
-    duration_destroy_chronicle = std::chrono::duration <double, std::nano>();
+    duration_destroy_chronicle = std::chrono::duration<double, std::nano>();
     for(int i = 0; i < NUM_CHRONICLE; i++)
     {
         t1 = std::chrono::steady_clock::now();
-        int ret = client.DestroyChronicle(chronicle_names[i]);//, flags);
+        int ret = client.DestroyChronicle(chronicle_names[i]); //, flags);
         t2 = std::chrono::steady_clock::now();
         assert(ret == chronolog::CL_SUCCESS);
         duration_destroy_chronicle += (t2 - t1);
@@ -238,8 +252,9 @@ int main(int argc, char** argv) {
     LOG_INFO("[ClientLibMetadataRPCTest] Disconnecting from the server.");
     client.Disconnect();
 
-    LOG_INFO("[ClientLibMetadataRPCTest] CreateChronicle2 takes {} ns", duration_create_chronicle.count() / NUM_CHRONICLE);
+    LOG_INFO("[ClientLibMetadataRPCTest] CreateChronicle2 takes {} ns",
+             duration_create_chronicle.count() / NUM_CHRONICLE);
     LOG_INFO("[ClientLibMetadataRPCTest] DestroyChronicle2 takes {} ns",
-            duration_destroy_chronicle.count() / NUM_CHRONICLE);
+             duration_destroy_chronicle.count() / NUM_CHRONICLE);
     return 0;
 }

--- a/test/integration/Client/client_lib_multi_argobots_test.cpp
+++ b/test/integration/Client/client_lib_multi_argobots_test.cpp
@@ -17,7 +17,7 @@
 #define CHRONICLE_NAME_LEN 32
 #define STORY_NAME_LEN 32
 
-chronolog::Client*client;
+chronolog::Client* client;
 
 struct thread_arg
 {
@@ -25,43 +25,53 @@ struct thread_arg
     std::string client_id;
 };
 
-void thread_function(void*tt)
+void thread_function(void* tt)
 {
-    struct thread_arg*t = (struct thread_arg*)tt;
+    struct thread_arg* t = (struct thread_arg*)tt;
 
     int flags = 0;
     uint64_t offset;
     int ret;
     std::string chronicle_name;
-    if(t->tid % 2 == 0) chronicle_name = "Chronicle_1";
-    else chronicle_name = "Chronicle_2";
-    std::map <std::string, std::string> chronicle_attrs;
+    if(t->tid % 2 == 0)
+        chronicle_name = "Chronicle_1";
+    else
+        chronicle_name = "Chronicle_2";
+    std::map<std::string, std::string> chronicle_attrs;
     chronicle_attrs.emplace("Priority", "High");
     chronicle_attrs.emplace("IndexGranularity", "Millisecond");
     chronicle_attrs.emplace("TieringPolicy", "Hot");
     ret = client->CreateChronicle(chronicle_name, chronicle_attrs, flags);
-    LOG_DEBUG("[ClientLibMultiArgobotsTest] Thread (ID: {}) - Created Chronicle: {}. Return Code: {}", t->tid
-              , chronicle_name, ret);
+    LOG_DEBUG("[ClientLibMultiArgobotsTest] Thread (ID: {}) - Created Chronicle: {}. Return Code: {}",
+              t->tid,
+              chronicle_name,
+              ret);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_CHRONICLE_EXISTS ||
            ret == chronolog::CL_ERR_NO_KEEPERS);
     flags = 1;
     std::string story_name = gen_random(STORY_NAME_LEN);
-    std::map <std::string, std::string> story_attrs;
+    std::map<std::string, std::string> story_attrs;
     story_attrs.emplace("Priority", "High");
     story_attrs.emplace("IndexGranularity", "Millisecond");
     story_attrs.emplace("TieringPolicy", "Hot");
     flags = 2;
     auto acquire_ret = client->AcquireStory(chronicle_name, story_name, story_attrs, flags);
-    LOG_DEBUG(
-            "[ClientLibMultiArgobotsTest] Thread ID: {} - Attempted to acquire Story: {} in Chronicle: {}. Result Code: {}"
-            , t->tid, story_name, chronicle_name, acquire_ret.first);
+    LOG_DEBUG("[ClientLibMultiArgobotsTest] Thread ID: {} - Attempted to acquire Story: {} in Chronicle: {}. Result "
+              "Code: {}",
+              t->tid,
+              story_name,
+              chronicle_name,
+              acquire_ret.first);
     assert(acquire_ret.first == chronolog::CL_SUCCESS || acquire_ret.first == chronolog::CL_ERR_NOT_EXIST ||
            acquire_ret.first == chronolog::CL_ERR_NO_KEEPERS);
     ret = client->DestroyStory(chronicle_name, story_name);
 
-    LOG_DEBUG(
-            "[ClientLibMultiArgobotsTest] Thread ID: {} - Attempted to destroy story '{}' within chronicle '{}'. Result Code: {}"
-            , t->tid, story_name, chronicle_name, acquire_ret.first);
+    LOG_DEBUG("[ClientLibMultiArgobotsTest] Thread ID: {} - Attempted to destroy story '{}' within chronicle '{}'. "
+              "Result Code: {}",
+              t->tid,
+              story_name,
+              chronicle_name,
+              acquire_ret.first);
     assert(ret == chronolog::CL_ERR_ACQUIRED || ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST ||
            ret == chronolog::CL_ERR_NO_KEEPERS);
     ret = client->Disconnect();
@@ -70,33 +80,48 @@ void thread_function(void*tt)
     assert(ret == chronolog::CL_ERR_ACQUIRED || ret == chronolog::CL_SUCCESS);
     ret = client->ReleaseStory(chronicle_name, story_name);
 
-    LOG_DEBUG("[ClientLibMultiArgobotsTest] Thread ID: {} - Released Story: {} from Chronicle: {}. Result Code: {}"
-              , t->tid, story_name, chronicle_name, ret);
+    LOG_DEBUG("[ClientLibMultiArgobotsTest] Thread ID: {} - Released Story: {} from Chronicle: {}. Result Code: {}",
+              t->tid,
+              story_name,
+              chronicle_name,
+              ret);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NO_KEEPERS || ret == chronolog::CL_ERR_NOT_EXIST);
     ret = client->DestroyStory(chronicle_name, story_name);
 
-    LOG_DEBUG("[ClientLibMultiArgobotsTest] Thread ID: {} - Destroyed Story: {} from Chronicle: {}. Result Code: {}"
-              , t->tid, story_name, chronicle_name, ret);
+    LOG_DEBUG("[ClientLibMultiArgobotsTest] Thread ID: {} - Destroyed Story: {} from Chronicle: {}. Result Code: {}",
+              t->tid,
+              story_name,
+              chronicle_name,
+              ret);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED ||
            ret == chronolog::CL_ERR_NO_KEEPERS);
     ret = client->DestroyChronicle(chronicle_name);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED);
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
     std::atomic<long> duration_connect{}, duration_disconnect{};
     std::vector<std::thread> thread_vec;
 
     // Load configuration
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[ClientLibMultiArgobotsTest] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[ClientLibMultiArgobotsTest] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[ClientLibMultiArgobotsTest] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
+        else
+        {
+            std::cout << "[ClientLibMultiArgobotsTest] Configuration file loaded successfully from '" << conf_file_path
+                      << "'." << std::endl;
+        }
+    }
+    else
+    {
         std::cout << "[ClientLibMultiArgobotsTest] No configuration file provided. Using default values." << std::endl;
     }
     confManager.log_configuration(std::cout);
@@ -109,7 +134,8 @@ int main(int argc, char** argv) {
                                                        confManager.LOG_CONF.LOGFILESIZE,
                                                        confManager.LOG_CONF.LOGFILENUM,
                                                        confManager.LOG_CONF.FLUSHLEVEL);
-    if (result == 1) {
+    if(result == 1)
+    {
         return EXIT_FAILURE;
     }
 
@@ -124,7 +150,8 @@ int main(int argc, char** argv) {
 
     client = new chronolog::Client(portalConf);
     int ret = client->Connect();
-    if (ret != chronolog::CL_SUCCESS) {
+    if(ret != chronolog::CL_SUCCESS)
+    {
         LOG_ERROR("[ClientLibMultiArgobotsTest] Failed to connect, ret: {}", ret);
         return EXIT_FAILURE;
     }
@@ -133,12 +160,14 @@ int main(int argc, char** argv) {
     int num_xstreams = 8;
     int num_threads = 8;
 
-    ABT_xstream*xstreams = (ABT_xstream*)malloc(sizeof(ABT_xstream) * num_xstreams);
-    ABT_pool*pools = (ABT_pool*)malloc(sizeof(ABT_pool) * num_xstreams);
-    ABT_thread*threads = (ABT_thread*)malloc(sizeof(ABT_thread) * num_threads);
-    std::vector <struct thread_arg> t_args(num_threads);;
+    ABT_xstream* xstreams = (ABT_xstream*)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_pool* pools = (ABT_pool*)malloc(sizeof(ABT_pool) * num_xstreams);
+    ABT_thread* threads = (ABT_thread*)malloc(sizeof(ABT_thread) * num_threads);
+    std::vector<struct thread_arg> t_args(num_threads);
+    ;
 
-    std::string client_id = gen_random(8);;
+    std::string client_id = gen_random(8);
+    ;
     std::string server_uri = portalConf.PROTO_CONF + "://" + portalConf.IP + ":" + std::to_string(portalConf.PORT);
     int flags = 0;
 
@@ -149,7 +178,7 @@ int main(int argc, char** argv) {
     else
     {
         LOG_ERROR("[ClientLibMultiArgobotsTest] Failed to connect to the server. Error code: {}", ret);
-        exit(1);  // Exit if connection fails
+        exit(1); // Exit if connection fails
     }
     assert(ret == chronolog::CL_SUCCESS);
 
@@ -163,16 +192,10 @@ int main(int argc, char** argv) {
 
     ABT_xstream_self(&xstreams[0]);
 
-    for(int i = 1; i < num_xstreams; i++)
-    {
-        ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
-    }
+    for(int i = 1; i < num_xstreams; i++) { ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]); }
 
 
-    for(int i = 0; i < num_xstreams; i++)
-    {
-        ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
-    }
+    for(int i = 0; i < num_xstreams; i++) { ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]); }
 
 
     for(int i = 0; i < num_threads; i++)
@@ -180,8 +203,7 @@ int main(int argc, char** argv) {
         ABT_thread_create(pools[i], thread_function, &t_args[i], ABT_THREAD_ATTR_NULL, &threads[i]);
     }
 
-    for(int i = 0; i < num_threads; i++)
-        ABT_thread_free(&threads[i]);
+    for(int i = 0; i < num_threads; i++) ABT_thread_free(&threads[i]);
 
     for(int i = 1; i < num_xstreams; i++)
     {

--- a/test/integration/Client/client_lib_multi_argobots_test.cpp
+++ b/test/integration/Client/client_lib_multi_argobots_test.cpp
@@ -1,6 +1,12 @@
-#include <thread>
-#include <abt.h>
 #include <atomic>
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <abt.h>
 
 #include <cmd_arg_parse.h>
 #include <chronolog_client.h>

--- a/test/integration/Client/client_lib_multi_openmp_test.cpp
+++ b/test/integration/Client/client_lib_multi_openmp_test.cpp
@@ -1,5 +1,11 @@
 #include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
 #include <thread>
+#include <vector>
+
 #include <omp.h>
 
 #include <cmd_arg_parse.h>

--- a/test/integration/Client/client_lib_multi_openmp_test.cpp
+++ b/test/integration/Client/client_lib_multi_openmp_test.cpp
@@ -16,18 +16,26 @@
 
 #define STORY_NAME_LEN 32
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     // Load configuration
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[ClientLibMultiOpenMPTest] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[ClientLibMultiOpenMPTest] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[ClientLibMultiOpenMPTest] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
+        else
+        {
+            std::cout << "[ClientLibMultiOpenMPTest] Configuration file loaded successfully from '" << conf_file_path
+                      << "'." << std::endl;
+        }
+    }
+    else
+    {
         std::cout << "[ClientLibMultiOpenMPTest] No configuration file provided. Using default values." << std::endl;
     }
     confManager.log_configuration(std::cout);
@@ -40,7 +48,8 @@ int main(int argc, char**argv)
                                                        confManager.LOG_CONF.LOGFILESIZE,
                                                        confManager.LOG_CONF.LOGFILENUM,
                                                        confManager.LOG_CONF.FLUSHLEVEL);
-    if (result == 1) {
+    if(result == 1)
+    {
         return EXIT_FAILURE;
     }
 
@@ -69,15 +78,17 @@ int main(int argc, char**argv)
     uint64_t offset;
 
     std::string client_id = gen_random(8);
-    int ret = client->Connect();//server_uri, client_id, flags);//, offset);
+    int ret = client->Connect(); //server_uri, client_id, flags);//, offset);
     LOG_INFO("[ClientLibMultiOpenMPTest] Successfully connected to the server.");
 #pragma omp for
     for(int i = 0; i < num_threads; i++)
     {
         std::string chronicle_name;
-        if(i % 2 == 0) chronicle_name = "gscs5er9TcdJ9mOgUDteDVBcI0oQjozK";
-        else chronicle_name = "6RPkwqX2IOpR41dVCqmWauX9RfXIuTAp";
-        std::map <std::string, std::string> chronicle_attrs;
+        if(i % 2 == 0)
+            chronicle_name = "gscs5er9TcdJ9mOgUDteDVBcI0oQjozK";
+        else
+            chronicle_name = "6RPkwqX2IOpR41dVCqmWauX9RfXIuTAp";
+        std::map<std::string, std::string> chronicle_attrs;
         chronicle_attrs.emplace("Priority", "High");
         chronicle_attrs.emplace("IndexGranularity", "Millisecond");
         chronicle_attrs.emplace("TieringPolicy", "Hot");
@@ -89,7 +100,7 @@ int main(int argc, char**argv)
         std::string story_name = gen_random(STORY_NAME_LEN);
         LOG_INFO("[ClientLibMultiOpenMPTest] Thread {} creating story: {}", i, story_name);
 
-        std::map <std::string, std::string> story_attrs;
+        std::map<std::string, std::string> story_attrs;
         story_attrs.emplace("Priority", "High");
         story_attrs.emplace("IndexGranularity", "Millisecond");
         story_attrs.emplace("TieringPolicy", "Hot");
@@ -97,17 +108,17 @@ int main(int argc, char**argv)
         auto acquire_ret = client->AcquireStory(chronicle_name, story_name, story_attrs, flags);
 
         assert(acquire_ret.first == chronolog::CL_SUCCESS);
-        ret = client->DestroyStory(chronicle_name, story_name);//, flags);
+        ret = client->DestroyStory(chronicle_name, story_name); //, flags);
         LOG_INFO("[ClientLibMultiOpenMPTest] Thread {} destroying story: {}", i, story_name);
 
         assert(ret == chronolog::CL_ERR_ACQUIRED);
-        ret = client->Disconnect();//client_id, flags);
+        ret = client->Disconnect(); //client_id, flags);
         assert(ret == chronolog::CL_ERR_ACQUIRED);
-        ret = client->ReleaseStory(chronicle_name, story_name);//, flags);
+        ret = client->ReleaseStory(chronicle_name, story_name); //, flags);
         assert(ret == chronolog::CL_SUCCESS);
-        ret = client->DestroyStory(chronicle_name, story_name);//, flags);
+        ret = client->DestroyStory(chronicle_name, story_name); //, flags);
         assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED);
-        ret = client->DestroyChronicle(chronicle_name);//, flags);
+        ret = client->DestroyChronicle(chronicle_name); //, flags);
         assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED);
         LOG_INFO("[ClientLibMultiOpenMPTest] Thread {} destroying chronicle: {}", i, chronicle_name);
     }

--- a/test/integration/Client/client_lib_multi_pthread_test.cpp
+++ b/test/integration/Client/client_lib_multi_pthread_test.cpp
@@ -1,5 +1,9 @@
 #include <cassert>
+#include <iostream>
+#include <map>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include <cmd_arg_parse.h>
 #include <chronolog_client.h>

--- a/test/integration/Client/client_lib_multi_pthread_test.cpp
+++ b/test/integration/Client/client_lib_multi_pthread_test.cpp
@@ -19,90 +19,118 @@ struct thread_arg
     std::string client_id;
 };
 
-chronolog::Client*client;
+chronolog::Client* client;
 
-void thread_body(struct thread_arg*t)
+void thread_body(struct thread_arg* t)
 {
     LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - Starting execution.", t->tid);
     int flags = 0;
     uint64_t offset;
     int ret;
     std::string chronicle_name;
-    if(t->tid % 2 == 0) chronicle_name = "Chronicle_2";
-    else chronicle_name = "Chronicle_1";
+    if(t->tid % 2 == 0)
+        chronicle_name = "Chronicle_2";
+    else
+        chronicle_name = "Chronicle_1";
 
     LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - Creating Chronicle: {}", t->tid, chronicle_name);
-    std::map <std::string, std::string> chronicle_attrs;
+    std::map<std::string, std::string> chronicle_attrs;
     chronicle_attrs.emplace("Priority", "High");
     chronicle_attrs.emplace("IndexGranularity", "Millisecond");
     chronicle_attrs.emplace("TieringPolicy", "Hot");
     ret = client->CreateChronicle(chronicle_name, chronicle_attrs, flags);
-    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - CreateChronicle result for {}: {}", t->tid, chronicle_name
-             , chronolog::to_string_client(ret));
+    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - CreateChronicle result for {}: {}",
+             t->tid,
+             chronicle_name,
+             chronolog::to_string_client(ret));
 
     flags = 1;
     std::string story_name = gen_random(STORY_NAME_LEN);
     LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - Generating Story: {}", t->tid, story_name);
 
-    std::map <std::string, std::string> story_attrs;
+    std::map<std::string, std::string> story_attrs;
     story_attrs.emplace("Priority", "High");
     story_attrs.emplace("IndexGranularity", "Millisecond");
     story_attrs.emplace("TieringPolicy", "Hot");
     flags = 2;
     auto acquire_ret = client->AcquireStory(chronicle_name, story_name, story_attrs, flags);
-    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - AcquireStory result for {}:{} - {}", t->tid, chronicle_name
-             , story_name, chronolog::to_string_client(acquire_ret.first));
+    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - AcquireStory result for {}:{} - {}",
+             t->tid,
+             chronicle_name,
+             story_name,
+             chronolog::to_string_client(acquire_ret.first));
 
     assert(acquire_ret.first == chronolog::CL_SUCCESS || acquire_ret.first == chronolog::CL_ERR_NOT_EXIST);
-    ret = client->DestroyStory(chronicle_name, story_name);//, flags);
-    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - DestroyStory result for {}:{} - {}", t->tid, chronicle_name
-             , story_name, chronolog::to_string_client(ret));
+    ret = client->DestroyStory(chronicle_name, story_name); //, flags);
+    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - DestroyStory result for {}:{} - {}",
+             t->tid,
+             chronicle_name,
+             story_name,
+             chronolog::to_string_client(ret));
 
     assert(ret == chronolog::CL_ERR_ACQUIRED || ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST);
     ret = client->Disconnect(); //t->client_id, flags);
-    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - Disconnect result: {}", t->tid, chronolog::to_string_client(ret));
+    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - Disconnect result: {}",
+             t->tid,
+             chronolog::to_string_client(ret));
 
     assert(ret == chronolog::CL_ERR_ACQUIRED || ret == chronolog::CL_SUCCESS);
-    ret = client->ReleaseStory(chronicle_name, story_name);//, flags);
-    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - ReleaseStory result for {}:{} - {}", t->tid, chronicle_name
-             , story_name, chronolog::to_string_client(ret));
+    ret = client->ReleaseStory(chronicle_name, story_name); //, flags);
+    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - ReleaseStory result for {}:{} - {}",
+             t->tid,
+             chronicle_name,
+             story_name,
+             chronolog::to_string_client(ret));
 
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NO_CONNECTION);
-    ret = client->DestroyStory(chronicle_name, story_name);//, flags);
-    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - DestroyStory result for {}:{} - {}", t->tid, chronicle_name
-             , story_name, chronolog::to_string_client(ret));
+    ret = client->DestroyStory(chronicle_name, story_name); //, flags);
+    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - DestroyStory result for {}:{} - {}",
+             t->tid,
+             chronicle_name,
+             story_name,
+             chronolog::to_string_client(ret));
 
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED ||
            ret == chronolog::CL_ERR_NO_CONNECTION);
 
-    ret = client->DestroyChronicle(chronicle_name);//, flags);
+    ret = client->DestroyChronicle(chronicle_name); //, flags);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED ||
            ret == chronolog::CL_ERR_NO_CONNECTION);
-    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - DestroyChronicle result for {}: {}", t->tid, chronicle_name
-             , chronolog::to_string_client(ret));
+    LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - DestroyChronicle result for {}: {}",
+             t->tid,
+             chronicle_name,
+             chronolog::to_string_client(ret));
     LOG_INFO("[ClientLibMultiPThreadTest] Thread (ID: {}) - Execution completed.", t->tid);
 }
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     int provided;
     std::string client_id = gen_random(8);
 
     int num_threads = 4;
 
-    std::vector <struct thread_arg> t_args(num_threads);
-    std::vector <std::thread> workers(num_threads);
+    std::vector<struct thread_arg> t_args(num_threads);
+    std::vector<std::thread> workers(num_threads);
 
     // Load configuration
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[ClientLibMultiPthreadTest] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[ClientLibMultiPthreadTest] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[ClientLibMultiPthreadTest] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
+        else
+        {
+            std::cout << "[ClientLibMultiPthreadTest] Configuration file loaded successfully from '" << conf_file_path
+                      << "'." << std::endl;
+        }
+    }
+    else
+    {
         std::cout << "[ClientLibMultiPthreadTest] No configuration file provided. Using default values." << std::endl;
     }
     confManager.log_configuration(std::cout);
@@ -115,7 +143,8 @@ int main(int argc, char**argv)
                                                        confManager.LOG_CONF.LOGFILESIZE,
                                                        confManager.LOG_CONF.LOGFILENUM,
                                                        confManager.LOG_CONF.FLUSHLEVEL);
-    if (result == 1) {
+    if(result == 1)
+    {
         return EXIT_FAILURE;
     }
 
@@ -130,23 +159,24 @@ int main(int argc, char**argv)
 
     client = new chronolog::Client(portalConf);
     int ret = client->Connect();
-    if (ret != chronolog::CL_SUCCESS) {
+    if(ret != chronolog::CL_SUCCESS)
+    {
         LOG_ERROR("[ClientLibMultiPThreadTest] Initial Connect failed: {}", chronolog::to_string_client(ret));
         return EXIT_FAILURE;
     }
 
     // Launch threads
-    for (int i = 0; i < num_threads; i++) {
+    for(int i = 0; i < num_threads; i++)
+    {
         t_args[i].tid = i;
         t_args[i].client_id = client_id;
         std::thread t{thread_body, &t_args[i]};
         workers[i] = std::move(t);
     }
 
-    for(int i = 0; i < num_threads; i++)
-        workers[i].join();
+    for(int i = 0; i < num_threads; i++) workers[i].join();
 
-    ret = client->Disconnect();//client_id, flags);
+    ret = client->Disconnect(); //client_id, flags);
     delete client;
 
     return 0;

--- a/test/integration/Client/client_lib_multi_storytellers.cpp
+++ b/test/integration/Client/client_lib_multi_storytellers.cpp
@@ -20,9 +20,9 @@ struct thread_arg
     std::string client_id;
 };
 
-chronolog::Client*client;
+chronolog::Client* client;
 
-void thread_body(struct thread_arg*t)
+void thread_body(struct thread_arg* t)
 {
     // Local variable declarations
     int flags = 0;
@@ -37,24 +37,29 @@ void thread_body(struct thread_arg*t)
         chronicle_name = "CHRONICLE_1";
 
     // Create attributes for the chronicle
-    std::map <std::string, std::string> chronicle_attrs;
+    std::map<std::string, std::string> chronicle_attrs;
     chronicle_attrs.emplace("Priority", "High");
     flags = 1;
 
     // Create the chronicle
     ret = client->CreateChronicle(chronicle_name, chronicle_attrs, flags);
-    LOG_DEBUG("[ClientLibMultiStorytellers] Chronicle created: tid={}, ChronicleName={}, Flags: {}", t->tid
-              , chronicle_name, flags);
+    LOG_DEBUG("[ClientLibMultiStorytellers] Chronicle created: tid={}, ChronicleName={}, Flags: {}",
+              t->tid,
+              chronicle_name,
+              flags);
 
     // Create attributes for the story
     std::string story_name = "STORY"; //gen_random(STORY_NAME_LEN);
-    std::map <std::string, std::string> story_attrs;
+    std::map<std::string, std::string> story_attrs;
     flags = 2;
 
     // Acquire the story
     auto acquire_ret = client->AcquireStory(chronicle_name, story_name, story_attrs, flags);
-    LOG_DEBUG("[ClientLibMultiStorytellers] Story acquired: tid={}, ChronicleName={}, StoryName={}, Ret: {}", t->tid
-              , chronicle_name, story_name, chronolog::to_string_client(acquire_ret.first));
+    LOG_DEBUG("[ClientLibMultiStorytellers] Story acquired: tid={}, ChronicleName={}, StoryName={}, Ret: {}",
+              t->tid,
+              chronicle_name,
+              story_name,
+              chronolog::to_string_client(acquire_ret.first));
 
     // Assertion for successful story acquisition or expected errors
     assert(acquire_ret.first == chronolog::CL_SUCCESS || acquire_ret.first == chronolog::CL_ERR_NOT_EXIST ||
@@ -73,8 +78,11 @@ void thread_body(struct thread_arg*t)
 
         // Release the story
         ret = client->ReleaseStory(chronicle_name, story_name);
-        LOG_DEBUG("[ClientLibMultiStorytellers] Story released: tid={}, ChronicleName={}, StoryName={}, Ret: {}", t->tid
-                  , chronicle_name, story_name, chronolog::to_string_client(ret));
+        LOG_DEBUG("[ClientLibMultiStorytellers] Story released: tid={}, ChronicleName={}, StoryName={}, Ret: {}",
+                  t->tid,
+                  chronicle_name,
+                  story_name,
+                  chronolog::to_string_client(ret));
 
         // Assertion for successful story release or expected errors
         assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NO_CONNECTION);
@@ -82,8 +90,11 @@ void thread_body(struct thread_arg*t)
 
     // Destroy the story
     ret = client->DestroyStory(chronicle_name, story_name);
-    LOG_DEBUG("[ClientLibMultiStorytellers] Story destroyed: tid={}, ChronicleName={}, StoryName={}, Ret: {}", t->tid
-              , chronicle_name, story_name, chronolog::to_string_client(ret));
+    LOG_DEBUG("[ClientLibMultiStorytellers] Story destroyed: tid={}, ChronicleName={}, StoryName={}, Ret: {}",
+              t->tid,
+              chronicle_name,
+              story_name,
+              chronolog::to_string_client(ret));
 
     // Assertion for successful story destruction or expected errors
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED ||
@@ -99,26 +110,34 @@ void thread_body(struct thread_arg*t)
 }
 
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     int provided;
     std::string client_id = gen_random(8);
 
     int num_threads = 4;
 
-    std::vector <struct thread_arg> t_args(num_threads);
-    std::vector <std::thread> workers(num_threads);
+    std::vector<struct thread_arg> t_args(num_threads);
+    std::vector<std::thread> workers(num_threads);
 
     // Load configuration
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[ClientLibMultiStorytellers] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[ClientLibMultiStorytellers] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[ClientLibMultiStorytellers] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
+        else
+        {
+            std::cout << "[ClientLibMultiStorytellers] Configuration file loaded successfully from '" << conf_file_path
+                      << "'." << std::endl;
+        }
+    }
+    else
+    {
         std::cout << "[ClientLibMultiStorytellers] No configuration file provided. Using default values." << std::endl;
     }
     confManager.log_configuration(std::cout);
@@ -131,7 +150,8 @@ int main(int argc, char**argv)
                                                        confManager.LOG_CONF.LOGFILESIZE,
                                                        confManager.LOG_CONF.LOGFILENUM,
                                                        confManager.LOG_CONF.FLUSHLEVEL);
-    if (result == 1) {
+    if(result == 1)
+    {
         return EXIT_FAILURE;
     }
 
@@ -163,8 +183,7 @@ int main(int argc, char**argv)
         workers[i] = std::move(t);
     }
 
-    for(int i = 0; i < num_threads; i++)
-        workers[i].join();
+    for(int i = 0; i < num_threads; i++) workers[i].join();
 
     ret = client->Disconnect();
     delete client;

--- a/test/integration/Client/client_lib_multi_storytellers.cpp
+++ b/test/integration/Client/client_lib_multi_storytellers.cpp
@@ -1,6 +1,10 @@
 #include <cassert>
-#include <thread>
 #include <chrono>
+#include <iostream>
+#include <map>
+#include <string>
+#include <thread>
+#include <vector>
 
 #include <cmd_arg_parse.h>
 #include <chronolog_client.h>

--- a/test/integration/Client/client_lib_story_reader.cpp
+++ b/test/integration/Client/client_lib_story_reader.cpp
@@ -1,6 +1,11 @@
 #include <cassert>
-#include <thread>
 #include <chrono>
+#include <iostream>
+#include <map>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
 
 #include <cmd_arg_parse.h>
 #include <chronolog_client.h>

--- a/test/integration/Client/client_lib_story_reader.cpp
+++ b/test/integration/Client/client_lib_story_reader.cpp
@@ -24,24 +24,31 @@ struct thread_arg
     uint64_t segment_end;
 };
 
-chronolog::Client*client;
+chronolog::Client* client;
 
-void writer_thread(struct thread_arg * t)
+void writer_thread(struct thread_arg* t)
 {
     LOG_INFO("[ClientLibStoryReader] Writer thread tid={} starting", t->tid);
 
     // Local variable declarations
     int flags = 1;
-    std::map <std::string, std::string> chronicle_attrs;
-    std::map <std::string, std::string> story_attrs;
+    std::map<std::string, std::string> chronicle_attrs;
+    std::map<std::string, std::string> story_attrs;
 
     // Create the chronicle
-    int ret= client->CreateChronicle(t->chronicle, chronicle_attrs, flags);
-    LOG_INFO("[ClientLibStoryReader] Chronicle created: tid={}, ChronicleName={}, Flags: {}", t->tid , t->chronicle, flags);
+    int ret = client->CreateChronicle(t->chronicle, chronicle_attrs, flags);
+    LOG_INFO("[ClientLibStoryReader] Chronicle created: tid={}, ChronicleName={}, Flags: {}",
+             t->tid,
+             t->chronicle,
+             flags);
 
     // Acquire the story
     auto acquire_ret = client->AcquireStory(t->chronicle, t->story, story_attrs, flags);
-    LOG_INFO("[ClientLibStoryReader] Writer thread tid={} acquired story {} {}, Ret: {}", t->tid , t->chronicle, t->story, acquire_ret.first);
+    LOG_INFO("[ClientLibStoryReader] Writer thread tid={} acquired story {} {}, Ret: {}",
+             t->tid,
+             t->chronicle,
+             t->story,
+             acquire_ret.first);
 
     // Assertion for successful story acquisition or expected errors
     assert(acquire_ret.first == chronolog::CL_SUCCESS || acquire_ret.first == chronolog::CL_ERR_NOT_EXIST ||
@@ -56,45 +63,59 @@ void writer_thread(struct thread_arg * t)
         {
             // Log an event to the story
             timestamp = story_handle->log_event("line " + std::to_string(i));
-            if(i== 0)
-            { t->segment_start = timestamp; }
+            if(i == 0)
+            {
+                t->segment_start = timestamp;
+            }
             t->segment_end = timestamp;
             std::this_thread::sleep_for(std::chrono::milliseconds(i % 10));
         }
     }
 
-    LOG_INFO("[ClientLibStoryReader] Writer thread tid={} finished logging messages for story {}-{} segment {}-{}", t->tid,t->chronicle,t->story, t->segment_start, t->segment_end);
+    LOG_INFO("[ClientLibStoryReader] Writer thread tid={} finished logging messages for story {}-{} segment {}-{}",
+             t->tid,
+             t->chronicle,
+             t->story,
+             t->segment_start,
+             t->segment_end);
     LOG_INFO("[ClientLibStoryReader] Writer thread tid={} exiting ", t->tid);
 }
 
 
-
-void reader_thread( int tid, struct thread_arg * t)
+void reader_thread(int tid, struct thread_arg* t)
 {
-    LOG_INFO("[ClientLibStoryReader] Reader thread tid={} starting",tid);
+    LOG_INFO("[ClientLibStoryReader] Reader thread tid={} starting", tid);
 
-    // make the reader thread sleep to allow the writer threads create the story and log some events 
+    // make the reader thread sleep to allow the writer threads create the story and log some events
     // allow the events to propagate through the keeper/grappher into ChronoLog store
-    while(t->segment_end==0)
-    { 
-        LOG_INFO("[ClientLibStoryReader] Reader thread tid={} is waiting",tid);
+    while(t->segment_end == 0)
+    {
+        LOG_INFO("[ClientLibStoryReader] Reader thread tid={} is waiting", tid);
         sleep(60);
     }
 
-    int ret = chronolog::CL_ERR_UNKNOWN;;
-    std::map <std::string, std::string> chronicle_attrs;
-    std::map <std::string, std::string> story_attrs;
+    int ret = chronolog::CL_ERR_UNKNOWN;
+    ;
+    std::map<std::string, std::string> chronicle_attrs;
+    std::map<std::string, std::string> story_attrs;
     int flags = 1;
 
     std::vector<chronolog::Event> replay_events;
     // Create the chronicle
-    ret= client->CreateChronicle(t->chronicle, chronicle_attrs, flags);
-    LOG_INFO("[ClientLibStoryReader] Chronicle created: tid={}, ChronicleName={}, Flags: {}", t->tid , t->chronicle, flags);
+    ret = client->CreateChronicle(t->chronicle, chronicle_attrs, flags);
+    LOG_INFO("[ClientLibStoryReader] Chronicle created: tid={}, ChronicleName={}, Flags: {}",
+             t->tid,
+             t->chronicle,
+             flags);
 
 
     // Acquire the story
     auto acquire_ret = client->AcquireStory(t->chronicle, t->story, story_attrs, flags);
-    LOG_INFO("[ClientLibStoryReader] Reader thread tid={} acquired story: {} {}, Ret: {}", tid , t->chronicle, t->story, acquire_ret.first);
+    LOG_INFO("[ClientLibStoryReader] Reader thread tid={} acquired story: {} {}, Ret: {}",
+             tid,
+             t->chronicle,
+             t->story,
+             acquire_ret.first);
 
     // Assertion for successful story acquisition or expected errors
     assert(acquire_ret.first == chronolog::CL_SUCCESS || acquire_ret.first == chronolog::CL_ERR_NOT_EXIST ||
@@ -104,52 +125,74 @@ void reader_thread( int tid, struct thread_arg * t)
     {
         auto story_handle = acquire_ret.second;
 
-        LOG_INFO("[ClientLibStoryReader] Reader thread tid={} sending playback_request for story: {} {} segment{}-{}", tid , t->chronicle, t->story, t->segment_start, t->segment_end);
+        LOG_INFO("[ClientLibStoryReader] Reader thread tid={} sending playback_request for story: {} {} segment{}-{}",
+                 tid,
+                 t->chronicle,
+                 t->story,
+                 t->segment_start,
+                 t->segment_end);
 
-        ret = client->ReplayStory(t->chronicle, t->story,t->segment_start, (t->segment_end), replay_events);
+        ret = client->ReplayStory(t->chronicle, t->story, t->segment_start, (t->segment_end), replay_events);
 
         if(ret == chronolog::CL_SUCCESS)
-        {   
-        
-            LOG_INFO("[ClientLibStoryReader] Reader thread tid={} completed replay story{}-{}  event_series has {} events",
-                         tid , t->chronicle, t->story, replay_events.size());
-        
-            for( auto event: replay_events)
-            {
-                LOG_INFO("[ClientLibStoryReader] replay event{}", event.to_string());
-            }
-        }
-        else 
         {
-            LOG_INFO("[ClientLibStoryReader] Reader thread tid={} failed to replay story: {}-{}, Return_code: {}", tid , t->chronicle, t->story, ret);
+
+            LOG_INFO("[ClientLibStoryReader] Reader thread tid={} completed replay story{}-{}  event_series has {} "
+                     "events",
+                     tid,
+                     t->chronicle,
+                     t->story,
+                     replay_events.size());
+
+            for(auto event: replay_events) { LOG_INFO("[ClientLibStoryReader] replay event{}", event.to_string()); }
+        }
+        else
+        {
+            LOG_INFO("[ClientLibStoryReader] Reader thread tid={} failed to replay story: {}-{}, Return_code: {}",
+                     tid,
+                     t->chronicle,
+                     t->story,
+                     ret);
         }
 
-        
-        
+
         // Release the story
         ret = client->ReleaseStory(t->chronicle, t->story);
-        LOG_INFO("[ClientLibStoryReader] Reader thread tid={} released story: {} {}, Ret: {}", tid , t->chronicle, t->story, ret);
+        LOG_INFO("[ClientLibStoryReader] Reader thread tid={} released story: {} {}, Ret: {}",
+                 tid,
+                 t->chronicle,
+                 t->story,
+                 ret);
 
         // Assertion for successful story release or expected errors
-        assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NO_CONNECTION || ret == chronolog::CL_ERR_NOT_ACQUIRED);
+        assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NO_CONNECTION ||
+               ret == chronolog::CL_ERR_NOT_ACQUIRED);
     }
 
     LOG_INFO("[ClientLibStoryReader] Reader thread tid={} exiting", tid);
 }
 
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     // Load configuration
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[ClientLibStoryReader] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[ClientLibStoryReader] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[ClientLibStoryReader] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
+        else
+        {
+            std::cout << "[ClientLibStoryReader] Configuration file loaded successfully from '" << conf_file_path
+                      << "'." << std::endl;
+        }
+    }
+    else
+    {
         std::cout << "[ClientLibStoryReader] No configuration file provided. Using default values." << std::endl;
     }
     confManager.log_configuration(std::cout);
@@ -162,7 +205,8 @@ int main(int argc, char**argv)
                                                        confManager.LOG_CONF.LOGFILESIZE,
                                                        confManager.LOG_CONF.LOGFILENUM,
                                                        confManager.LOG_CONF.FLUSHLEVEL);
-    if (result == 1) {
+    if(result == 1)
+    {
         return EXIT_FAILURE;
     }
 
@@ -182,10 +226,14 @@ int main(int argc, char**argv)
 
     bool run_hybrid_test = false;
 
-    if((argc==1) || (argc >1 && argv[1][0] == '1'))
-    { run_hybrid_test = false; }
-    else if(argc > 1 && argv[1][0] =='2')
-    { run_hybrid_test = true; }
+    if((argc == 1) || (argc > 1 && argv[1][0] == '1'))
+    {
+        run_hybrid_test = false;
+    }
+    else if(argc > 1 && argv[1][0] == '2')
+    {
+        run_hybrid_test = true;
+    }
 
     LOG_INFO("[ClientLibStoryReader] Running...");
 
@@ -204,52 +252,59 @@ int main(int argc, char**argv)
     std::string story_name("STORY");
 
 
-// simple reader test for the case when we do know that HDF5 archive contains the story segment for the time range we'd like to read
+    // simple reader test for the case when we do know that HDF5 archive contains the story segment for the time range we'd like to read
 
     LOG_INFO("[ClientLibStoryReader] Starting simple reader test for story: {}-{}", chronicle_name, story_name);
-    
-    struct thread_arg segment_arg{0, chronicle_name,story_name,1746486900000000000,1746486930000000000};
 
-    reader_thread(0, & segment_arg); 
+    struct thread_arg segment_arg
+    {
+        0, chronicle_name, story_name, 1746486900000000000, 1746486930000000000
+    };
+
+    reader_thread(0, &segment_arg);
 
     LOG_INFO("[ClientLibStoryReader] Finished simple reader test for story: {}-{}", chronicle_name, story_name);
 
-    if( !run_hybrid_test )
+    if(!run_hybrid_test)
     {
         return 1;
     }
 
-//// hybrid writer-reader client test with multiple threads
-    
-    LOG_INFO("[ClientLibStoryReader] Starting multithreaded writer / reader test for story: {}-{}", chronicle_name, story_name);
+    //// hybrid writer-reader client test with multiple threads
+
+    LOG_INFO("[ClientLibStoryReader] Starting multithreaded writer / reader test for story: {}-{}",
+             chronicle_name,
+             story_name);
 
     int num_threads = 2;
 
-    std::vector <struct thread_arg> t_args(num_threads);
-    std::vector <std::thread> workers(num_threads);
+    std::vector<struct thread_arg> t_args(num_threads);
+    std::vector<std::thread> workers(num_threads);
 
-   for(int i = 0; i < num_threads; ++i)
+    for(int i = 0; i < num_threads; ++i)
     {
         t_args[i].tid = i;
         t_args[i].chronicle = chronicle_name;
         t_args[i].story = story_name;
-        t_args[i].segment_start = 0; 
+        t_args[i].segment_start = 0;
         t_args[i].segment_end = 0;
 
-        // even threads are writers , odd threads are readers 
-        if( i%2 == 0)
-        {   workers[i] = std::move( std::thread(writer_thread, &t_args[i])); }
+        // even threads are writers , odd threads are readers
+        if(i % 2 == 0)
+        {
+            workers[i] = std::move(std::thread(writer_thread, &t_args[i]));
+        }
         else
-        {   workers[i] = std::move( std::thread(reader_thread, i , &t_args[i-1])); }
-        
+        {
+            workers[i] = std::move(std::thread(reader_thread, i, &t_args[i - 1]));
+        }
     }
 
-    for(int i = 0; i < num_threads; i++)
-        workers[i].join();
+    for(int i = 0; i < num_threads; i++) workers[i].join();
 
     // Destroy the story
     ret = client->DestroyStory(chronicle_name, story_name);
-    LOG_INFO("[ClientLibStoryReader] Story destroyed: {} {}, Ret: {}",  chronicle_name, story_name, ret);
+    LOG_INFO("[ClientLibStoryReader] Story destroyed: {} {}, Ret: {}", chronicle_name, story_name, ret);
 
     // Assertion for successful story destruction or expected errors
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED ||

--- a/test/integration/Client/client_lib_thread_interdependency_test.cpp
+++ b/test/integration/Client/client_lib_thread_interdependency_test.cpp
@@ -1,12 +1,14 @@
-#include <thread>
-#include <chrono>
-#include <vector>
+#include <algorithm>
 #include <bitset>
+#include <cassert>
+#include <chrono>
 #include <cstdlib>
+#include <iostream>
+#include <mutex>
 #include <random>
 #include <string>
-#include <algorithm>
-#include <iostream>
+#include <thread>
+#include <vector>
 
 #include <cmd_arg_parse.h>
 #include <chronolog_client.h>

--- a/test/integration/Client/client_lib_thread_interdependency_test.cpp
+++ b/test/integration/Client/client_lib_thread_interdependency_test.cpp
@@ -27,9 +27,9 @@ struct thread_arg
     int sleep_time;
 };
 
-chronolog::Client*client;
-std::vector <struct thread_arg> t_args;
-std::vector <int> shared_state;
+chronolog::Client* client;
+std::vector<struct thread_arg> t_args;
+std::vector<int> shared_state;
 std::mutex shared_state_mutex;
 
 enum class ThreadState
@@ -73,12 +73,15 @@ void update_chronicle_threads_state(int tid, ThreadState new_state)
 {
     for(size_t i = 0; i < shared_state.size(); ++i)
     {
-        if(t_args[i].tid == tid) continue;
+        if(t_args[i].tid == tid)
+            continue;
         if((t_args[i].chronicle_name == t_args[tid].chronicle_name))
         {
             shared_state[i] = static_cast<int>(new_state);
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- Thread {} state updated to: {}", tid, i
-                     , get_state_name(new_state));
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- Thread {} state updated to: {}",
+                     tid,
+                     i,
+                     get_state_name(new_state));
         }
     }
 }
@@ -87,43 +90,50 @@ void update_story_threads_state(int tid, ThreadState new_state)
 {
     for(size_t i = 0; i < shared_state.size(); ++i)
     {
-        if(t_args[i].tid == tid) continue;
+        if(t_args[i].tid == tid)
+            continue;
         if((t_args[i].chronicle_name == t_args[tid].chronicle_name) && (t_args[i].story_name == t_args[tid].story_name))
         {
-            shared_state[i] = static_cast<int>(new_state);  // Update state
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- Thread {} state updated to: {}", tid, i
-                     , get_state_name(new_state));
+            shared_state[i] = static_cast<int>(new_state); // Update state
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- Thread {} state updated to: {}",
+                     tid,
+                     i,
+                     get_state_name(new_state));
         }
     }
 }
 
 void check_thread_initialization(int tid, int ret)
 {
-    std::lock_guard <std::mutex> lock(shared_state_mutex);
+    std::lock_guard<std::mutex> lock(shared_state_mutex);
     if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::UNKNOWN)
     {
         shared_state[tid] = static_cast<int>(ThreadState::THREAD_INITIALIZED);
-        LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}", tid, get_state_name(
-                ThreadState::THREAD_INITIALIZED));
+        LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}",
+                 tid,
+                 get_state_name(ThreadState::THREAD_INITIALIZED));
     }
 }
 
 void check_chronicle_created(int tid, int ret)
 {
-    std::lock_guard <std::mutex> lock(shared_state_mutex);
+    std::lock_guard<std::mutex> lock(shared_state_mutex);
     if(ret == chronolog::CL_SUCCESS)
     {
         if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::THREAD_INITIALIZED)
         {
             shared_state[tid] = static_cast<int>(ThreadState::CHRONICLE_CREATED);
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}", tid, get_state_name(
-                    ThreadState::CHRONICLE_CREATED));
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}",
+                     tid,
+                     get_state_name(ThreadState::CHRONICLE_CREATED));
             update_chronicle_threads_state(tid, ThreadState::CHRONICLE_CREATED);
         }
         else
         {
-            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS when transitioning to "
-                      "CHRONICLE_CREATED state from a state different than THREAD_INITIALIZED", tid);
+            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS when "
+                      "transitioning to "
+                      "CHRONICLE_CREATED state from a state different than THREAD_INITIALIZED",
+                      tid);
         }
     }
     else if(ret == chronolog::CL_ERR_CHRONICLE_EXISTS)
@@ -131,14 +141,17 @@ void check_chronicle_created(int tid, int ret)
         if(static_cast<ThreadState>(shared_state[tid]) != ThreadState::UNKNOWN &&
            static_cast<ThreadState>(shared_state[tid]) != ThreadState::THREAD_INITIALIZED)
         {
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_CHRONICLE_EXISTS return "
-                     "value when trying to create a chronicle on a state different from UNKNOWN or THREAD_INITIALIZED"
-                     , tid);
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_CHRONICLE_EXISTS "
+                     "return "
+                     "value when trying to create a chronicle on a state different from UNKNOWN or THREAD_INITIALIZED",
+                     tid);
         }
         else
         {
-            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_CHRONICLE_EXISTS return value"
-                      " when trying to create a chronicle on the UNKNOWN or THREAD_INITIALIZED state", tid);
+            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_CHRONICLE_EXISTS "
+                      "return value"
+                      " when trying to create a chronicle on the UNKNOWN or THREAD_INITIALIZED state",
+                      tid);
         }
     }
     else
@@ -149,7 +162,7 @@ void check_chronicle_created(int tid, int ret)
 
 void check_story_acquired(int tid, int ret)
 {
-    std::lock_guard <std::mutex> lock(shared_state_mutex);
+    std::lock_guard<std::mutex> lock(shared_state_mutex);
     if(ret == chronolog::CL_SUCCESS)
     {
         if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::CHRONICLE_CREATED ||
@@ -157,20 +170,25 @@ void check_story_acquired(int tid, int ret)
            static_cast<ThreadState>(shared_state[tid]) == ThreadState::STORY_DESTROYED)
         {
             shared_state[tid] = static_cast<int>(ThreadState::STORY_ACQUIRED);
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}", tid, get_state_name(
-                    ThreadState::STORY_ACQUIRED));
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}",
+                     tid,
+                     get_state_name(ThreadState::STORY_ACQUIRED));
             update_story_threads_state(tid, ThreadState::STORY_ACQUIRED);
         }
         else if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::STORY_ACQUIRED)
         {
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS return value when trying"
-                     " to acquire a Story on a STORY_ACQUIRED", tid);
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS return value "
+                     "when trying"
+                     " to acquire a Story on a STORY_ACQUIRED",
+                     tid);
         }
         else
         {
-            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS return value when trying "
+            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS return value "
+                      "when trying "
                       "to acquire a story on a state different than CHRONICLE_CREATED, STORY_RELEASED, STORY_DESTROYED "
-                      "or STORY_ACQUIRED", tid);
+                      "or STORY_ACQUIRED",
+                      tid);
         }
     }
     else if(ret == chronolog::CL_ERR_NOT_EXIST)
@@ -178,13 +196,17 @@ void check_story_acquired(int tid, int ret)
         if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::THREAD_INITIALIZED ||
            static_cast<ThreadState>(shared_state[tid]) == ThreadState::CHRONICLE_DESTROYED)
         {
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return value when "
-                     "trying to acquire a Story on a THREAD_INITIALIZED or CHRONICLE_DESTROYED", tid);
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return "
+                     "value when "
+                     "trying to acquire a Story on a THREAD_INITIALIZED or CHRONICLE_DESTROYED",
+                     tid);
         }
         else
         {
-            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return value when "
-                      "trying to acquire a story on the THREAD_INITIALIZED or CHRONICLE_DESTROYED state", tid);
+            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return "
+                      "value when "
+                      "trying to acquire a story on the THREAD_INITIALIZED or CHRONICLE_DESTROYED state",
+                      tid);
         }
     }
     else
@@ -195,20 +217,23 @@ void check_story_acquired(int tid, int ret)
 
 void check_story_released(int tid, int ret)
 {
-    std::lock_guard <std::mutex> lock(shared_state_mutex);
+    std::lock_guard<std::mutex> lock(shared_state_mutex);
     if(ret == chronolog::CL_SUCCESS)
     {
         if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::STORY_ACQUIRED)
         {
             shared_state[tid] = static_cast<int>(ThreadState::STORY_RELEASED);
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}", tid, get_state_name(
-                    ThreadState::STORY_RELEASED));
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}",
+                     tid,
+                     get_state_name(ThreadState::STORY_RELEASED));
             update_story_threads_state(tid, ThreadState::STORY_RELEASED);
         }
         else
         {
-            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS return value when "
-                      "trying to release a story on the a STORY_RELEASED state", tid);
+            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS return value "
+                      "when "
+                      "trying to release a story on the a STORY_RELEASED state",
+                      tid);
         }
     }
     else if(ret == chronolog::CL_ERR_NOT_ACQUIRED)
@@ -217,15 +242,18 @@ void check_story_released(int tid, int ret)
            static_cast<ThreadState>(shared_state[tid]) == ThreadState::STORY_DESTROYED ||
            static_cast<ThreadState>(shared_state[tid]) == ThreadState::CHRONICLE_DESTROYED)
         {
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_ACQUIRED return value "
-                     "when trying to release a Story on a STORY_RELEASED,STORY_DESTROYED or CHRONICLE_DESTROYED state"
-                     , tid);
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_ACQUIRED "
+                     "return value "
+                     "when trying to release a Story on a STORY_RELEASED,STORY_DESTROYED or CHRONICLE_DESTROYED state",
+                     tid);
         }
         else
         {
-            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_ACQUIRED return value "
+            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_ACQUIRED "
+                      "return value "
                       "when trying to release a story on the a state different from STORY_RELEASED, STORY_DESTROYED or"
-                      " CHRONICLE_DESTROYED", tid);
+                      " CHRONICLE_DESTROYED",
+                      tid);
         }
     }
     else
@@ -236,34 +264,41 @@ void check_story_released(int tid, int ret)
 
 void check_story_destroyed(int tid, int ret)
 {
-    std::lock_guard <std::mutex> lock(shared_state_mutex);
+    std::lock_guard<std::mutex> lock(shared_state_mutex);
 
     if(ret == chronolog::CL_SUCCESS)
     {
         if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::STORY_RELEASED)
         {
             shared_state[tid] = static_cast<int>(ThreadState::STORY_DESTROYED);
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}", tid, get_state_name(
-                    ThreadState::STORY_DESTROYED));
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}",
+                     tid,
+                     get_state_name(ThreadState::STORY_DESTROYED));
             update_story_threads_state(tid, ThreadState::STORY_DESTROYED);
         }
         else
         {
-            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS return value when"
-                      " trying to destroy a story on a state different from STORY_RELEASED", tid);
+            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS return value "
+                      "when"
+                      " trying to destroy a story on a state different from STORY_RELEASED",
+                      tid);
         }
     }
     else if(ret == chronolog::CL_ERR_ACQUIRED)
     {
         if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::STORY_ACQUIRED)
         {
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_ACQUIRED return value when "
-                     "trying to destroy a Story on the STORY_ACQUIRED state.", tid);
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_ACQUIRED return "
+                     "value when "
+                     "trying to destroy a Story on the STORY_ACQUIRED state.",
+                     tid);
         }
         else
         {
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_ACQUIRED return value when "
-                     "trying to destroy a story on a state different from STORY_ACQUIRED state.", tid);
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_ACQUIRED return "
+                     "value when "
+                     "trying to destroy a story on a state different from STORY_ACQUIRED state.",
+                     tid);
         }
     }
     else if(ret == chronolog::CL_ERR_NOT_EXIST)
@@ -271,14 +306,18 @@ void check_story_destroyed(int tid, int ret)
         if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::STORY_DESTROYED ||
            static_cast<ThreadState>(shared_state[tid]) == ThreadState::CHRONICLE_DESTROYED)
         {
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return value when "
-                     " trying to destroy a Story on the STORY_DESTROYED or CHRONICLE_DESTROYED state.", tid);
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return "
+                     "value when "
+                     " trying to destroy a Story on the STORY_DESTROYED or CHRONICLE_DESTROYED state.",
+                     tid);
         }
         else
         {
-            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return value when "
+            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return "
+                      "value when "
                       "trying to destroy a story on a state different than STORY_DESTROYED or CHRONICLE_DESTROYED "
-                      "state.", tid);
+                      "state.",
+                      tid);
         }
     }
     else
@@ -289,48 +328,58 @@ void check_story_destroyed(int tid, int ret)
 
 void check_chronicle_destroyed(int tid, int ret)
 {
-    std::lock_guard <std::mutex> lock(shared_state_mutex);
+    std::lock_guard<std::mutex> lock(shared_state_mutex);
     if(ret == chronolog::CL_SUCCESS)
     {
         if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::STORY_RELEASED ||
            static_cast<ThreadState>(shared_state[tid]) == ThreadState::STORY_DESTROYED)
         {
             shared_state[tid] = static_cast<int>(ThreadState::CHRONICLE_DESTROYED);
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}", tid, get_state_name(
-                    ThreadState::CHRONICLE_DESTROYED));
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}",
+                     tid,
+                     get_state_name(ThreadState::CHRONICLE_DESTROYED));
             update_chronicle_threads_state(tid, ThreadState::CHRONICLE_DESTROYED);
         }
         else
         {
-            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS return value when trying "
-                      "to destroy chronicle on a state different than STORY_RELEASED", tid);
+            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_SUCCESS return value "
+                      "when trying "
+                      "to destroy chronicle on a state different than STORY_RELEASED",
+                      tid);
         }
     }
     else if(ret == chronolog::CL_ERR_ACQUIRED)
     {
         if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::STORY_ACQUIRED)
         {
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_ACQUIRED return value when "
-                     "trying to destroy chronicle on STORY_ACQUIRED state", tid);
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_ACQUIRED return "
+                     "value when "
+                     "trying to destroy chronicle on STORY_ACQUIRED state",
+                     tid);
         }
         else
         {
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_ACQUIRED return value when "
-                     "trying to destroy chronicle on a state different than STORY_ACQUIRED", tid);
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_ACQUIRED return "
+                     "value when "
+                     "trying to destroy chronicle on a state different than STORY_ACQUIRED",
+                     tid);
         }
     }
     else if(ret == chronolog::CL_ERR_NOT_EXIST)
     {
         if(static_cast<ThreadState>(shared_state[tid]) == ThreadState::CHRONICLE_DESTROYED)
         {
-            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return value when "
-                     "trying to destroy chronicle on a state STORY_DESTROYED or CHRONICLE_DESTROYED", tid);
+            LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return "
+                     "value when "
+                     "trying to destroy chronicle on a state STORY_DESTROYED or CHRONICLE_DESTROYED",
+                     tid);
         }
         else
         {
-            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return value when "
-                      "trying to destroy chronicle on a state different than STORY_DESTROYED or CHRONICLE_DESTROYED"
-                      , tid);
+            LOG_ERROR("[ClientLibThreadInterdependencyTest] -Thread {}- received a chronolog::CL_ERR_NOT_EXIST return "
+                      "value when "
+                      "trying to destroy chronicle on a state different than STORY_DESTROYED or CHRONICLE_DESTROYED",
+                      tid);
         }
     }
     else
@@ -341,13 +390,14 @@ void check_chronicle_destroyed(int tid, int ret)
 
 void check_thread_finalized(int tid, int ret)
 {
-    std::lock_guard <std::mutex> lock(shared_state_mutex);
+    std::lock_guard<std::mutex> lock(shared_state_mutex);
     shared_state[tid] = static_cast<int>(ThreadState::THREAD_FINALIZED);
-    LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}", tid, get_state_name(
-            ThreadState::THREAD_FINALIZED));
+    LOG_INFO("[ClientLibThreadInterdependencyTest] -Thread {}- State updated to: {}",
+             tid,
+             get_state_name(ThreadState::THREAD_FINALIZED));
 }
 
-void thread_body(struct thread_arg*t)
+void thread_body(struct thread_arg* t)
 {
     // Thread Initialized
     check_thread_initialization(t->tid, 0);
@@ -355,23 +405,29 @@ void thread_body(struct thread_arg*t)
     // Add random sleep times
     std::this_thread::sleep_for(std::chrono::seconds(t->sleep_time));
 
-    LOG_INFO("[ClientLibThreadInterdependencyTest] Thread Info: tid={}, Chronicle Name={}, Story Name={}", t->tid
-             , t->chronicle_name, t->story_name);
+    LOG_INFO("[ClientLibThreadInterdependencyTest] Thread Info: tid={}, Chronicle Name={}, Story Name={}",
+             t->tid,
+             t->chronicle_name,
+             t->story_name);
     // Chronicle Variables
-    std::map <std::string, std::string> chronicle_attrs;
+    std::map<std::string, std::string> chronicle_attrs;
     chronicle_attrs.emplace("Priority", "High");
     int flags = 1;
     // Chronicle creation
     int ret = client->CreateChronicle(t->chronicle_name, chronicle_attrs, flags);
-    LOG_INFO("[ClientLibThreadInterdependencyTest] Chronicle created: tid={}, Ret: {}", t->tid, chronolog::to_string_client(ret));
+    LOG_INFO("[ClientLibThreadInterdependencyTest] Chronicle created: tid={}, Ret: {}",
+             t->tid,
+             chronolog::to_string_client(ret));
     check_chronicle_created(t->tid, ret);
 
     // Story Variables
-    std::map <std::string, std::string> story_attrs;
+    std::map<std::string, std::string> story_attrs;
     flags = 2;
     // Acquire story
     auto acquire_ret = client->AcquireStory(t->chronicle_name, t->story_name, story_attrs, flags);
-    LOG_INFO("[ClientLibThreadInterdependencyTest] Story acquired: tid={}, Ret: {}", t->tid, chronolog::to_string_client(acquire_ret.first));
+    LOG_INFO("[ClientLibThreadInterdependencyTest] Story acquired: tid={}, Ret: {}",
+             t->tid,
+             chronolog::to_string_client(acquire_ret.first));
     check_story_acquired(t->tid, acquire_ret.first);
 
     auto story_handle = acquire_ret.second;
@@ -384,19 +440,25 @@ void thread_body(struct thread_arg*t)
 
     // Release the story
     ret = client->ReleaseStory(t->chronicle_name, t->story_name);
-    LOG_INFO("[ClientLibThreadInterdependencyTest] Story released: tid={}, Ret: {}", t->tid, chronolog::to_string_client(ret));
+    LOG_INFO("[ClientLibThreadInterdependencyTest] Story released: tid={}, Ret: {}",
+             t->tid,
+             chronolog::to_string_client(ret));
     check_story_released(t->tid, ret);
 
 
     // Destroy the story
     ret = client->DestroyStory(t->chronicle_name, t->story_name);
-    LOG_INFO("[ClientLibThreadInterdependencyTest] Story destroyed: tid={}, Ret: {}", t->tid, chronolog::to_string_client(ret));
+    LOG_INFO("[ClientLibThreadInterdependencyTest] Story destroyed: tid={}, Ret: {}",
+             t->tid,
+             chronolog::to_string_client(ret));
     check_story_destroyed(t->tid, ret);
 
 
     // Destroy the chronicle
     ret = client->DestroyChronicle(t->chronicle_name);
-    LOG_INFO("[ClientLibThreadInterdependencyTest] Chronicle destroyed: tid={}, Ret: {}", t->tid, chronolog::to_string_client(ret));
+    LOG_INFO("[ClientLibThreadInterdependencyTest] Chronicle destroyed: tid={}, Ret: {}",
+             t->tid,
+             chronolog::to_string_client(ret));
     check_chronicle_destroyed(t->tid, ret);
 
 
@@ -404,7 +466,7 @@ void thread_body(struct thread_arg*t)
     check_thread_finalized(t->tid, 0);
 }
 
-int parse_num_threads_arg(int argc, char**argv)
+int parse_num_threads_arg(int argc, char** argv)
 {
     // Check for additional arguments
     if(argc > 1)
@@ -422,7 +484,7 @@ int parse_num_threads_arg(int argc, char**argv)
                           << std::endl;
             }
         }
-        catch(const std::exception &e)
+        catch(const std::exception& e)
         {
             std::cerr << "Invalid number of threads provided. Using default: " << DEFAULT_NUM_THREADS << std::endl;
         }
@@ -430,19 +492,28 @@ int parse_num_threads_arg(int argc, char**argv)
     return DEFAULT_NUM_THREADS;
 }
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     // Load configuration
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[ClientLibThreadInterdependencyTest] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[ClientLibThreadInterdependencyTest] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[ClientLibThreadInterdependencyTest] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
-        std::cout << "[ClientLibThreadInterdependencyTest] No configuration file provided. Using default values." << std::endl;
+        else
+        {
+            std::cout << "[ClientLibThreadInterdependencyTest] Configuration file loaded successfully from '"
+                      << conf_file_path << "'." << std::endl;
+        }
+    }
+    else
+    {
+        std::cout << "[ClientLibThreadInterdependencyTest] No configuration file provided. Using default values."
+                  << std::endl;
     }
     confManager.log_configuration(std::cout);
 
@@ -454,7 +525,8 @@ int main(int argc, char**argv)
                                                        confManager.LOG_CONF.LOGFILESIZE,
                                                        confManager.LOG_CONF.LOGFILENUM,
                                                        confManager.LOG_CONF.FLUSHLEVEL);
-    if (result == 1) {
+    if(result == 1)
+    {
         return EXIT_FAILURE;
     }
 
@@ -464,7 +536,7 @@ int main(int argc, char**argv)
     portalConf.IP = confManager.PORTAL_CONF.IP;
     portalConf.PORT = confManager.PORTAL_CONF.PORT;
     portalConf.PROVIDER_ID = confManager.PORTAL_CONF.PROVIDER_ID;
-    
+
     client = new chronolog::Client(portalConf);
     int ret = client->Connect();
     if(chronolog::CL_SUCCESS != ret)
@@ -480,7 +552,7 @@ int main(int argc, char**argv)
     // Initiate test
     LOG_INFO("[ClientLibThreadInterdependencyTest] Running test with " + std::to_string(num_threads) + " threads.");
     t_args.resize(num_threads);
-    std::vector <std::thread> workers(num_threads);
+    std::vector<std::thread> workers(num_threads);
     shared_state.resize(num_threads, 0);
 
     // Randomization setup
@@ -488,14 +560,14 @@ int main(int argc, char**argv)
     std::mt19937 gen(rd());
 
     // Generate random assignments for story-to-thread
-    std::uniform_int_distribution <> story_dis(0, 3); // Range [0, 3] for 4 stories: 11, 12, 21, 22
+    std::uniform_int_distribution<> story_dis(0, 3); // Range [0, 3] for 4 stories: 11, 12, 21, 22
 
     // Generate random sleep times
     const int max_sleep_time = 10; // Define maximum sleep time in seconds
-    std::uniform_int_distribution <> sleep_dis(0, max_sleep_time);
+    std::uniform_int_distribution<> sleep_dis(0, max_sleep_time);
 
     // Chronicle and story mapping
-    const std::vector <std::string> story_mapping = {"11", "12", "21", "22"};
+    const std::vector<std::string> story_mapping = {"11", "12", "21", "22"};
 
     // Create and start the worker threads
     for(int i = 0; i < num_threads; i++)
@@ -505,14 +577,11 @@ int main(int argc, char**argv)
         t_args[i].story_name = "STORY_" + story_mapping[story_dis(gen)].substr(1, 1);
         t_args[i].sleep_time = sleep_dis(gen);
         std::thread t{thread_body, &t_args[i]}; // Start the thread
-        workers[i] = std::move(t);             // Move thread to workers vector
+        workers[i] = std::move(t);              // Move thread to workers vector
     }
 
     // Join all worker threads to wait for their completion
-    for(int i = 0; i < num_threads; i++)
-    {
-        workers[i].join();
-    }
+    for(int i = 0; i < num_threads; i++) { workers[i].join(); }
 
     LOG_INFO("[ClientLibThreadInterdependencyTest] End of the test.");
 

--- a/test/integration/Client/client_reader_to_csv.cpp
+++ b/test/integration/Client/client_reader_to_csv.cpp
@@ -26,85 +26,110 @@ struct thread_arg
     uint64_t segment_end;
 };
 
-chronolog::Client*client;
+chronolog::Client* client;
 
 namespace chl = chronolog;
 
-void reader_thread( int tid, struct thread_arg * t, std::vector<chronolog::Event> & replay_events)
+void reader_thread(int tid, struct thread_arg* t, std::vector<chronolog::Event>& replay_events)
 {
-    LOG_INFO("[ClientLibStoryReader] Reader thread tid={} starting",tid);
+    LOG_INFO("[ClientLibStoryReader] Reader thread tid={} starting", tid);
 
-    // make the reader thread sleep to allow the writer threads create the story and log some events 
+    // make the reader thread sleep to allow the writer threads create the story and log some events
     // allow the events to propagate through the keeper/grappher into ChronoLog store
-    while(t->segment_end==0)
-    { 
-        LOG_INFO("[ClientLibStoryReader] Reader thread tid={} is waiting",tid);
+    while(t->segment_end == 0)
+    {
+        LOG_INFO("[ClientLibStoryReader] Reader thread tid={} is waiting", tid);
         sleep(60);
     }
 
     int ret = chronolog::CL_ERR_UNKNOWN;
-    std::map <std::string, std::string> chronicle_attrs;
-    std::map <std::string, std::string> story_attrs;
+    std::map<std::string, std::string> chronicle_attrs;
+    std::map<std::string, std::string> story_attrs;
     int flags = 1;
 
     // std::vector<chronolog::Event> replay_events;
 
     // Create the chronicle
-    ret= client->CreateChronicle(t->chronicle, chronicle_attrs, flags);
-    LOG_INFO("[ClientLibStoryReader] Chronicle created: tid={}, ChronicleName={}, Flags: {}", t->tid , t->chronicle, flags);
+    ret = client->CreateChronicle(t->chronicle, chronicle_attrs, flags);
+    LOG_INFO("[ClientLibStoryReader] Chronicle created: tid={}, ChronicleName={}, Flags: {}",
+             t->tid,
+             t->chronicle,
+             flags);
 
 
     // Acquire the story
     auto acquire_ret = client->AcquireStory(t->chronicle, t->story, story_attrs, flags);
-    LOG_INFO("[ClientLibStoryReader] Reader thread tid={} acquired story: {} {}, Ret: {}", tid , t->chronicle, t->story, chl::to_string_client(acquire_ret.first));
+    LOG_INFO("[ClientLibStoryReader] Reader thread tid={} acquired story: {} {}, Ret: {}",
+             tid,
+             t->chronicle,
+             t->story,
+             chl::to_string_client(acquire_ret.first));
 
     if(acquire_ret.first == chronolog::CL_SUCCESS)
     {
         auto story_handle = acquire_ret.second;
 
-        LOG_INFO("[StoryReaderClient] Reader thread tid={} sending playback_request for story: {} {} segment{}-{}", tid , t->chronicle, t->story, t->segment_start, t->segment_end);
+        LOG_INFO("[StoryReaderClient] Reader thread tid={} sending playback_request for story: {} {} segment{}-{}",
+                 tid,
+                 t->chronicle,
+                 t->story,
+                 t->segment_start,
+                 t->segment_end);
 
-        ret = client->ReplayStory(t->chronicle, t->story,t->segment_start, (t->segment_end), replay_events);
+        ret = client->ReplayStory(t->chronicle, t->story, t->segment_start, (t->segment_end), replay_events);
 
         if(ret == chronolog::CL_SUCCESS)
-        {   
-        
-            LOG_INFO("[StoryReaderClient] Reader thread tid={} completed replay story{}-{}  event_series has {} events",
-                         tid , t->chronicle, t->story, replay_events.size());
-        
-            for( auto event: replay_events)
-            {
-                LOG_DEBUG("[StoryReaderClient] replay event{}", event.to_string());
-            }
-        }
-        else 
         {
-            LOG_INFO("[StoryReaderClient] Reader thread tid={} failed to replay story: {}-{}, Return_code: {}", tid , t->chronicle, t->story, chl::to_string_client(ret));
+
+            LOG_INFO("[StoryReaderClient] Reader thread tid={} completed replay story{}-{}  event_series has {} events",
+                     tid,
+                     t->chronicle,
+                     t->story,
+                     replay_events.size());
+
+            for(auto event: replay_events) { LOG_DEBUG("[StoryReaderClient] replay event{}", event.to_string()); }
+        }
+        else
+        {
+            LOG_INFO("[StoryReaderClient] Reader thread tid={} failed to replay story: {}-{}, Return_code: {}",
+                     tid,
+                     t->chronicle,
+                     t->story,
+                     chl::to_string_client(ret));
         }
 
-        
-        
+
         // Release the story
         ret = client->ReleaseStory(t->chronicle, t->story);
-        LOG_INFO("[StoryReaderClient] Reader thread tid={} released story: {} {}, Ret: {}", tid , t->chronicle, t->story, chl::to_string_client(ret));
-
+        LOG_INFO("[StoryReaderClient] Reader thread tid={} released story: {} {}, Ret: {}",
+                 tid,
+                 t->chronicle,
+                 t->story,
+                 chl::to_string_client(ret));
     }
 
     LOG_INFO("[ClientLibStoryReader] Reader thread tid={} exiting", tid);
 }
 
-int parse_command_args(int argc, char**argv, std::string & config_file, std::string & chronicle , std::string & story, int & interval, std::string & output_csv_file)
-                  //  , uint64_t start_time, uint64_t end_time)
+int parse_command_args(int argc,
+                       char** argv,
+                       std::string& config_file,
+                       std::string& chronicle,
+                       std::string& story,
+                       int& interval,
+                       std::string& output_csv_file)
+//  , uint64_t start_time, uint64_t end_time)
 {
-    int opt=0;
+    int opt = 0;
 
     // Define the long options and their corresponding short options
-    struct option long_options[] = {{"config", required_argument, 0, 'c'}
-                                    , {"chronicle", required_argument, 0, 'r'}
-                                    , {"story", required_argument, 0, 's'}
-                                    , {"interval", required_argument,0,'i'}
-                                    , {"output_file", required_argument, 0, 'f'}
-                                    , {0       , 0                , 0, 0} // Terminate the options array
+    struct option long_options[] = {
+            {"config", required_argument, 0, 'c'},
+            {"chronicle", required_argument, 0, 'r'},
+            {"story", required_argument, 0, 's'},
+            {"interval", required_argument, 0, 'i'},
+            {"output_file", required_argument, 0, 'f'},
+            {0, 0, 0, 0} // Terminate the options array
     };
 
 
@@ -120,14 +145,14 @@ int parse_command_args(int argc, char**argv, std::string & config_file, std::str
                 chronicle = std::string(optarg);
                 break;
             case 's':
-                story = std::string(optarg); 
+                story = std::string(optarg);
                 break;
             case 'i':
                 interval = std::stol(optarg);
                 break;
             case 'f':
                 output_csv_file = std::string(optarg);
-                break; 
+                break;
             default:
                 // Unknown option
                 std::cerr << "[cmd_arg_parse] Encountered an unknown option: " << static_cast<char>(opt) << std::endl;
@@ -137,7 +162,7 @@ int parse_command_args(int argc, char**argv, std::string & config_file, std::str
     return 1;
 }
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     // Load configuration
     std::string conf_file_path("./default_client_conf.json");
@@ -148,20 +173,27 @@ int main(int argc, char**argv)
 
     parse_command_args(argc, argv, conf_file_path, chronicle_name, story_name, interval_in_secs, output_csv_file_path);
 
-    std::cout<<"Using configuration parameters : conf_file_path {"<< conf_file_path
-            <<"} chronicle {"<<chronicle_name<<"} story {"<<story_name
-            <<"} output_csv_file_path {"<< output_csv_file_path 
-            <<"} interval {" << interval_in_secs<<" secs}"<<std::endl;
+    std::cout << "Using configuration parameters : conf_file_path {" << conf_file_path << "} chronicle {"
+              << chronicle_name << "} story {" << story_name << "} output_csv_file_path {" << output_csv_file_path
+              << "} interval {" << interval_in_secs << " secs}" << std::endl;
 
 
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[StoryReaderClient] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[StoryReaderClient] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[StoryReaderClient] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
+        else
+        {
+            std::cout << "[StoryReaderClient] Configuration file loaded successfully from '" << conf_file_path << "'."
+                      << std::endl;
+        }
+    }
+    else
+    {
         std::cout << "[StoryReaderClient] No configuration file provided. Using default values." << std::endl;
     }
     confManager.log_configuration(std::cout);
@@ -174,7 +206,8 @@ int main(int argc, char**argv)
                                                        confManager.LOG_CONF.LOGFILESIZE,
                                                        confManager.LOG_CONF.LOGFILENUM,
                                                        confManager.LOG_CONF.FLUSHLEVEL);
-    if (result == 1) {
+    if(result == 1)
+    {
         return EXIT_FAILURE;
     }
 
@@ -206,38 +239,48 @@ int main(int argc, char**argv)
     }
 
     auto end_point = std::chrono::high_resolution_clock::now();
-    auto start_point = end_point - std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::seconds(interval_in_secs));
+    auto start_point =
+            end_point - std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::seconds(interval_in_secs));
 
     uint64_t start_time = start_point.time_since_epoch().count();
-    uint64_t end_time= end_point.time_since_epoch().count();
+    uint64_t end_time = end_point.time_since_epoch().count();
 
     auto start_time_t = std::chrono::system_clock::to_time_t(start_point);
     auto end_time_t = std::chrono::system_clock::to_time_t(end_point);
-    
 
-    std::cout <<"Replay time range "<<start_time <<" " << std::put_time(std::localtime(&start_time_t), "%Y-%m-%d %H:%M:%S.")<<start_time%1000000000 
-            <<" - "<< end_time << " " << std::put_time(std::localtime(&end_time_t), "%Y-%m-%d %H:%M:%S.") << end_time % 1000000000
-            << std::endl;
 
-    LOG_INFO("[StoryReaderClient] ReplayStory Request for story {}-{} time range {}-{}", chronicle_name,story_name ,start_time,end_time);
+    std::cout << "Replay time range " << start_time << " "
+              << std::put_time(std::localtime(&start_time_t), "%Y-%m-%d %H:%M:%S.") << start_time % 1000000000 << " - "
+              << end_time << " " << std::put_time(std::localtime(&end_time_t), "%Y-%m-%d %H:%M:%S.")
+              << end_time % 1000000000 << std::endl;
+
+    LOG_INFO("[StoryReaderClient] ReplayStory Request for story {}-{} time range {}-{}",
+             chronicle_name,
+             story_name,
+             start_time,
+             end_time);
 
     std::vector<chronolog::Event> replay_event_series;
-    
-    struct thread_arg segment_arg{0, chronicle_name,story_name,start_time,end_time};
 
-    reader_thread(0, & segment_arg, replay_event_series); 
+    struct thread_arg segment_arg
+    {
+        0, chronicle_name, story_name, start_time, end_time
+    };
+
+    reader_thread(0, &segment_arg, replay_event_series);
 
     LOG_INFO("[StoryReaderClient] Finished reader test for story: {}-{}", chronicle_name, story_name);
     LOG_INFO("[StoryReaderClient] Replay event series has {} events", replay_event_series.size());
-    
+
     std::ofstream output_csv_fstream;
 
-    output_csv_fstream.open(output_csv_file_path, std::ofstream::out|std::ofstream::app);
+    output_csv_fstream.open(output_csv_file_path, std::ofstream::out | std::ofstream::app);
     for(const auto& event: replay_event_series)
     {
-        time_t event_time_t = event.time()/1000000000;
-        output_csv_fstream << std::put_time(std::localtime(&event_time_t), "%Y-%m-%d %H:%M:%S.")<<event.time()%1000000000 <<','
-            << event.client_id() << ',' << event.index() << ',' << event.log_record() << std::endl;
+        time_t event_time_t = event.time() / 1000000000;
+        output_csv_fstream << std::put_time(std::localtime(&event_time_t), "%Y-%m-%d %H:%M:%S.")
+                           << event.time() % 1000000000 << ',' << event.client_id() << ',' << event.index() << ','
+                           << event.log_record() << std::endl;
     }
     output_csv_fstream.close();
 

--- a/test/integration/Client/client_reader_to_csv.cpp
+++ b/test/integration/Client/client_reader_to_csv.cpp
@@ -1,10 +1,14 @@
 #include <cassert>
-#include <thread>
 #include <chrono>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <fstream>
+#include <map>
 #include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
 #include <getopt.h>
 
 #include <chronolog_client.h>

--- a/test/integration/Keeper-Grapher/extract_test.cpp
+++ b/test/integration/Keeper-Grapher/extract_test.cpp
@@ -1,17 +1,17 @@
 // System headers
-#include <cstdlib>         // for exit(), EXIT_FAILURE
-#include <stdexcept>       // for std::runtime_error
+#include <cstdlib>   // for exit(), EXIT_FAILURE
+#include <stdexcept> // for std::runtime_error
 
 // Standard library headers
-#include <string>          // for std::string, std::to_string()
-#include <vector>          // for std::vector
-#include <deque>           // for std::deque
-#include <mutex>           // for std::mutex, std::lock_guard
-#include <chrono>          // for std::chrono::high_resolution_clock, std::chrono::duration_cast
-#include <sstream>         // for std::stringstream, std::ostringstream
-#include <iostream>        // for std::ios
-#include <random>          // for std::random_device, std::mt19937, std::uniform_int_distribution
-#include <utility>         // for std::move, std::pair
+#include <string>   // for std::string, std::to_string()
+#include <vector>   // for std::vector
+#include <deque>    // for std::deque
+#include <mutex>    // for std::mutex, std::lock_guard
+#include <chrono>   // for std::chrono::high_resolution_clock, std::chrono::duration_cast
+#include <sstream>  // for std::stringstream, std::ostringstream
+#include <iostream> // for std::ios
+#include <random>   // for std::random_device, std::mt19937, std::uniform_int_distribution
+#include <utility>  // for std::move, std::pair
 
 // Third-party headers
 #include <thallium.hpp>
@@ -30,27 +30,27 @@ namespace tl = thallium;
 #define MAX_BULK_MEM_SIZE (1024 * 1024 * 4)
 
 std::string rpc_name_g = "record_story_chunk";
-tl::engine*tl_engine_g;
+tl::engine* tl_engine_g;
 tl::remote_procedure bulk_put_g;
 tl::provider_handle service_ph_g;
-std::deque <chronolog::StoryChunk*> story_chunk_queue_g;
+std::deque<chronolog::StoryChunk*> story_chunk_queue_g;
 std::mutex story_chunk_queue_mutex_g;
 
-chronolog::StoryChunk*generateRandomStoryChunk()
+chronolog::StoryChunk* generateRandomStoryChunk()
 {
     std::random_device rd;
     std::mt19937 gen(rd());
-    std::uniform_int_distribution <> dis(1, 100);
+    std::uniform_int_distribution<> dis(1, 100);
     std::string chronicle_name = "CHRONICLE_" + std::to_string(dis(gen));
     std::string story_name = "STORY_" + std::to_string(dis(gen));
     uint64_t client_id = dis(gen);
     uint64_t story_id = dis(gen);
     uint64_t start_time = dis(gen) * 4;
     uint64_t end_time = start_time + NUM_EVENTS * 128;
-//    std::string log_event_str_base = "FFFFFFFFFFFFFFFFFFFFFF" + std::to_string(story_id); // for #events=10
+    //    std::string log_event_str_base = "FFFFFFFFFFFFFFFFFFFFFF" + std::to_string(story_id); // for #events=10
     std::string log_event_str_base = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" + std::to_string(story_id); // for #events=100
-//    std::string log_event_str_base = "FFFFFFFFFF = " + std::to_string(story_id); // for #events=1000
-    auto*story_chunk = new chronolog::StoryChunk(chronicle_name, story_name, story_id, start_time, end_time);
+    //    std::string log_event_str_base = "FFFFFFFFFF = " + std::to_string(story_id); // for #events=1000
+    auto* story_chunk = new chronolog::StoryChunk(chronicle_name, story_name, story_id, start_time, end_time);
     for(int i = 0; i < NUM_EVENTS; ++i)
     {
         //chronolog::EventSequence event_sequence = chronolog::EventSequence(start_time, client_id, i);
@@ -60,17 +60,17 @@ chronolog::StoryChunk*generateRandomStoryChunk()
         event.eventTime = start_time + i * 2;
         event.eventIndex = i;
         // for #events=10
-//        event.logRecord =
-//                log_event_str_base + ", AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSTTUUVVWWXXYYZZ" + std::to_string(i);
-//        event.logRecord += event.logRecord;
-//        event.logRecord += event.logRecord;
-//        event.logRecord += event.logRecord;
-//        event.logRecord += event.logRecord;
-//        event.logRecord += event.logRecord;
-//        event.logRecord += event.logRecord;
-//        event.logRecord += event.logRecord;
-//        event.logRecord += log_event_str_base + ", AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSTTUUVVWW" + std::to_string(i);
-//        event.logRecord += log_event_str_base + ", AABBCCDDEEFFGGHHIIJJKKLLM" + std::to_string(i);
+        //        event.logRecord =
+        //                log_event_str_base + ", AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSTTUUVVWWXXYYZZ" + std::to_string(i);
+        //        event.logRecord += event.logRecord;
+        //        event.logRecord += event.logRecord;
+        //        event.logRecord += event.logRecord;
+        //        event.logRecord += event.logRecord;
+        //        event.logRecord += event.logRecord;
+        //        event.logRecord += event.logRecord;
+        //        event.logRecord += event.logRecord;
+        //        event.logRecord += log_event_str_base + ", AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSTTUUVVWW" + std::to_string(i);
+        //        event.logRecord += log_event_str_base + ", AABBCCDDEEFFGGHHIIJJKKLLM" + std::to_string(i);
         // for #events=100
         event.logRecord =
                 log_event_str_base + ", AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSTTUUVVWWXXYYZZ1" + std::to_string(i);
@@ -84,14 +84,14 @@ chronolog::StoryChunk*generateRandomStoryChunk()
         event.logRecord +=
                 log_event_str_base + ", AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSTTUUVVWWXXYYZZ" + std::to_string(i);
         // for #events=1000
-//        event.logRecord = log_event_str_base + ", AABBCCDDEEFFGGHHIIJJKKLLMMNN = " + std::to_string(i);
+        //        event.logRecord = log_event_str_base + ", AABBCCDDEEFFGGHHIIJJKKLLMMNN = " + std::to_string(i);
         story_chunk->insertEvent(event);
     }
 
     return story_chunk;
 }
 
-size_t serializeWithCereal(chronolog::StoryChunk*story_chunk, std::stringstream &ss)
+size_t serializeWithCereal(chronolog::StoryChunk* story_chunk, std::stringstream& ss)
 {
     cereal::BinaryOutputArchive oarchive(ss);
     oarchive(*story_chunk);
@@ -108,62 +108,70 @@ void standaloneExtraction()
     while(!story_chunk_queue_g.empty())
     {
         // get StoryChunk
-        std::lock_guard <std::mutex> lock(story_chunk_queue_mutex_g);
+        std::lock_guard<std::mutex> lock(story_chunk_queue_mutex_g);
         if(story_chunk_queue_g.empty())
         {
             LOG_INFO("[standalone_extract_test] T{}: StoryChunk queue is empty. Exiting ...", tid);
             return;
         }
-        chronolog::StoryChunk*story_chunk = story_chunk_queue_g.front();
+        chronolog::StoryChunk* story_chunk = story_chunk_queue_g.front();
         story_chunk_queue_g.pop_front();
-        LOG_DEBUG("[standalone_extract_test] T{}: Extracting a story chunk with StoryID: {}, StartTime: {} ...", tid
-                  , story_chunk->getStoryId(), story_chunk->getStartTime());
+        LOG_DEBUG("[standalone_extract_test] T{}: Extracting a story chunk with StoryID: {}, StartTime: {} ...",
+                  tid,
+                  story_chunk->getStoryId(),
+                  story_chunk->getStartTime());
 
         // serialize StoryChunk
         start = std::chrono::high_resolution_clock::now();
         size_t serialized_story_chunk_size;
-        char *serialized_buf = new char[MAX_BULK_MEM_SIZE];
+        char* serialized_buf = new char[MAX_BULK_MEM_SIZE];
         std::ostringstream oss(std::ios::binary);
         oss.rdbuf()->pubsetbuf(serialized_buf, MAX_BULK_MEM_SIZE);
         cereal::BinaryOutputArchive oarchive(oss);
         oarchive(*story_chunk);
         serialized_story_chunk_size = oss.tellp();
         end = std::chrono::high_resolution_clock::now();
-//        for(auto i = 0; i < serialized_story_chunk_size; ++i)
-//        {
-//            std::cout << serialized_buf[i] << " ";
-//        }
-//        std::cout << std::endl;
+        //        for(auto i = 0; i < serialized_story_chunk_size; ++i)
+        //        {
+        //            std::cout << serialized_buf[i] << " ";
+        //        }
+        //        std::cout << std::endl;
         size_t story_chunk_size = sizeof(uint64_t) * 5; // for five uint64_t members in StoryChunk
         story_chunk_size += story_chunk->getChronicleName().size();
         story_chunk_size += story_chunk->getStoryName().size();
-        for(const auto &iter: *story_chunk)
+        for(const auto& iter: *story_chunk)
         {
             story_chunk_size += sizeof(iter.first) + sizeof(iter.second.storyId) + sizeof(iter.second.eventTime) +
                                 sizeof(iter.second.clientId) + sizeof(iter.second.eventIndex) +
                                 iter.second.logRecord.size();
         }
         LOG_INFO("[standalone_extract_test] T{}: StoryChunk size before serialization: {}", tid, story_chunk_size);
-        LOG_INFO("[standalone_extract_test] T{}: StoryChunk size after serialization: {}", tid
-                 , serialized_story_chunk_size);
-        LOG_INFO("[standalone_extract_test] T{}: Serialization took {} us", tid,
-                std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0);
+        LOG_INFO("[standalone_extract_test] T{}: StoryChunk size after serialization: {}",
+                 tid,
+                 serialized_story_chunk_size);
+        LOG_INFO("[standalone_extract_test] T{}: Serialization took {} us",
+                 tid,
+                 std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count() / 1000.0);
 
         // prepare memory segments
-        std::vector <std::pair <void*, std::size_t>> segments(1);
+        std::vector<std::pair<void*, std::size_t>> segments(1);
         segments[0].first = (void*)(serialized_buf);
         segments[0].second = serialized_story_chunk_size + 1;
         tl::bulk tl_bulk = tl_engine_g->expose(segments, tl::bulk_mode::read_only);
 
         // call RPC
-        LOG_DEBUG("[standalone_extract_test] T{}: Calling RPC on Grapher with serialized story chunk size: {} ...", tid
-                  , tl_bulk.size());
+        LOG_DEBUG("[standalone_extract_test] T{}: Calling RPC on Grapher with serialized story chunk size: {} ...",
+                  tid,
+                  tl_bulk.size());
         start = std::chrono::high_resolution_clock::now();
         result = bulk_put_g.on(service_ph_g)(tl_bulk);
         end = std::chrono::high_resolution_clock::now();
-        LOG_DEBUG("[standalone_extract_test] T{}: RPC call on Grapher returned with result: {}", tid, chronolog::to_string_client(result));
-        LOG_INFO("[standalone_extract_test] T{}: RPC call on Grapher took {} us", tid,
-                std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0);
+        LOG_DEBUG("[standalone_extract_test] T{}: RPC call on Grapher returned with result: {}",
+                  tid,
+                  chronolog::to_string_client(result));
+        LOG_INFO("[standalone_extract_test] T{}: RPC call on Grapher took {} us",
+                 tid,
+                 std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count() / 1000.0);
 
         // result check
         if(result == serialized_story_chunk_size + 1)
@@ -172,8 +180,9 @@ void standaloneExtraction()
         }
         else
         {
-            LOG_ERROR("[standalone_extract_test] T{}: Failed to drain a story chunk to Grapher, Error Code: {}", tid
-                      , chronolog::to_string_client(result));
+            LOG_ERROR("[standalone_extract_test] T{}: Failed to drain a story chunk to Grapher, Error Code: {}",
+                      tid,
+                      chronolog::to_string_client(result));
         }
 
         // release memory
@@ -182,17 +191,18 @@ void standaloneExtraction()
     LOG_DEBUG("[standalone_extract_test] T{}: Exiting ...", tid);
 }
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     std::string conf_file_path;
     conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ConfigurationManager confManager(conf_file_path);
-    int result = chronolog::chrono_monitor::initialize("console", confManager.KEEPER_CONF.LOG_CONF.LOGFILE
-                                                       , confManager.KEEPER_CONF.LOG_CONF.LOGLEVEL
-                                                       , confManager.KEEPER_CONF.LOG_CONF.LOGNAME
-                                                       , confManager.KEEPER_CONF.LOG_CONF.LOGFILESIZE
-                                                       , confManager.KEEPER_CONF.LOG_CONF.LOGFILENUM
-                                                       , confManager.KEEPER_CONF.LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize("console",
+                                                       confManager.KEEPER_CONF.LOG_CONF.LOGFILE,
+                                                       confManager.KEEPER_CONF.LOG_CONF.LOGLEVEL,
+                                                       confManager.KEEPER_CONF.LOG_CONF.LOGNAME,
+                                                       confManager.KEEPER_CONF.LOG_CONF.LOGFILESIZE,
+                                                       confManager.KEEPER_CONF.LOG_CONF.LOGFILENUM,
+                                                       confManager.KEEPER_CONF.LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
@@ -200,7 +210,7 @@ int main(int argc, char**argv)
 
     for(int i = 0; i < NUM_STORY_CHUNKS; ++i)
     {
-        chronolog::StoryChunk*story_chunk = generateRandomStoryChunk();
+        chronolog::StoryChunk* story_chunk = generateRandomStoryChunk();
         story_chunk_queue_g.push_back(story_chunk);
     }
 
@@ -221,11 +231,14 @@ int main(int argc, char**argv)
 
     // get provider handle
     std::string KEEPER_GRAPHER_NA_STRING =
-            KEEPER_GRAPHER_PROTOCOL + "://" + confManager.KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.IP +
-            ":" + std::to_string(confManager.KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.BASE_PORT);
+            KEEPER_GRAPHER_PROTOCOL + "://" + confManager.KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.IP + ":" +
+            std::to_string(confManager.KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.BASE_PORT);
     uint16_t extraction_provider_id = confManager.KEEPER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.SERVICE_PROVIDER_ID;
-    LOG_DEBUG("[extract_test_main] T{}: Looking up {} at: {} with provider id {} ...", tid, rpc_name_g
-              , KEEPER_GRAPHER_NA_STRING, extraction_provider_id);
+    LOG_DEBUG("[extract_test_main] T{}: Looking up {} at: {} with provider id {} ...",
+              tid,
+              rpc_name_g,
+              KEEPER_GRAPHER_NA_STRING,
+              extraction_provider_id);
     service_ph_g = tl::provider_handle(tl_engine_g->lookup(KEEPER_GRAPHER_NA_STRING), extraction_provider_id);
     if(service_ph_g.is_null())
     {
@@ -236,18 +249,18 @@ int main(int argc, char**argv)
 
     // create a thread to call RPC
     tl::abt scope;
-    std::vector <tl::managed <tl::xstream>> extraction_streams;
-    tl::managed <tl::pool> tl_pool = tl::pool::create(tl::pool::access::spmc, tl::pool::kind::fifo_wait);
+    std::vector<tl::managed<tl::xstream>> extraction_streams;
+    tl::managed<tl::pool> tl_pool = tl::pool::create(tl::pool::access::spmc, tl::pool::kind::fifo_wait);
     for(int i = 0; i < NUM_THREADS; i++)
     {
-        tl::managed <tl::xstream> es = tl::xstream::create(tl::scheduler::predef::basic_wait, *tl_pool);
+        tl::managed<tl::xstream> es = tl::xstream::create(tl::scheduler::predef::basic_wait, *tl_pool);
         extraction_streams.push_back(std::move(es));
     }
-    std::vector <tl::managed <tl::thread>> extraction_threads;
+    std::vector<tl::managed<tl::thread>> extraction_threads;
     for(int i = 0; i < NUM_THREADS; ++i)
     {
-        tl::managed <tl::thread> th = extraction_streams[i % extraction_streams.size()]->make_thread([]()
-                                                                                                     { standaloneExtraction(); });
+        tl::managed<tl::thread> th =
+                extraction_streams[i % extraction_streams.size()]->make_thread([]() { standaloneExtraction(); });
         extraction_threads.push_back(std::move(th));
         LOG_DEBUG("[extract_test_main] T{}: Extraction thread {} created.", tid, i);
     }
@@ -257,23 +270,14 @@ int main(int argc, char**argv)
     LOG_DEBUG("[extract_test_main] T{}: Engine has been successfully finalized.", tid);
 
     LOG_INFO("[extract_test_main] T{}: Waiting for extraction threads to shut down ...", tid);
-    for(auto &eth: extraction_threads)
-    {
-        eth->join();
-    }
+    for(auto& eth: extraction_threads) { eth->join(); }
     LOG_DEBUG("[extract_test_main] T{}: Extraction threads successfully shut down.");
 
     LOG_DEBUG("[extract_test_main] T{}: Waiting for streams to close ...", tid);
-    for(auto &es: extraction_streams)
-    {
-        es->join();
-    }
+    for(auto& es: extraction_streams) { es->join(); }
     LOG_DEBUG("[extract_test_main] T{}: Streams have been successfully closed.");
 
-    for(auto &story_chunk: story_chunk_queue_g)
-    {
-        delete story_chunk;
-    }
+    for(auto& story_chunk: story_chunk_queue_g) { delete story_chunk; }
     delete tl_engine_g;
     return 0;
 }

--- a/test/integration/Keeper-Grapher/extract_test.cpp
+++ b/test/integration/Keeper-Grapher/extract_test.cpp
@@ -1,8 +1,23 @@
+// System headers
+#include <cstdlib>         // for exit(), EXIT_FAILURE
+#include <stdexcept>       // for std::runtime_error
+
+// Standard library headers
+#include <string>          // for std::string, std::to_string()
+#include <vector>          // for std::vector
+#include <deque>           // for std::deque
+#include <mutex>           // for std::mutex, std::lock_guard
+#include <chrono>          // for std::chrono::high_resolution_clock, std::chrono::duration_cast
+#include <sstream>         // for std::stringstream, std::ostringstream
+#include <iostream>        // for std::ios
+#include <random>          // for std::random_device, std::mt19937, std::uniform_int_distribution
+#include <utility>         // for std::move, std::pair
+
+// Third-party headers
 #include <thallium.hpp>
-#include <random>
-#include <deque>
 #include <cereal/archives/binary.hpp>
 
+// Project headers
 #include <ConfigurationManager.h>
 #include <StoryChunk.h>
 #include <cmd_arg_parse.h>

--- a/test/integration/Keeper-Grapher/ingest_test.cpp
+++ b/test/integration/Keeper-Grapher/ingest_test.cpp
@@ -1,6 +1,19 @@
+// System headers
+#include <cstdlib>         // for exit(), EXIT_FAILURE
+#include <stdexcept>       // for std::exception
+
+// Standard library headers
+#include <string>          // for std::string
+#include <vector>          // for std::vector
+#include <chrono>          // for std::chrono::high_resolution_clock, std::chrono::duration_cast
+#include <sstream>         // for std::stringstream, std::istringstream
+#include <utility>         // for std::move, std::pair
+
+// Third-party headers
 #include <thallium.hpp>
 #include <cereal/archives/binary.hpp>
 
+// Project headers
 #include <ConfigurationManager.h>
 #include <StoryChunk.h>
 #include <cmd_arg_parse.h>

--- a/test/integration/Keeper-Grapher/ingest_test.cpp
+++ b/test/integration/Keeper-Grapher/ingest_test.cpp
@@ -1,13 +1,13 @@
 // System headers
-#include <cstdlib>         // for exit(), EXIT_FAILURE
-#include <stdexcept>       // for std::exception
+#include <cstdlib>   // for exit(), EXIT_FAILURE
+#include <stdexcept> // for std::exception
 
 // Standard library headers
-#include <string>          // for std::string
-#include <vector>          // for std::vector
-#include <chrono>          // for std::chrono::high_resolution_clock, std::chrono::duration_cast
-#include <sstream>         // for std::stringstream, std::istringstream
-#include <utility>         // for std::move, std::pair
+#include <string>  // for std::string
+#include <vector>  // for std::vector
+#include <chrono>  // for std::chrono::high_resolution_clock, std::chrono::duration_cast
+#include <sstream> // for std::stringstream, std::istringstream
+#include <utility> // for std::move, std::pair
 
 // Third-party headers
 #include <thallium.hpp>
@@ -23,23 +23,20 @@ namespace tl = thallium;
 #define MAX_BULK_MEM_SIZE (1024 * 1024 * 4)
 #define NUM_STREAMS 4
 
-class StoryChunkRecordService: public tl::provider <StoryChunkRecordService>
+class StoryChunkRecordService: public tl::provider<StoryChunkRecordService>
 {
 public:
-    static StoryChunkRecordService*CreateStoryChunkRecordService(tl::engine &tl_engine
-                                                                 , tl::managed <tl::pool> &tl_pool
-                                                                 , uint16_t service_provider_id)
+    static StoryChunkRecordService*
+    CreateStoryChunkRecordService(tl::engine& tl_engine, tl::managed<tl::pool>& tl_pool, uint16_t service_provider_id)
     {
         return new StoryChunkRecordService(tl_engine, tl_pool, service_provider_id);
     }
 
-    StoryChunkRecordService(tl::engine &tl_engine, tl::managed <tl::pool> &tl_pool, uint16_t service_provider_id)
-            : tl::provider <StoryChunkRecordService>(tl_engine, service_provider_id)
+    StoryChunkRecordService(tl::engine& tl_engine, tl::managed<tl::pool>& tl_pool, uint16_t service_provider_id)
+        : tl::provider<StoryChunkRecordService>(tl_engine, service_provider_id)
     {
-        define("record_story_chunk", &StoryChunkRecordService::record_story_chunk, *tl_pool,
-                            tl::ignore_return_value());
-        get_engine().push_finalize_callback(this, [p = this]()
-        { delete p; });
+        define("record_story_chunk", &StoryChunkRecordService::record_story_chunk, *tl_pool, tl::ignore_return_value());
+        get_engine().push_finalize_callback(this, [p = this]() { delete p; });
         LOG_DEBUG("[StoryChunkRecordService] StoryChunkRecordService setup complete");
     }
 
@@ -49,7 +46,7 @@ public:
         get_engine().pop_finalize_callback(this);
     }
 
-    void record_story_chunk(tl::request const &request, tl::bulk &b)
+    void record_story_chunk(tl::request const& request, tl::bulk& b)
     {
         try
         {
@@ -59,8 +56,8 @@ public:
             LOG_DEBUG("[StoryChunkRecordService] ES{}:T{}: StoryChunk recording RPC invoked", esid, tid);
             tl::endpoint ep = request.get_endpoint();
             LOG_DEBUG("[StoryChunkRecordService] ES{}:T{}: Endpoint obtained", esid, tid);
-            std::vector <char> mem_vec(MAX_BULK_MEM_SIZE);
-            std::vector <std::pair <void*, std::size_t>> segments(1);
+            std::vector<char> mem_vec(MAX_BULK_MEM_SIZE);
+            std::vector<std::pair<void*, std::size_t>> segments(1);
             segments[0].first = (void*)(&mem_vec[0]);
             segments[0].second = mem_vec.size();
             LOG_DEBUG("[StoryChunkRecordService] ES{}:T{}: Bulk memory prepared, size: {}", esid, tid, mem_vec.size());
@@ -74,22 +71,27 @@ public:
             start = std::chrono::high_resolution_clock::now();
             deserializedWithCereal(&mem_vec[0], b.size() - 1, story_chunk);
             end = std::chrono::high_resolution_clock::now();
-            LOG_DEBUG("[StoryChunkRecordService] ES{}:T{}: StoryChunk received: StoryID: {}, StartTime: {}", esid, tid
-                      , story_chunk.getStoryId(), story_chunk.getStartTime());
-            LOG_INFO("[StoryChunkRecordService] ES{}:T{}: Deserialization took {} us", esid, tid,
-                    std::chrono::duration_cast <std::chrono::nanoseconds>(end - start).count() / 1000.0);
+            LOG_DEBUG("[StoryChunkRecordService] ES{}:T{}: StoryChunk received: StoryID: {}, StartTime: {}",
+                      esid,
+                      tid,
+                      story_chunk.getStoryId(),
+                      story_chunk.getStartTime());
+            LOG_INFO("[StoryChunkRecordService] ES{}:T{}: Deserialization took {} us",
+                     esid,
+                     tid,
+                     std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count() / 1000.0);
             request.respond(b.size());
             LOG_DEBUG("[StoryChunkRecordService] ES{}:T{}: StoryChunk recording RPC responded {}", esid, tid, b.size());
         }
-        catch(tl::exception &e)
+        catch(tl::exception& e)
         {
             LOG_ERROR("[StoryChunkRecordService] Fail to ingest story chunk, Thallium exception caught: {}", e.what());
         }
-        catch(cereal::Exception &e)
+        catch(cereal::Exception& e)
         {
             LOG_ERROR("[StoryChunkRecordService] Fail to ingest story chunk, Cereal exception caught: {}", e.what());
         }
-        catch(std::exception &e)
+        catch(std::exception& e)
         {
             LOG_ERROR("[StoryChunkRecordService] Fail to ingest story chunk, std::exception caught: {}", e.what());
         }
@@ -100,7 +102,7 @@ public:
     }
 
 private:
-    void deserializedWithCereal(char*buffer, size_t size, chronolog::StoryChunk &story_chunk)
+    void deserializedWithCereal(char* buffer, size_t size, chronolog::StoryChunk& story_chunk)
     {
         std::string str(buffer, buffer + size);
         std::istringstream iss(str);
@@ -109,17 +111,18 @@ private:
     }
 };
 
-int main(int argc, char**argv)
+int main(int argc, char** argv)
 {
     std::string conf_file_path;
     conf_file_path = parse_conf_path_arg(argc, argv);
     chronolog::ConfigurationManager confManager(conf_file_path);
-    int result = chronolog::chrono_monitor::initialize("console", confManager.GRAPHER_CONF.LOG_CONF.LOGFILE
-                                    , confManager.GRAPHER_CONF.LOG_CONF.LOGLEVEL
-                                    , confManager.GRAPHER_CONF.LOG_CONF.LOGNAME
-                                    , confManager.GRAPHER_CONF.LOG_CONF.LOGFILESIZE
-                                    , confManager.GRAPHER_CONF.LOG_CONF.LOGFILENUM
-                                    , confManager.GRAPHER_CONF.LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize("console",
+                                                       confManager.GRAPHER_CONF.LOG_CONF.LOGFILE,
+                                                       confManager.GRAPHER_CONF.LOG_CONF.LOGLEVEL,
+                                                       confManager.GRAPHER_CONF.LOG_CONF.LOGNAME,
+                                                       confManager.GRAPHER_CONF.LOG_CONF.LOGFILESIZE,
+                                                       confManager.GRAPHER_CONF.LOG_CONF.LOGFILENUM,
+                                                       confManager.GRAPHER_CONF.LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);
@@ -138,26 +141,23 @@ int main(int argc, char**argv)
     ss << extraction_engine.self();
     LOG_DEBUG("[standalone_ingest_test] Engine: {}", ss.str());
 
-    std::vector <tl::managed <tl::xstream>> tl_es_vec;
-    tl::managed <tl::pool> tl_pool = tl::pool::create(tl::pool::access::spmc);
+    std::vector<tl::managed<tl::xstream>> tl_es_vec;
+    tl::managed<tl::pool> tl_pool = tl::pool::create(tl::pool::access::spmc);
     LOG_DEBUG("[standalone_ingest_test] Pool created");
     for(int j = 0; j < NUM_STREAMS; j++)
     {
-        tl::managed <tl::xstream> es = tl::xstream::create(tl::scheduler::predef::deflt, *tl_pool);
+        tl::managed<tl::xstream> es = tl::xstream::create(tl::scheduler::predef::deflt, *tl_pool);
         LOG_DEBUG("[standalone_ingest_test] A new stream is created");
         tl_es_vec.push_back(std::move(es));
     }
 
     int service_provider_id = confManager.GRAPHER_CONF.KEEPER_GRAPHER_DRAIN_SERVICE_CONF.SERVICE_PROVIDER_ID;
-    StoryChunkRecordService*story_chunk_recording_service = StoryChunkRecordService::CreateStoryChunkRecordService(
-            extraction_engine, tl_pool, service_provider_id);
+    StoryChunkRecordService* story_chunk_recording_service =
+            StoryChunkRecordService::CreateStoryChunkRecordService(extraction_engine, tl_pool, service_provider_id);
     LOG_DEBUG("[standalone_ingest_test] StoryChunkRecordService created");
 
     extraction_engine.wait_for_finalize();
-    for(int j = 0; j < NUM_STREAMS; j++)
-    {
-        tl_es_vec[j]->join();
-    }
+    for(int j = 0; j < NUM_STREAMS; j++) { tl_es_vec[j]->join(); }
 
     delete story_chunk_recording_service;
 

--- a/test/unit/StoryChunkTest.cpp
+++ b/test/unit/StoryChunkTest.cpp
@@ -2,7 +2,9 @@
 #include <gtest/gtest.h>
 #include <map>
 #include <spdlog/spdlog.h>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include <StoryChunk.h>
 #include <chrono_monitor.h>

--- a/test/unit/StoryPipelineTest.cpp
+++ b/test/unit/StoryPipelineTest.cpp
@@ -36,9 +36,9 @@ TEST(StoryPipeline_TestConstructors, testOnBoundaryStartTime)
     initLogger();
     chl::StoryChunkExtractionQueue q;
 
-    uint64_t startNs = 9ULL * NS;// 9s
-    uint16_t granS = 3;          // seconds
-    uint16_t windowS = 1;        // second
+    uint64_t startNs = 9ULL * NS; // 9s
+    uint16_t granS = 3;           // seconds
+    uint16_t windowS = 1;         // second
 
     ASSERT_NO_THROW({
         chl::StoryPipeline p(q, "C", "S", 1, startNs, granS, windowS);
@@ -60,9 +60,9 @@ TEST(StoryPipeline_TestConstructors, testNonBoundaryRounding)
     initLogger();
     chl::StoryChunkExtractionQueue q;
 
-    uint64_t startNs = 5500000000ULL;// 5.5 s
-    uint16_t granS = 3;              // seconds
-    uint16_t windowS = 1;            // seconds
+    uint64_t startNs = 5500000000ULL; // 5.5 s
+    uint16_t granS = 3;               // seconds
+    uint16_t windowS = 1;             // seconds
 
     ASSERT_NO_THROW({
         chl::StoryPipeline p(q, "C", "S", 2, startNs, granS, windowS);
@@ -483,7 +483,6 @@ TEST(StoryPipeline_TestFinalize, testNoPendingChunks)
     chl::StoryPipeline p(q, "C", "S", 1, 0, 1, 1);
     EXPECT_NO_THROW(p.finalize());
     EXPECT_EQ(q.size(), 0);
-
 }
 
 // Test if finalize processes the chunk in the passive deque
@@ -501,7 +500,6 @@ TEST(StoryPipeline_TestFinalize, testOnlyPassiveDeque)
 
     p.finalize();
     EXPECT_EQ(q.size(), 1);
-
 }
 
 // Test if finalize processes the chunk in the active deque
@@ -519,7 +517,6 @@ TEST(StoryPipeline_TestFinalize, testOnlyActiveDeque)
 
     p.finalize();
     EXPECT_EQ(q.size(), 1);
-
 }
 
 // Test if finalize handles both passive and active deques in FIFO

--- a/test/unit/StoryPipelineTest.cpp
+++ b/test/unit/StoryPipelineTest.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include <limits>
+#include <string>
+#include <vector>
 
 #include <StoryPipeline.h>
 #include <StoryChunkExtractionQueue.h>

--- a/tools/cli/client_admin.cpp
+++ b/tools/cli/client_admin.cpp
@@ -6,7 +6,6 @@
 #include <unistd.h>
 #include <pwd.h>
 #include <getopt.h>
-#include <time.h>
 
 #include <algorithm>
 #include <chrono>

--- a/tools/cli/client_admin.cpp
+++ b/tools/cli/client_admin.cpp
@@ -1,10 +1,25 @@
 #include <cassert>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <unistd.h>
 #include <pwd.h>
 #include <getopt.h>
-#include <functional>
+#include <time.h>
+
+#include <algorithm>
 #include <chrono>
 #include <cctype>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include <mpi.h>
 #include <margo.h>
 

--- a/tools/cli/client_admin.cpp
+++ b/tools/cli/client_admin.cpp
@@ -49,25 +49,27 @@ typedef struct workload_conf_args_
     bool perf_test = false;
 } workload_conf_args;
 
-void usage(char **argv)
+void usage(char** argv)
 {
-    std::cerr << "\nUsage: " << argv[0] << " [options]\n"
-                                           "-c|--config <config_file>\n"
-                                           "-i|--interactive\tInteract with ChronoLog like a shell\n"
-                                           "-w|--write\t\tRecord events\n"
-                                           "-r|--read\t\tRetrieve events\n"
-                                           "-h|--chronicle_count <chronicle_count_per_proc>\n"
-                                           "-t|--story_count <story_count_per_proc>\n"
-                                           "-a|--min_event_size <min_event_size_in_byte>\n"
-                                           "-s|--ave_event_size <ave_event_size_in_byte>\n"
-                                           "-b|--max_event_size <max_event_size_in_byte>\n"
-                                           "-n|--event_count <event_count_per_proc>\n"
-                                           "-g|--event_interval <event_interval_in_us>\n"
-                                           "-y|--barrier\t\tHold next API call until completion of previous one\n"
-                                           "-f|--event_payload_file <event_payload_file>\n"
-                                           "-o|--shared_story\tAll procs record events to the same chronicle\n"
-                                           "-p|--perf\t\tReport performance metrics after completion\n"
-                                           "-u|--usage\t\tPrint this page\n" << std::endl;
+    std::cerr << "\nUsage: " << argv[0]
+              << " [options]\n"
+                 "-c|--config <config_file>\n"
+                 "-i|--interactive\tInteract with ChronoLog like a shell\n"
+                 "-w|--write\t\tRecord events\n"
+                 "-r|--read\t\tRetrieve events\n"
+                 "-h|--chronicle_count <chronicle_count_per_proc>\n"
+                 "-t|--story_count <story_count_per_proc>\n"
+                 "-a|--min_event_size <min_event_size_in_byte>\n"
+                 "-s|--ave_event_size <ave_event_size_in_byte>\n"
+                 "-b|--max_event_size <max_event_size_in_byte>\n"
+                 "-n|--event_count <event_count_per_proc>\n"
+                 "-g|--event_interval <event_interval_in_us>\n"
+                 "-y|--barrier\t\tHold next API call until completion of previous one\n"
+                 "-f|--event_payload_file <event_payload_file>\n"
+                 "-o|--shared_story\tAll procs record events to the same chronicle\n"
+                 "-p|--perf\t\tReport performance metrics after completion\n"
+                 "-u|--usage\t\tPrint this page\n"
+              << std::endl;
 }
 
 void random_sleep()
@@ -80,24 +82,19 @@ void random_sleep()
     usleep(usec * rank);
 }
 
-std::string &trim_string(std::string &str)
+std::string& trim_string(std::string& str)
 {
     // Trim leading space
-    str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](unsigned char ch)
-    {
-        return !std::isspace(ch);
-    }));
+    str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](unsigned char ch) { return !std::isspace(ch); }));
     // Trim trailing space
-    str.erase(std::find_if(str.rbegin(), str.rend(), [](unsigned char ch)
-    {
-        return !std::isspace(ch);
-    }).base(), str.end());
+    str.erase(std::find_if(str.rbegin(), str.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(),
+              str.end());
     return str;
 }
 
-uint64_t get_uint64_t_from_string(const std::string &str)
+uint64_t get_uint64_t_from_string(const std::string& str)
 {
-    char *endptr;
+    char* endptr;
     errno = 0; // Reset errno before calling strtoull
     uint64_t value = strtoull(str.c_str(), &endptr, 10);
     if(*endptr != '\0')
@@ -113,33 +110,33 @@ uint64_t get_uint64_t_from_string(const std::string &str)
     return value;
 }
 
-std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char **argv)
+std::pair<std::string, workload_conf_args> cmd_arg_parse(int argc, char** argv)
 {
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     int opt;
-    char *config_file = nullptr;
+    char* config_file = nullptr;
     workload_conf_args workload_args;
 
     // Define the long options and their corresponding short options
-    struct option long_options[] = {{  "config"            , required_argument, nullptr, 'c'}
-                                    , {"interactive"       , optional_argument, nullptr, 'i'}
-                                    , {"write"             , no_argument       , nullptr, 'w'}
-                                    , {"read"              , optional_argument, nullptr, 'r'}
-                                    , {"chronicle_count"   , required_argument, nullptr, 'h'}
-                                    , {"story_count"       , required_argument, nullptr, 't'}
-                                    , {"min_event_size"    , required_argument, nullptr, 'a'}
-                                    , {"ave_event_size"    , required_argument, nullptr, 's'}
-                                    , {"max_event_size"    , required_argument, nullptr, 'b'}
-                                    , {"event_count"       , required_argument, nullptr, 'n'}
-                                    , {"event_interval"    , required_argument, nullptr, 'g'}
-                                    , {"barrier"           , optional_argument, nullptr, 'y'}
-                                    , {"event_payload_file", optional_argument, nullptr, 'f'}
-                                    , {"shared_story"      , optional_argument, nullptr, 'o'}
-                                    , {"perf"              , optional_argument, nullptr, 'p'}
-                                    , {"usage"             , no_argument       , nullptr, 'u'}
-                                    , {nullptr             , 0                , nullptr, 0}};
+    struct option long_options[] = {{"config", required_argument, nullptr, 'c'},
+                                    {"interactive", optional_argument, nullptr, 'i'},
+                                    {"write", no_argument, nullptr, 'w'},
+                                    {"read", optional_argument, nullptr, 'r'},
+                                    {"chronicle_count", required_argument, nullptr, 'h'},
+                                    {"story_count", required_argument, nullptr, 't'},
+                                    {"min_event_size", required_argument, nullptr, 'a'},
+                                    {"ave_event_size", required_argument, nullptr, 's'},
+                                    {"max_event_size", required_argument, nullptr, 'b'},
+                                    {"event_count", required_argument, nullptr, 'n'},
+                                    {"event_interval", required_argument, nullptr, 'g'},
+                                    {"barrier", optional_argument, nullptr, 'y'},
+                                    {"event_payload_file", optional_argument, nullptr, 'f'},
+                                    {"shared_story", optional_argument, nullptr, 'o'},
+                                    {"perf", optional_argument, nullptr, 'p'},
+                                    {"usage", no_argument, nullptr, 'u'},
+                                    {nullptr, 0, nullptr, 0}};
 
     // Parse the command-line options
     while((opt = getopt_long(argc, argv, "c:iwrh:t:a:s:b:n:g:yf:opu", long_options, nullptr)) != -1)
@@ -229,21 +226,21 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char **argv)
                 if(!workload_args.event_payload_file.empty())
                 {
                     std::cout << "Event payload file specified (event payloads in lines): "
-                        << workload_args.event_payload_file.c_str() << std::endl;
+                              << workload_args.event_payload_file.c_str() << std::endl;
                 }
                 else
                 {
                     std::cout << "No event payload file specified, use default/specified separate conf args ..."
-                        << std::endl;
+                              << std::endl;
                     std::cout << "Min event size (minimum of event payload length following a normal distribution): "
-                        << workload_args.min_event_size << " bytes" << std::endl;
+                              << workload_args.min_event_size << " bytes" << std::endl;
                     std::cout << "Ave event size (median of event payload length following a normal distribution): "
-                        << workload_args.ave_event_size << " bytes" << std::endl;
+                              << workload_args.ave_event_size << " bytes" << std::endl;
                     std::cout << "Max event size (maximum of event payload length following a normal distribution): "
-                        << workload_args.max_event_size << " bytes" << std::endl;
+                              << workload_args.max_event_size << " bytes" << std::endl;
                     std::cout << "Event count (#events per proc): " << workload_args.event_count << std::endl;
-                    std::cout << "Event interval (time in-between event accesses): "
-                        << workload_args.event_interval << " us" << std::endl;
+                    std::cout << "Event interval (time in-between event accesses): " << workload_args.event_interval
+                              << " us" << std::endl;
                 }
                 std::cout << "Barrier (hold on next ChronoLog API call until completion of the previous one): "
                           << (workload_args.barrier ? "true" : "false") << std::endl;
@@ -251,7 +248,7 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char **argv)
                           << (workload_args.shared_story ? "true" : "false") << std::endl;
             }
         }
-        return {std::pair <std::string, workload_conf_args>((config_file), workload_args)};
+        return {std::pair<std::string, workload_conf_args>((config_file), workload_args)};
     }
     else
     {
@@ -263,27 +260,27 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char **argv)
             std::cout << "Chronicle count (#chronicles per proc): " << workload_args.chronicle_count << std::endl;
             std::cout << "Story count (#stories per proc) : " << workload_args.story_count << std::endl;
             std::cout << "Min event size (minimum of event payload length following a normal distribution): "
-                << workload_args.min_event_size << " bytes" << std::endl;
+                      << workload_args.min_event_size << " bytes" << std::endl;
             std::cout << "Ave event size (median of event payload length following a normal distribution): "
-                << workload_args.ave_event_size << " bytes" << std::endl;
+                      << workload_args.ave_event_size << " bytes" << std::endl;
             std::cout << "Max event size (maximum of event payload length following a normal distribution): "
-                << workload_args.max_event_size << " bytes" << std::endl;
+                      << workload_args.max_event_size << " bytes" << std::endl;
             std::cout << "Event count (#events per proc): " << workload_args.event_count << std::endl;
-            std::cout << "Event interval (time in-between event accesses): "
-                << workload_args.event_interval << " us" << std::endl;
+            std::cout << "Event interval (time in-between event accesses): " << workload_args.event_interval << " us"
+                      << std::endl;
             std::cout << "Barrier (hold on next data access until completion of the previous one): "
-                << (workload_args.barrier ? "true" : "false") << std::endl;
+                      << (workload_args.barrier ? "true" : "false") << std::endl;
             std::cout << "Shared story (all procs access the same story): "
-                << (workload_args.shared_story ? "true" : "false") << std::endl;
+                      << (workload_args.shared_story ? "true" : "false") << std::endl;
         }
         return {"", workload_args};
     }
 }
 
-int test_create_chronicle(chronolog::Client &client, const std::string &chronicle_name)
+int test_create_chronicle(chronolog::Client& client, const std::string& chronicle_name)
 {
     int ret, flags = 0;
-    std::map <std::string, std::string> chronicle_attrs;
+    std::map<std::string, std::string> chronicle_attrs;
     chronicle_attrs.emplace("Priority", "High");
     chronicle_attrs.emplace("IndexGranularity", "Millisecond");
     chronicle_attrs.emplace("TieringPolicy", "Hot");
@@ -292,61 +289,65 @@ int test_create_chronicle(chronolog::Client &client, const std::string &chronicl
     return ret;
 }
 
-std::pair <int, chronolog::StoryHandle *>
-test_acquire_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name)
+std::pair<int, chronolog::StoryHandle*>
+test_acquire_story(chronolog::Client& client, const std::string& chronicle_name, const std::string& story_name)
 {
-//    random_sleep();
+    //    random_sleep();
     int flags = 0;
-    std::map <std::string, std::string> story_acquisition_attrs;
+    std::map<std::string, std::string> story_acquisition_attrs;
     story_acquisition_attrs.emplace("Priority", "High");
     story_acquisition_attrs.emplace("IndexGranularity", "Millisecond");
     story_acquisition_attrs.emplace("TieringPolicy", "Hot");
-    std::pair <int, chronolog::StoryHandle *> acq_ret = client.AcquireStory(chronicle_name, story_name
-                                                                            , story_acquisition_attrs, flags);
-//    LOG_DEBUG("acq_ret: {}", to_string_client(acq_ret.first));
-//    assert(acq_ret.first == chronolog::CL_SUCCESS || acq_ret.first == chronolog::CL_ERR_ACQUIRED);
+    std::pair<int, chronolog::StoryHandle*> acq_ret =
+            client.AcquireStory(chronicle_name, story_name, story_acquisition_attrs, flags);
+    //    LOG_DEBUG("acq_ret: {}", to_string_client(acq_ret.first));
+    //    assert(acq_ret.first == chronolog::CL_SUCCESS || acq_ret.first == chronolog::CL_ERR_ACQUIRED);
     return acq_ret;
 }
 
-uint64_t test_write_event(chronolog::StoryHandle *story_handle, const std::string &event_payload)
+uint64_t test_write_event(chronolog::StoryHandle* story_handle, const std::string& event_payload)
 {
     uint64_t ret = story_handle->log_event(event_payload);
     assert(ret > 0);
     return ret;
 }
 
-int test_replay_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name
-                      , uint64_t start_time, uint64_t end_time, std::vector <chronolog::Event> &replay_events)
+int test_replay_story(chronolog::Client& client,
+                      const std::string& chronicle_name,
+                      const std::string& story_name,
+                      uint64_t start_time,
+                      uint64_t end_time,
+                      std::vector<chronolog::Event>& replay_events)
 {
     int ret = client.ReplayStory(chronicle_name, story_name, start_time, end_time, replay_events);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST);
     return ret;
 }
 
-int test_release_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name)
+int test_release_story(chronolog::Client& client, const std::string& chronicle_name, const std::string& story_name)
 {
     int ret = client.ReleaseStory(chronicle_name, story_name);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST);
     return ret;
 }
 
-int test_destroy_chronicle(chronolog::Client &client, const std::string &chronicle_name)
+int test_destroy_chronicle(chronolog::Client& client, const std::string& chronicle_name)
 {
     int ret = client.DestroyChronicle(chronicle_name);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED);
     return ret;
 }
 
-int test_destroy_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name)
+int test_destroy_story(chronolog::Client& client, const std::string& chronicle_name, const std::string& story_name)
 {
     int ret = client.DestroyStory(chronicle_name, story_name);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST || ret == chronolog::CL_ERR_ACQUIRED);
     return ret;
 }
 
-std::vector <std::string> parse_command_line(const std::string &line)
+std::vector<std::string> parse_command_line(const std::string& line)
 {
-    std::vector <std::string> tokens;
+    std::vector<std::string> tokens;
     std::string current_token;
     bool in_quotes = false;
 
@@ -400,15 +401,15 @@ std::vector <std::string> parse_command_line(const std::string &line)
 }
 
 // function to extract and execute commands from command line input
-void command_dispatcher(const std::string &command_line, std::unordered_map <std::string, std::function <void(
-        std::vector <std::string> &)>> command_map)
+void command_dispatcher(const std::string& command_line,
+                        std::unordered_map<std::string, std::function<void(std::vector<std::string>&)>> command_map)
 {
     if(command_line.empty())
     {
         return;
     }
 
-    std::vector <std::string> parsed_tokens = parse_command_line(command_line);
+    std::vector<std::string> parsed_tokens = parse_command_line(command_line);
 
     if(parsed_tokens.empty())
     {
@@ -428,7 +429,7 @@ void command_dispatcher(const std::string &command_line, std::unordered_map <std
     }
 }
 
-uint64_t get_event_timestamp(std::string &event_line)
+uint64_t get_event_timestamp(std::string& event_line)
 {
     /*
      * Supported log files: syslog, auth.log, kern.log, ufw.log on Ubuntu
@@ -443,7 +444,7 @@ uint64_t get_event_timestamp(std::string &event_line)
     std::tm timeinfo{};
     auto now = std::chrono::system_clock::now();
     std::time_t current_time = std::chrono::system_clock::to_time_t(now);
-    std::tm *time_info_now = std::localtime(&current_time);
+    std::tm* time_info_now = std::localtime(&current_time);
     // assume the log file is generated in the same year as the current time
     timeinfo.tm_year = time_info_now->tm_year;
     strptime(timestamp_str.c_str(), "%b %d %H:%M:%S", &timeinfo);
@@ -451,7 +452,7 @@ uint64_t get_event_timestamp(std::string &event_line)
     return timestamp;
 }
 
-uint64_t get_bigbang_timestamp(std::ifstream &file)
+uint64_t get_bigbang_timestamp(std::ifstream& file)
 {
     std::string line;
     std::getline(file, line);
@@ -460,7 +461,7 @@ uint64_t get_bigbang_timestamp(std::ifstream &file)
     return bigbang_timestamp;
 }
 
-void interactive_create_chronicle(std::vector <std::string> &tokens, chronolog::Client &client)
+void interactive_create_chronicle(std::vector<std::string>& tokens, chronolog::Client& client)
 {
     if(tokens.size() != 2)
     {
@@ -485,7 +486,7 @@ void interactive_create_chronicle(std::vector <std::string> &tokens, chronolog::
     }
 }
 
-chronolog::StoryHandle* interactive_acquire_story(std::vector <std::string> &tokens, chronolog::Client &client)
+chronolog::StoryHandle* interactive_acquire_story(std::vector<std::string>& tokens, chronolog::Client& client)
 {
     if(tokens.size() != 4)
     {
@@ -493,21 +494,19 @@ chronolog::StoryHandle* interactive_acquire_story(std::vector <std::string> &tok
         return nullptr;
     }
     int ret_i;
-    chronolog::StoryHandle *story_handle = nullptr;
-    const std::string &chronicle_name = tokens[2];
-    const std::string &story_name = tokens[3];
+    chronolog::StoryHandle* story_handle = nullptr;
+    const std::string& chronicle_name = tokens[2];
+    const std::string& story_name = tokens[3];
     auto ret = test_acquire_story(client, chronicle_name, story_name);
     ret_i = ret.first;
     story_handle = ret.second;
     if(ret_i == chronolog::CL_SUCCESS)
     {
-        std::cout << "Story acquired successfully: " << story_name << " in Chronicle "
-                  << chronicle_name << std::endl;
+        std::cout << "Story acquired successfully: " << story_name << " in Chronicle " << chronicle_name << std::endl;
     }
     else if(ret_i == chronolog::CL_ERR_ACQUIRED)
     {
-        std::cout << "Story already acquired: " << story_name << " in Chronicle " << chronicle_name
-                  << std::endl;
+        std::cout << "Story already acquired: " << story_name << " in Chronicle " << chronicle_name << std::endl;
     }
     else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
     {
@@ -521,7 +520,7 @@ chronolog::StoryHandle* interactive_acquire_story(std::vector <std::string> &tok
     return story_handle;
 }
 
-void interactive_release_story(std::vector <std::string> &tokens, chronolog::Client &client)
+void interactive_release_story(std::vector<std::string>& tokens, chronolog::Client& client)
 {
     if(tokens.size() != 4)
     {
@@ -534,13 +533,11 @@ void interactive_release_story(std::vector <std::string> &tokens, chronolog::Cli
     ret_i = test_release_story(client, chronicle_name, story_name);
     if(ret_i == chronolog::CL_SUCCESS)
     {
-        std::cout << "Story released successfully: " << story_name << " in Chronicle "
-                  << chronicle_name << std::endl;
+        std::cout << "Story released successfully: " << story_name << " in Chronicle " << chronicle_name << std::endl;
     }
     else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
     {
-        std::cout << "Story does not exist: " << story_name << " in Chronicle " << chronicle_name
-                  << std::endl;
+        std::cout << "Story does not exist: " << story_name << " in Chronicle " << chronicle_name << std::endl;
     }
     else
     {
@@ -549,7 +546,7 @@ void interactive_release_story(std::vector <std::string> &tokens, chronolog::Cli
     }
 }
 
-void interactive_write_event(std::vector <std::string> &tokens, chronolog::StoryHandle *story_handle)
+void interactive_write_event(std::vector<std::string>& tokens, chronolog::StoryHandle* story_handle)
 {
     if(tokens.size() < 2)
     {
@@ -569,8 +566,7 @@ void interactive_write_event(std::vector <std::string> &tokens, chronolog::Story
     ret_u = test_write_event(story_handle, event_payload);
     if(ret_u > 0)
     {
-        std::cout << "Event written successfully, payload length: " << event_payload.length()
-                  << std::endl;
+        std::cout << "Event written successfully, payload length: " << event_payload.length() << std::endl;
     }
     else
     {
@@ -578,7 +574,7 @@ void interactive_write_event(std::vector <std::string> &tokens, chronolog::Story
     }
 }
 
-void interactive_replay_story(std::vector <std::string> &tokens, chronolog::Client &client)
+void interactive_replay_story(std::vector<std::string>& tokens, chronolog::Client& client)
 {
     if(tokens.size() != 5)
     {
@@ -590,22 +586,17 @@ void interactive_replay_story(std::vector <std::string> &tokens, chronolog::Clie
     const std::string& story_name = tokens[2];
     uint64_t start_time = get_uint64_t_from_string(tokens[3]);
     uint64_t end_time = get_uint64_t_from_string(tokens[4]);
-    std::vector <chronolog::Event> replay_events;
+    std::vector<chronolog::Event> replay_events;
     ret_i = test_replay_story(client, chronicle_name, story_name, start_time, end_time, replay_events);
     if(ret_i == chronolog::CL_SUCCESS)
     {
-        std::cout << "Replay successful, retrieved " << replay_events.size() << " events from "
-                  << chronicle_name << " story " << story_name << " between "
-                  << start_time << " and " << end_time << std::endl;
-        for(const auto &event: replay_events)
-        {
-            std::cout << event.to_string() << std::endl;
-        }
+        std::cout << "Replay successful, retrieved " << replay_events.size() << " events from " << chronicle_name
+                  << " story " << story_name << " between " << start_time << " and " << end_time << std::endl;
+        for(const auto& event: replay_events) { std::cout << event.to_string() << std::endl; }
     }
     else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
     {
-        std::cout << "Story does not exist: " << story_name << " in Chronicle " << chronicle_name
-                  << std::endl;
+        std::cout << "Story does not exist: " << story_name << " in Chronicle " << chronicle_name << std::endl;
     }
     else
     {
@@ -614,7 +605,7 @@ void interactive_replay_story(std::vector <std::string> &tokens, chronolog::Clie
     }
 }
 
-void interactive_destroy_story(std::vector <std::string> &tokens, chronolog::Client &client)
+void interactive_destroy_story(std::vector<std::string>& tokens, chronolog::Client& client)
 {
     if(tokens.size() != 4)
     {
@@ -627,18 +618,16 @@ void interactive_destroy_story(std::vector <std::string> &tokens, chronolog::Cli
     ret_i = test_destroy_story(client, chronicle_name, story_name);
     if(ret_i == chronolog::CL_SUCCESS)
     {
-        std::cout << "Story destroyed successfully: " << story_name << " in Chronicle "
-                  << chronicle_name << std::endl;
+        std::cout << "Story destroyed successfully: " << story_name << " in Chronicle " << chronicle_name << std::endl;
     }
     else if(ret_i == chronolog::CL_ERR_ACQUIRED)
     {
-        std::cout << "Story is still acquired, cannot destroy: " << story_name << " in Chronicle "
-                  << chronicle_name << std::endl;
+        std::cout << "Story is still acquired, cannot destroy: " << story_name << " in Chronicle " << chronicle_name
+                  << std::endl;
     }
     else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
     {
-        std::cout << "Story does not exist: " << story_name << " in Chronicle " << chronicle_name
-                  << std::endl;
+        std::cout << "Story does not exist: " << story_name << " in Chronicle " << chronicle_name << std::endl;
     }
     else
     {
@@ -647,7 +636,7 @@ void interactive_destroy_story(std::vector <std::string> &tokens, chronolog::Cli
     }
 }
 
-void interactive_destroy_chronicle(std::vector <std::string> &tokens, chronolog::Client &client)
+void interactive_destroy_chronicle(std::vector<std::string>& tokens, chronolog::Client& client)
 {
     if(tokens.size() != 3)
     {
@@ -676,7 +665,7 @@ void interactive_destroy_chronicle(std::vector <std::string> &tokens, chronolog:
     }
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     // To suppress argobots warning
     std::string argobots_conf_str = R"({"argobots" : {"abt_mem_max_num_stacks" : 8
@@ -688,7 +677,7 @@ int main(int argc, char **argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-    std::pair <std::string, workload_conf_args> cmd_args = cmd_arg_parse(argc, argv);
+    std::pair<std::string, workload_conf_args> cmd_args = cmd_arg_parse(argc, argv);
     std::string conf_file_path = cmd_args.first;
     workload_conf_args workload_args = cmd_args.second;
 
@@ -720,7 +709,7 @@ int main(int argc, char **argv)
         }
     }
 
-    if (rank == 0)
+    if(rank == 0)
     {
         confManager.log_configuration(std::cout);
     }
@@ -748,10 +737,9 @@ int main(int argc, char **argv)
         std::cout << "[ClientAdmin] Running in write mode." << std::endl;
     }
 
-    chronolog::Client client = workload_args.read ?
-                               chronolog::Client(confManager.PORTAL_CONF, confManager.QUERY_CONF) :
-                               chronolog::Client(confManager.PORTAL_CONF);
-    chronolog::StoryHandle *story_handle;
+    chronolog::Client client = workload_args.read ? chronolog::Client(confManager.PORTAL_CONF, confManager.QUERY_CONF)
+                                                  : chronolog::Client(confManager.PORTAL_CONF);
+    chronolog::StoryHandle* story_handle;
 
     TimerWrapper connectTimer(workload_args.perf_test, "Connect");
     TimerWrapper createChronicleTimer(workload_args.perf_test, "CreateChronicle");
@@ -768,10 +756,10 @@ int main(int argc, char **argv)
     uint64_t event_payload_size_per_rank = 0;
 
     std::string client_id = gen_random(8);
-//    std::cout << "Generated client id: " << client_id << std::endl;
+    //    std::cout << "Generated client id: " << client_id << std::endl;
 
-    const std::string &server_protoc = confManager.PORTAL_CONF.PROTO_CONF;
-    const std::string &server_ip = confManager.PORTAL_CONF.IP;
+    const std::string& server_protoc = confManager.PORTAL_CONF.PROTO_CONF;
+    const std::string& server_ip = confManager.PORTAL_CONF.IP;
     std::string server_port = std::to_string(confManager.PORTAL_CONF.PORT);
     std::string server_provider_id = std::to_string(confManager.PORTAL_CONF.PROVIDER_ID);
     std::string server_address = server_protoc + "://" + server_ip + ":" + server_port + "@" + server_provider_id;
@@ -791,58 +779,52 @@ int main(int argc, char **argv)
     if(workload_args.interactive)
     {
         // Interactive mode, accept commands from stdin
-        std::cout << "Metadata operations: \n" << "\t-c <chronicle_name> , create a Chronicle <chronicle_name>\n"
+        std::cout << "Metadata operations: \n"
+                  << "\t-c <chronicle_name> , create a Chronicle <chronicle_name>\n"
                   << "\t-a -s <chronicle_name> <story_name>, acquire Story <story_name> in Chronicle <chronicle_name>\n"
                   << "\t-w <event_string>, write Event with <event_string> as payload\n"
                   << "\t-r <chronicle_name> <story_name> <start_time> <end_time>, read Events in Story <story_name> of "
                      "Chronicle <chronicle_name> from <start_time> to <end_time>\n"
                   << "\t-q -s <chronicle_name> <story_name>, release Story <story_name> in Chronicle <chronicle_name>\n"
                   << "\t-d -s <chronicle_name> <story_name>, destroy Story <story_name> in Chronicle <chronicle_name>\n"
-                  << "\t-d -c <chronicle_name>, destroy Chronicle <chronicle_name>\n" << "\t-disconnect\n" << std::endl;
+                  << "\t-d -c <chronicle_name>, destroy Chronicle <chronicle_name>\n"
+                  << "\t-disconnect\n"
+                  << std::endl;
 
-        std::unordered_map <std::string, std::function <void(std::vector <std::string> &)>> command_map = {{  "-c", [&](
-std::vector <std::string> &command_subs)
-        {
-            interactive_create_chronicle(command_subs, client);
-        }}
-                                                                                                           , {"-a", [&](
-                        std::vector <std::string> &command_subs)
-                {
-                    if(command_subs[1] == "-s")
-                    {
-                        story_handle = interactive_acquire_story(command_subs, client);
-                    }
-                }}
-                                                                                                           , {"-q", [&](
-                        std::vector <std::string> &command_subs)
-                {
-                    if(command_subs[1] == "-s")
-                    {
-                        interactive_release_story(command_subs, client);
-                    }
-                }}
-                                                                                                           , {"-w", [&](
-                        std::vector <std::string> &command_subs)
-                {
-                    interactive_write_event(command_subs, story_handle);
-                }}
-                                                                                                           , {"-r", [&](
-                        std::vector <std::string> &command_subs)
-                {
-                    interactive_replay_story(command_subs, client);
-                }}
-                                                                                                           , {"-d", [&](
-                        std::vector <std::string> &command_subs)
-                {
-                    if(command_subs[1] == "-c")
-                    {
-                        interactive_destroy_chronicle(command_subs, client);
-                    }
-                    else if(command_subs[1] == "-s")
-                    {
-                        interactive_destroy_story(command_subs, client);
-                    }
-                }}};
+        std::unordered_map<std::string, std::function<void(std::vector<std::string>&)>> command_map = {
+                {"-c",
+                 [&](std::vector<std::string>& command_subs) { interactive_create_chronicle(command_subs, client); }},
+                {"-a",
+                 [&](std::vector<std::string>& command_subs)
+                 {
+                     if(command_subs[1] == "-s")
+                     {
+                         story_handle = interactive_acquire_story(command_subs, client);
+                     }
+                 }},
+                {"-q",
+                 [&](std::vector<std::string>& command_subs)
+                 {
+                     if(command_subs[1] == "-s")
+                     {
+                         interactive_release_story(command_subs, client);
+                     }
+                 }},
+                {"-w",
+                 [&](std::vector<std::string>& command_subs) { interactive_write_event(command_subs, story_handle); }},
+                {"-r", [&](std::vector<std::string>& command_subs) { interactive_replay_story(command_subs, client); }},
+                {"-d",
+                 [&](std::vector<std::string>& command_subs)
+                 {
+                     if(command_subs[1] == "-c")
+                     {
+                         interactive_destroy_chronicle(command_subs, client);
+                     }
+                     else if(command_subs[1] == "-s")
+                     {
+                         interactive_destroy_story(command_subs, client);
+                     }
+                 }}};
 
         std::string command_line;
         while(true)
@@ -850,7 +832,8 @@ std::vector <std::string> &command_subs)
             command_line.clear();
             std::getline(std::cin, command_line);
             command_line = trim_string(command_line);
-            if(command_line == "-disconnect") break;
+            if(command_line == "-disconnect")
+                break;
             command_dispatcher(command_line, command_map);
         }
     }
@@ -861,7 +844,7 @@ std::vector <std::string> &command_subs)
         std::mt19937 gen(rand_device());
         std::uniform_int_distribution char_dist(0, 255);
         double sigma = (double)(workload_args.max_event_size - workload_args.min_event_size) / 6;
-        std::normal_distribution <double> size_dist((double)workload_args.ave_event_size, sigma);
+        std::normal_distribution<double> size_dist((double)workload_args.ave_event_size, sigma);
         MPI_Barrier(MPI_COMM_WORLD);
         for(uint64_t i = 0; i < workload_args.chronicle_count; i++)
         {
@@ -890,20 +873,19 @@ std::vector <std::string> &command_subs)
                 if(workload_args.write && ret_i != chronolog::CL_SUCCESS)
                 {
                     std::cerr << "Failed to acquire story: " << story_name << " in Chronicle: " << chronicle_name
-                                                             << ", ret: " << chronolog::to_string_client(ret_i)
-                                                             << std::endl;
+                              << ", ret: " << chronolog::to_string_client(ret_i) << std::endl;
                     exit(EXIT_FAILURE);
                 }
                 else if(workload_args.read && ret_i == chronolog::CL_ERR_NOT_EXIST)
                 {
                     std::cerr << "Story does not exist: " << story_name << " in Chronicle: " << chronicle_name
-                                                          << ", ret: " << chronolog::to_string_client(ret_i)
-                                                          << std::endl;
-                    std::cout << "Please make sure a write test with the same configuration is executed before the read test."
+                              << ", ret: " << chronolog::to_string_client(ret_i) << std::endl;
+                    std::cout << "Please make sure a write test with the same configuration is executed before the "
+                                 "read test."
                               << std::endl;
                     exit(EXIT_FAILURE);
                 }
-//                std::cout << "Return value of AcquireStory: " << chronolog::to_string_client(ret_i) << std::endl;
+                //                std::cout << "Return value of AcquireStory: " << chronolog::to_string_client(ret_i) << std::endl;
                 if(workload_args.barrier)
                     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -911,125 +893,128 @@ std::vector <std::string> &command_subs)
                 {
                     // replay story test
                     uint64_t start_time = 0, end_time = UINT64_MAX;
-                    std::vector <chronolog::Event> replay_events;
-                    uint64_t event_count_per_story =
-                            workload_args.event_count / workload_args.story_count;
+                    std::vector<chronolog::Event> replay_events;
+                    uint64_t event_count_per_story = workload_args.event_count / workload_args.story_count;
                     event_payload_size_per_rank = 0;
-                    replayStoryTimer.timeBlock([&]()
-                                               {
-                                                   for(uint64_t k = 0; k < event_count_per_story; k++)
-                                                   {
-                                                       ret_u = test_replay_story(client, chronicle_name, story_name, start_time, end_time
-                                                                                 , replay_events);
-                                                       replayStoryTimer.pauseTimer();
-                                                       for(const auto &event: replay_events)
-                                                       {
-                                                           event_payload_size_per_rank += event.log_record().size();
-                                                       }
+                    replayStoryTimer.timeBlock(
+                            [&]()
+                            {
+                                for(uint64_t k = 0; k < event_count_per_story; k++)
+                                {
+                                    ret_u = test_replay_story(client,
+                                                              chronicle_name,
+                                                              story_name,
+                                                              start_time,
+                                                              end_time,
+                                                              replay_events);
+                                    replayStoryTimer.pauseTimer();
+                                    for(const auto& event: replay_events)
+                                    {
+                                        event_payload_size_per_rank += event.log_record().size();
+                                    }
 
-                                                       if(workload_args.event_interval > 0)
-                                                           usleep(workload_args.event_interval);
-                                                   }
-                                               });
+                                    if(workload_args.event_interval > 0)
+                                        usleep(workload_args.event_interval);
+                                }
+                            });
                 }
                 else
                 {
                     // write event test
                     std::string event_payload;
-                    writeEventTimer.timeBlock([&]()
-                                              {
-                                                  uint64_t event_count_per_story =
-                                                          workload_args.event_count / workload_args.story_count;
-                                                  for(uint64_t k = 0; k < event_count_per_story; k++)
-                                                  {
-                                                      if(workload_args.event_payload_file.empty())
-                                                      {
-                                                          // randomly generate events size if range is specified
-                                                          writeEventTimer.pauseTimer();
+                    writeEventTimer.timeBlock(
+                            [&]()
+                            {
+                                uint64_t event_count_per_story = workload_args.event_count / workload_args.story_count;
+                                for(uint64_t k = 0; k < event_count_per_story; k++)
+                                {
+                                    if(workload_args.event_payload_file.empty())
+                                    {
+                                        // randomly generate events size if range is specified
+                                        writeEventTimer.pauseTimer();
 
-                                                          uint64_t event_size;
-                                                          if(workload_args.ave_event_size ==
-                                                             workload_args.min_event_size &&
-                                                             workload_args.ave_event_size ==
-                                                             workload_args.max_event_size)
-                                                          {
-                                                              event_size = workload_args.ave_event_size;
-                                                          }
-                                                          else
-                                                          {
-                                                              event_size = (unsigned long)std::min(
-                                                                      std::max(size_dist(gen),
-                                                                              (double)workload_args.min_event_size *
-                                                                              1.0),
-                                                                      (double)workload_args.max_event_size * 1.0);
-                                                          }
-                                                          event_payload = payload_str.substr(0, event_size);
-                                                          event_payload_size_per_rank += event_size;
-                                                          writeEventTimer.resumeTimer();
-                                                          ret_u = test_write_event(story_handle, event_payload);
-                                                          if(workload_args.barrier)
-                                                              MPI_Barrier(MPI_COMM_WORLD);
+                                        uint64_t event_size;
+                                        if(workload_args.ave_event_size == workload_args.min_event_size &&
+                                           workload_args.ave_event_size == workload_args.max_event_size)
+                                        {
+                                            event_size = workload_args.ave_event_size;
+                                        }
+                                        else
+                                        {
+                                            event_size = (unsigned long)std::min(
+                                                    std::max(size_dist(gen),
+                                                             (double)workload_args.min_event_size * 1.0),
+                                                    (double)workload_args.max_event_size * 1.0);
+                                        }
+                                        event_payload = payload_str.substr(0, event_size);
+                                        event_payload_size_per_rank += event_size;
+                                        writeEventTimer.resumeTimer();
+                                        ret_u = test_write_event(story_handle, event_payload);
+                                        if(workload_args.barrier)
+                                            MPI_Barrier(MPI_COMM_WORLD);
 
-                                                          if(workload_args.event_interval > 0)
-                                                              usleep(workload_args.event_interval);
-                                                      }
-                                                      else
-                                                      {
-                                                          // read event payload from payload file line by line
-                                                          std::ifstream input_file(workload_args.event_payload_file);
+                                        if(workload_args.event_interval > 0)
+                                            usleep(workload_args.event_interval);
+                                    }
+                                    else
+                                    {
+                                        // read event payload from payload file line by line
+                                        std::ifstream input_file(workload_args.event_payload_file);
 
-                                                          // check if the file opened successfully
-                                                          if(input_file.is_open())
-                                                          {
-                                                              writeEventTimer.pauseTimer();
-                                                              uint64_t bigbang_timestamp = get_bigbang_timestamp(
-                                                                      input_file);
-                                                              uint64_t last_event_timestamp = bigbang_timestamp;
-                                                              uint64_t event_timestamp;
-                                                              struct timespec sleep_ts{};
-                                                              while(std::getline(input_file, event_payload))
-                                                              {
-                                                                  if(event_payload.empty()) continue;
-                                                                  event_timestamp = get_event_timestamp(event_payload);
-                                                                  if(event_timestamp < last_event_timestamp)
-                                                                  {
-                                                                      LOG_INFO(
-                                                                              "An Out-of-Order event is found, sleeping for 1 second ...");
-                                                                      sleep_ts.tv_sec = 1;
-                                                                      sleep_ts.tv_nsec = 0;
-                                                                  }
-                                                                  else
-                                                                  {
-                                                                      sleep_ts.tv_sec = (long)(event_timestamp -
-                                                                                               last_event_timestamp) /
-                                                                                        1000000000;
-                                                                      sleep_ts.tv_nsec = (long)(event_timestamp -
-                                                                                                last_event_timestamp) %
-                                                                                         1000000000;
-                                                                  }
-                                                                  // TODO: (Kun) work around on failure when daytime changes
-                                                                  if(sleep_ts.tv_sec > 3600) sleep_ts.tv_sec = 0;
-                                                                  LOG_DEBUG(
-                                                                          "Sleeping for {}.{} seconds to emulate interval between events ..."
-                                                                          , sleep_ts.tv_sec, sleep_ts.tv_nsec);
-                                                                  nanosleep(&sleep_ts, nullptr);
-                                                                  last_event_timestamp = event_timestamp;
-                                                                  event_payload_size_per_rank += event_payload.size();
-                                                                  writeEventTimer.resumeTimer();
-                                                                  ret_u = test_write_event(story_handle, event_payload);
-                                                                  if(workload_args.barrier)
-                                                                      MPI_Barrier(MPI_COMM_WORLD);
-                                                              }
+                                        // check if the file opened successfully
+                                        if(input_file.is_open())
+                                        {
+                                            writeEventTimer.pauseTimer();
+                                            uint64_t bigbang_timestamp = get_bigbang_timestamp(input_file);
+                                            uint64_t last_event_timestamp = bigbang_timestamp;
+                                            uint64_t event_timestamp;
+                                            struct timespec sleep_ts
+                                            {
+                                            };
+                                            while(std::getline(input_file, event_payload))
+                                            {
+                                                if(event_payload.empty())
+                                                    continue;
+                                                event_timestamp = get_event_timestamp(event_payload);
+                                                if(event_timestamp < last_event_timestamp)
+                                                {
+                                                    LOG_INFO("An Out-of-Order event is found, sleeping for 1 second "
+                                                             "...");
+                                                    sleep_ts.tv_sec = 1;
+                                                    sleep_ts.tv_nsec = 0;
+                                                }
+                                                else
+                                                {
+                                                    sleep_ts.tv_sec =
+                                                            (long)(event_timestamp - last_event_timestamp) / 1000000000;
+                                                    sleep_ts.tv_nsec =
+                                                            (long)(event_timestamp - last_event_timestamp) % 1000000000;
+                                                }
+                                                // TODO: (Kun) work around on failure when daytime changes
+                                                if(sleep_ts.tv_sec > 3600)
+                                                    sleep_ts.tv_sec = 0;
+                                                LOG_DEBUG("Sleeping for {}.{} seconds to emulate interval between "
+                                                          "events ...",
+                                                          sleep_ts.tv_sec,
+                                                          sleep_ts.tv_nsec);
+                                                nanosleep(&sleep_ts, nullptr);
+                                                last_event_timestamp = event_timestamp;
+                                                event_payload_size_per_rank += event_payload.size();
+                                                writeEventTimer.resumeTimer();
+                                                ret_u = test_write_event(story_handle, event_payload);
+                                                if(workload_args.barrier)
+                                                    MPI_Barrier(MPI_COMM_WORLD);
+                                            }
 
-                                                              input_file.close();
-                                                          }
-                                                          else
-                                                          {
-                                                              std::cout << "Unable to open the file";
-                                                          }
-                                                      }
-                                                  }
-                                              });
+                                            input_file.close();
+                                        }
+                                        else
+                                        {
+                                            std::cout << "Unable to open the file";
+                                        }
+                                    }
+                                }
+                            });
                 }
 
                 if(workload_args.barrier)
@@ -1069,8 +1054,13 @@ std::vector <std::string> &command_subs)
         MPI_Reduce(&local_e2e_duration, &global_e2e_duration_ave, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
 
         uint64_t total_event_payload_size = 0;
-        MPI_Reduce(&event_payload_size_per_rank, &total_event_payload_size, 1, MPI_UINT64_T, MPI_SUM, 0
-                   , MPI_COMM_WORLD);
+        MPI_Reduce(&event_payload_size_per_rank,
+                   &total_event_payload_size,
+                   1,
+                   MPI_UINT64_T,
+                   MPI_SUM,
+                   0,
+                   MPI_COMM_WORLD);
         if(rank == 0)
         {
             std::cout << "==================================================================" << std::endl;
@@ -1086,11 +1076,13 @@ std::vector <std::string> &command_subs)
             if(workload_args.barrier)
             {
                 connect_thpt = (double)size / connectTimer.getDuration();
-                create_chronicle_thpt = (double)workload_args.chronicle_count * size / createChronicleTimer.getDuration();
+                create_chronicle_thpt =
+                        (double)workload_args.chronicle_count * size / createChronicleTimer.getDuration();
                 acquire_story_thpt = (double)workload_args.story_count * size / acquireStoryTimer.getDuration();
                 release_story_thpt = (double)workload_args.story_count * size / releaseStoryTimer.getDuration();
                 destroy_story_thpt = (double)workload_args.story_count * size / destroyStoryTimer.getDuration();
-                destroy_chronicle_thpt = (double)workload_args.chronicle_count * size / destroyChronicleTimer.getDuration();
+                destroy_chronicle_thpt =
+                        (double)workload_args.chronicle_count * size / destroyChronicleTimer.getDuration();
                 disconnect_thpt = (double)size / disconnectTimer.getDuration();
                 e2e_bandwidth = (double)total_event_payload_size / global_e2e_duration / 1e6;
                 if(workload_args.read)
@@ -1107,23 +1099,26 @@ std::vector <std::string> &command_subs)
             else
             {
                 connect_thpt = (double)size / connectTimer.getDurationAve();
-                create_chronicle_thpt = (double)workload_args.chronicle_count * size / createChronicleTimer.getDurationAve();
+                create_chronicle_thpt =
+                        (double)workload_args.chronicle_count * size / createChronicleTimer.getDurationAve();
                 acquire_story_thpt = (double)workload_args.story_count * size / acquireStoryTimer.getDurationAve();
                 release_story_thpt = (double)workload_args.story_count * size / releaseStoryTimer.getDurationAve();
                 destroy_story_thpt = (double)workload_args.story_count * size / destroyStoryTimer.getDurationAve();
-                destroy_chronicle_thpt = (double)workload_args.chronicle_count * size / destroyChronicleTimer.getDurationAve();
+                destroy_chronicle_thpt =
+                        (double)workload_args.chronicle_count * size / destroyChronicleTimer.getDurationAve();
                 disconnect_thpt = (double)size / disconnectTimer.getDurationAve();
                 e2e_bandwidth = (double)total_event_payload_size / global_e2e_duration / 1e6;
                 if(workload_args.read)
                 {
                     replay_story_bw = (double)total_event_payload_size / replayStoryTimer.getDurationAve() / 1e6;
-                    replay_story_thpt = (double)workload_args.event_count * size / replayStoryTimer.getDurationAve() / 1e6;
-
+                    replay_story_thpt =
+                            (double)workload_args.event_count * size / replayStoryTimer.getDurationAve() / 1e6;
                 }
                 else
                 {
                     record_event_bw = (double)total_event_payload_size / writeEventTimer.getDurationAve() / 1e6;
-                    record_event_thpt = (double)workload_args.event_count * size / writeEventTimer.getDurationAve() / 1e6;
+                    record_event_thpt =
+                            (double)workload_args.event_count * size / writeEventTimer.getDurationAve() / 1e6;
                 }
             }
             std::cout << "Connect throughput: " << connect_thpt << " connections/s" << std::endl;
@@ -1136,13 +1131,17 @@ std::vector <std::string> &command_subs)
             std::cout << "End-to-end (incl. metadata time) bandwidth: " << e2e_bandwidth << " MB/s" << std::endl;
             if(workload_args.read)
             {
-                std::cout << "Replay-story (incl. metadata time) bandwidth: " << replay_story_bw << " MB/s" << std::endl;
-                std::cout << "Replay-story (incl. metadata time) throughput: " << replay_story_thpt << " events/s" << std::endl;
+                std::cout << "Replay-story (incl. metadata time) bandwidth: " << replay_story_bw << " MB/s"
+                          << std::endl;
+                std::cout << "Replay-story (incl. metadata time) throughput: " << replay_story_thpt << " events/s"
+                          << std::endl;
             }
             else
             {
-                std::cout << "Record-event (incl. metadata time) bandwidth: " << record_event_bw << " MB/s" << std::endl;
-                std::cout << "Record-event (incl. metadata time) throughput: " << record_event_thpt << " events/s" << std::endl;
+                std::cout << "Record-event (incl. metadata time) bandwidth: " << record_event_bw << " MB/s"
+                          << std::endl;
+                std::cout << "Record-event (incl. metadata time) throughput: " << record_event_thpt << " events/s"
+                          << std::endl;
             }
         }
     }


### PR DESCRIPTION
I've been working on task #426 (Add Discovery Support) and discovered some hidden dependency issues that were masked by our current CMake structure. This PR fixes the first part - making all source files self-contained with explicit includes.

**What this fixes:**
- Files now explicitly include all headers they use (system, standard library, third-party, and project headers)
- Eliminates hidden dependencies that were working "by accident" through transitive includes
- Makes the codebase more maintainable and portable

**Why this matters:**
- The CMake restructuring for discovery support exposed these hidden dependencies
- Files were breaking because they relied on includes from other files
- This is a foundation fix that enables the larger discovery implementation

**Impact:**
- Build process is actually cleaner now (fewer warnings, more predictable)
- Each file is self-contained and explicit about its dependencies
- Enables proper CMake organization for the discovery features

**Next steps:**
- Issue #457 created for the CMake include directories part
- Once both issues are resolved, we can proceed with the discovery implementation

This is a low-risk change that just makes dependencies explicit. The build should be more robust and the code easier to understand.