### PR TITLE
Update pre-commit hook to use proper clang-format-18

### DIFF
--- a/CodeStyleFiles/pre-commit
+++ b/CodeStyleFiles/pre-commit
@@ -3,15 +3,22 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
+# Git runs hooks with a minimal PATH (often without ~/.local/bin, etc.).
+# Prepend common locations so clang-format is found when installed there.
+export PATH="${HOME}/.local/bin:/usr/local/bin:/usr/bin:${PATH}"
+
 # Get the root directory of the Git repository
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 # Adjust path to clang-format config if needed
 FORMAT_STYLE=file:"$REPO_ROOT/CodeStyleFiles/ChronoLog.clang-format"
 
-# Check if clang-format is installed
-if ! command -v clang-format &> /dev/null; then
-  echo "Error: clang-format is not installed or not in PATH."
+# Use clang-format-18 by default; override with CLANG_FORMAT if needed
+CLANG_FORMAT_CMD="${CLANG_FORMAT:-clang-format-18}"
+if ! command -v "$CLANG_FORMAT_CMD" &> /dev/null; then
+  echo "Error: clang-format-18 is not installed or not in PATH."
+  echo "If it is installed, ensure it is in one of: $HOME/.local/bin, /usr/local/bin, /usr/bin"
+  echo "Or set CLANG_FORMAT to the binary name or path (e.g. export CLANG_FORMAT=clang-format-18)."
   exit 1
 fi
 
@@ -32,7 +39,7 @@ fi
 # Format and re-stage each file
 for file in "${FILES[@]}"; do
   if [ -f "$file" ]; then
-    clang-format -style="$FORMAT_STYLE" -i "$file"
+    "$CLANG_FORMAT_CMD" -style="$FORMAT_STYLE" -i "$file"
     git add "$file"
   fi
 done

--- a/CodeStyleFiles/pre-commit
+++ b/CodeStyleFiles/pre-commit
@@ -3,26 +3,37 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-# Git runs hooks with a minimal PATH (often without ~/.local/bin, etc.).
-# Prepend common locations so clang-format is found when installed there.
-# Only change PATH when this script is run (not sourced), to avoid modifying the parent shell.
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  export PATH="${HOME}/.local/bin:/usr/local/bin:/usr/bin:${PATH}"
-fi
-
 # Get the root directory of the Git repository
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 # Adjust path to clang-format config if needed
 FORMAT_STYLE=file:"$REPO_ROOT/CodeStyleFiles/ChronoLog.clang-format"
 
-# Use clang-format-18 by default; override with CLANG_FORMAT if needed
-CLANG_FORMAT_CMD="${CLANG_FORMAT:-clang-format-18}"
-if ! command -v "$CLANG_FORMAT_CMD" &> /dev/null; then
-  echo "Error: clang-format-18 is not installed or not in PATH."
-  echo "If it is installed, ensure it is in one of: $HOME/.local/bin, /usr/local/bin, /usr/bin"
-  echo "Or set CLANG_FORMAT to the binary name or path (e.g. export CLANG_FORMAT=clang-format-18)."
-  exit 1
+# Resolve clang-format: search custom paths and PATH without modifying parent shell
+CLANG_FORMAT_NAME="${CLANG_FORMAT:-clang-format-18}"
+CLANG_FORMAT_CMD=
+if [[ -n "${CLANG_FORMAT:-}" && "$CLANG_FORMAT" == /* ]] && [ -x "$CLANG_FORMAT" ]; then
+  CLANG_FORMAT_CMD="$CLANG_FORMAT"
+else
+  SEARCH_DIRS=( "${HOME}/.local/bin" "/usr/local/bin" "/usr/bin" )
+  for d in "${SEARCH_DIRS[@]}"; do
+    if [ -x "$d/$CLANG_FORMAT_NAME" ]; then
+      CLANG_FORMAT_CMD="$d/$CLANG_FORMAT_NAME"
+      break
+    fi
+  done
+  if [[ -z "$CLANG_FORMAT_CMD" ]]; then
+    found=$(command -v "$CLANG_FORMAT_NAME" 2>/dev/null) || true
+    if [[ -n "$found" ]]; then
+      CLANG_FORMAT_CMD=$found
+    fi
+  fi
+  if [[ -z "$CLANG_FORMAT_CMD" ]]; then
+    echo "Error: clang-format-18 is not installed or not in PATH."
+    echo "If it is installed, ensure it is in one of: $HOME/.local/bin, /usr/local/bin, /usr/bin"
+    echo "Or set CLANG_FORMAT to the binary name or path (e.g. export CLANG_FORMAT=clang-format-18)."
+    exit 1
+  fi
 fi
 
 # Check if the clang-format configuration file exists

--- a/CodeStyleFiles/pre-commit
+++ b/CodeStyleFiles/pre-commit
@@ -5,7 +5,10 @@ set -e
 
 # Git runs hooks with a minimal PATH (often without ~/.local/bin, etc.).
 # Prepend common locations so clang-format is found when installed there.
-export PATH="${HOME}/.local/bin:/usr/local/bin:/usr/bin:${PATH}"
+# Only change PATH when this script is run (not sourced), to avoid modifying the parent shell.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  export PATH="${HOME}/.local/bin:/usr/local/bin:/usr/bin:${PATH}"
+fi
 
 # Get the root directory of the Git repository
 REPO_ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
A while ago, we updated the clang-format-18 version that was used on the github action, but we never updated the pre-commit file. This issue fixes this problem.