### PR TITLE
Use usleep instead to allow OS thread to actually sleep

### DIFF
--- a/chrono_common/include/StoryChunkExtractionModule.h
+++ b/chrono_common/include/StoryChunkExtractionModule.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <type_traits>
 
+#include <unistd.h>
 #include <atomic>
 #include <thallium.hpp>
 
@@ -130,7 +131,7 @@ public:
             }
             else
             {
-                tl::thread::self().yield();
+                usleep(1000);   // 1 ms: allow OS thread to sleep when queue is idle
             }
         }
     }

--- a/chrono_common/include/StoryChunkExtractionModule.h
+++ b/chrono_common/include/StoryChunkExtractionModule.h
@@ -131,7 +131,7 @@ public:
             }
             else
             {
-                usleep(1000);   // 1 ms: allow OS thread to sleep when queue is idle
+                usleep(1000); // 1 ms: allow OS thread to sleep when queue is idle
             }
         }
     }


### PR DESCRIPTION
Changes in this PR:

- Fix the bug that `chrono-keeper` and `chrono-grapher` keep the CPU frequency high even without any data access immediately after deployment.