### PR TITLE
Fix incomplete string concatenation in KeeperRegistrationMsg::to_string()

### DIFF
--- a/chrono_common/include/KeeperRegistrationMsg.h
+++ b/chrono_common/include/KeeperRegistrationMsg.h
@@ -42,8 +42,8 @@ public:
 
 inline std::string to_string(chronolog::KeeperRegistrationMsg const & msg)
 {
-    return std::string("KeeperRegistrationMsg{") + to_string(msg.getKeeperIdCard()) + "}";
-        std::string( "}{admin:") + to_string(msg.getAdminServiceId()) + "}";
+    return std::string("KeeperRegistrationMsg{") + to_string(msg.getKeeperIdCard()) + 
+           "}{admin:" + to_string(msg.getAdminServiceId()) + "}";
 }
 
 

--- a/chrono_common/include/KeeperRegistrationMsg.h
+++ b/chrono_common/include/KeeperRegistrationMsg.h
@@ -25,37 +25,34 @@ public:
 
     ~KeeperRegistrationMsg() = default;
 
-    KeeperIdCard const &getKeeperIdCard() const
-    { return keeperIdCard; }
+    KeeperIdCard const& getKeeperIdCard() const { return keeperIdCard; }
 
-    ServiceId const &getAdminServiceId() const
-    { return adminServiceId; }
+    ServiceId const& getAdminServiceId() const { return adminServiceId; }
 
     template <typename SerArchiveT>
-    void serialize(SerArchiveT & serT)
+    void serialize(SerArchiveT& serT)
     {
         serT & keeperIdCard;
         serT & adminServiceId;
     }
-
 };
 
-inline std::string to_string(chronolog::KeeperRegistrationMsg const & msg)
+inline std::string to_string(chronolog::KeeperRegistrationMsg const& msg)
 {
-    return std::string("KeeperRegistrationMsg{") + to_string(msg.getKeeperIdCard()) + 
+    return std::string("KeeperRegistrationMsg{") + to_string(msg.getKeeperIdCard()) +
            "}{admin:" + to_string(msg.getAdminServiceId()) + "}";
 }
 
 
-}//namespace
+} // namespace chronolog
 
-inline std::ostream &operator<<(std::ostream &out, chronolog::KeeperRegistrationMsg const &msg)
+inline std::ostream& operator<<(std::ostream& out, chronolog::KeeperRegistrationMsg const& msg)
 {
     out << "KeeperRegistrationMsg{" << msg.getKeeperIdCard() << "}{admin:" << msg.getAdminServiceId() << "}";
     return out;
 }
 
-inline std::string & operator+= (std::string &a_string, chronolog::KeeperRegistrationMsg const & msg)
+inline std::string& operator+=(std::string& a_string, chronolog::KeeperRegistrationMsg const& msg)
 {
     a_string += chronolog::to_string(msg);
     return a_string;


### PR DESCRIPTION
Fix a bug where the to_string() function created an unused string concatenation, causing compiler warnings and incomplete output. Combine the string concatenations into a single return statement to properly serialize the admin service ID.