### PR TITLE
Docker Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,10 @@ on:
     branches: [develop, main]
   push:
     branches: [develop, main]
-    paths:
-      - 'spack.yaml'
-      - 'Client/spack.yaml'
-      - '.github/docker/**'
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/chronolog-ci
   INSTALL_BASE: /home/grc-iit/chronolog-install
 
 jobs:
@@ -43,12 +38,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set repository name (lowercase)
-        id: repo-name
-        run: |
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          echo "name=${REPO_LOWER}" >> $GITHUB_OUTPUT
-
       - name: Compute base image hash
         id: basehash
         run: |
@@ -57,10 +46,10 @@ jobs:
       - name: Set base image name (immutable)
         id: set-base-image-name
         run: |
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           HASH="${{ steps.basehash.outputs.hash }}"
-          TAG="base-${HASH}"
-          echo "full-name=ghcr.io/${REPO_LOWER}/chronolog:${TAG}" >> $GITHUB_OUTPUT
+          TAG="sha-${HASH}"
+          echo "full-name=ghcr.io/${OWNER}/chronolog-base:${TAG}" >> $GITHUB_OUTPUT
           echo "Base image tag: ${TAG}"
 
       - name: Try to pull cached base image
@@ -167,9 +156,8 @@ jobs:
       - name: Set final image name
         id: set-final-image-name
         run: |
-          # Convert repository name to lowercase (Docker requirement)
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+
           # Use branch name for Docker image tag
           # For PRs, use the head branch; for pushes, use the current branch
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -177,13 +165,12 @@ jobs:
           else
             BRANCH_NAME="${{ github.ref_name }}"
           fi
-          
+
           # Sanitize branch name for Docker tag (replace / with -, remove invalid characters)
           BRANCH_TAG=$(echo "$BRANCH_NAME" | sed 's/\//-/g' | sed 's/[^a-zA-Z0-9._-]/-/g')
-          
-          TAG="chronolog-${BRANCH_TAG}"
-          echo "full-name=ghcr.io/${REPO_LOWER}/chronolog:${TAG}" >> $GITHUB_OUTPUT
-          echo "Final image tag: ${TAG} (from branch: ${BRANCH_NAME})"
+
+          echo "full-name=ghcr.io/${OWNER}/chronolog-ci:${BRANCH_TAG}" >> $GITHUB_OUTPUT
+          echo "Final image tag: ${BRANCH_TAG} (from branch: ${BRANCH_NAME})"
 
       - name: Create container for build and deploy
         id: create-container
@@ -508,8 +495,8 @@ jobs:
           IMAGE_NAME="${{ needs.local-deployment.outputs.image-name }}"
           echo "Pulling final image from local deployment: ${IMAGE_NAME}"
           docker pull "${IMAGE_NAME}"
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          docker tag "${IMAGE_NAME}" "ghcr.io/${REPO_LOWER}/chronolog:latest"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          docker tag "${IMAGE_NAME}" "ghcr.io/${OWNER}/chronolog-ci:latest"
           echo "✅ Successfully pulled and tagged image"
 
       - name: Set up distributed deployment
@@ -519,10 +506,10 @@ jobs:
           NUM_KEEPERS=2
           NUM_GRAPHERS=2
           NUM_PLAYERS=2
-          
+
           # Use the image from local deployment
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          BASE_IMAGE="ghcr.io/${REPO_LOWER}/chronolog:latest"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          BASE_IMAGE="ghcr.io/${OWNER}/chronolog-ci:latest"
           
           # Generate the docker-compose file dynamically
           cat > dynamic-compose.yaml <<EOF
@@ -1069,3 +1056,130 @@ jobs:
         run: |
           docker compose -f dynamic-compose.yaml down -v
           echo "✅ Containers cleaned up"
+
+  publish-dev-image:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-24.04
+    needs: chronolog-base
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image metadata
+        id: meta
+        run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "owner=${OWNER}" >> $GITHUB_OUTPUT
+
+      - name: Pull base Docker image
+        run: |
+          docker pull "${{ needs.chronolog-base.outputs.image-name }}"
+
+      - name: Create container for dev build
+        id: create-container
+        run: |
+          set -e
+          BASE_IMAGE="${{ needs.chronolog-base.outputs.image-name }}"
+          CONTAINER_ID=$(docker create --user root --init \
+            -v "${{ github.workspace }}:/home/grc-iit/chronolog-repo" \
+            -w /home/grc-iit/chronolog-repo \
+            "$BASE_IMAGE" \
+            bash -c "chown -R grc-iit:grc-iit /home/grc-iit/chronolog-repo && tail -f /dev/null")
+          echo "container-id=${CONTAINER_ID}" >> $GITHUB_OUTPUT
+          docker start "$CONTAINER_ID"
+
+      - name: Reconcretize Spack environment
+        run: |
+          set -e
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          docker exec "$CONTAINER_ID" bash -c "
+            set -e
+            source /home/grc-iit/spack/share/spack/setup-env.sh
+            spack env activate -p .
+            if [ ! -d \".spack-env/view\" ] || [ ! -d \".spack-env/view/bin\" ] || [ ! -d \".spack-env/view/lib\" ]; then
+              spack concretize --force
+            fi
+          "
+
+      - name: Build Debug
+        run: |
+          set -e
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          docker exec "$CONTAINER_ID" bash -c "
+            set -e
+            source /home/grc-iit/spack/share/spack/setup-env.sh
+            spack env activate -p .
+            mkdir -p /home/grc-iit/chronolog-install
+            chown -R grc-iit:grc-iit /home/grc-iit/chronolog-install || true
+            ./tools/deploy/ChronoLog/build.sh -t Debug -I /home/grc-iit/chronolog-install
+          "
+
+      - name: Install Debug
+        run: |
+          set -e
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          docker exec "$CONTAINER_ID" bash -c "
+            set -e
+            source /home/grc-iit/spack/share/spack/setup-env.sh
+            spack env activate -p .
+            ./tools/deploy/ChronoLog/install.sh -t Debug -I /home/grc-iit/chronolog-install
+          "
+
+      - name: Prepare image for publishing
+        run: |
+          set -e
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          docker exec "$CONTAINER_ID" bash -c "
+            set -e
+            # Copy source into container (bind-mount content does not survive docker commit)
+            cp -a /home/grc-iit/chronolog-repo /home/grc-iit/chronolog-src
+            # Remove build artifacts to reduce image size
+            rm -rf /home/grc-iit/chronolog-build
+            # Add runtime environment to bashrc
+            echo 'export PATH=/home/grc-iit/chronolog-install/chronolog/bin:\$PATH' >> /home/grc-iit/.bashrc
+            echo 'export LD_LIBRARY_PATH=/home/grc-iit/chronolog-install/chronolog/lib:\$LD_LIBRARY_PATH' >> /home/grc-iit/.bashrc
+            echo 'cd /home/grc-iit/chronolog-src' >> /home/grc-iit/.bashrc
+          "
+
+      - name: Commit and push dev image
+        run: |
+          set -e
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          OWNER="${{ steps.meta.outputs.owner }}"
+
+          docker stop "$CONTAINER_ID"
+          docker commit \
+            --change 'ENV PATH=/home/grc-iit/chronolog-install/chronolog/bin:$PATH' \
+            --change 'ENV LD_LIBRARY_PATH=/home/grc-iit/chronolog-install/chronolog/lib' \
+            --change 'ENV CHRONOLOG_HOME=/home/grc-iit/chronolog-install/chronolog' \
+            --change 'LABEL org.opencontainers.image.title=ChronoLog Developer Image' \
+            --change 'LABEL org.opencontainers.image.description=Debug build with source code for development' \
+            --change "LABEL org.opencontainers.image.revision=${{ github.sha }}" \
+            --change 'LABEL org.opencontainers.image.source=https://github.com/grc-iit/ChronoLog' \
+            --change 'USER grc-iit' \
+            --change 'WORKDIR /home/grc-iit/chronolog-src' \
+            "$CONTAINER_ID" "ghcr.io/${OWNER}/chronolog-dev:develop"
+
+          docker push "ghcr.io/${OWNER}/chronolog-dev:develop"
+
+      - name: Clean up
+        if: always()
+        run: |
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          docker stop "$CONTAINER_ID" 2>/dev/null || true
+          docker rm "$CONTAINER_ID" 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Set base image name
         id: set-base-image-name
         run: |
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           HASH="${{ steps.basehash.outputs.hash }}"
-          TAG="base-${HASH}"
-          echo "full-name=ghcr.io/${REPO_LOWER}/chronolog:${TAG}" >> $GITHUB_OUTPUT
+          TAG="sha-${HASH}"
+          echo "full-name=ghcr.io/${OWNER}/chronolog-base:${TAG}" >> $GITHUB_OUTPUT
           echo "Base image tag: ${TAG}"
 
       - name: Try to pull cached base image
@@ -120,7 +120,7 @@ jobs:
     needs: base-image
     permissions:
       contents: read
-      packages: read
+      packages: write
     timeout-minutes: 120
     outputs:
       version: ${{ steps.extract-version.outputs.version }}
@@ -215,6 +215,58 @@ jobs:
             ls \"\${BUILD_DIR}/\"chronolog-*-linux-*.tar.gz
           "
 
+      - name: Copy Release tarball out of container
+        run: |
+          set -e
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          mkdir -p /tmp/chronolog-artifacts
+          RELEASE_TAR=$(docker exec "$CONTAINER_ID" bash -c \
+            "ls \$HOME/chronolog-build/Release/chronolog-*-linux-x86_64.tar.gz 2>/dev/null | head -1")
+          echo "Release tarball: ${RELEASE_TAR}"
+          docker exec "$CONTAINER_ID" bash -c "cat '${RELEASE_TAR}'" \
+            > /tmp/chronolog-artifacts/$(basename "${RELEASE_TAR}")
+
+      - name: Commit release Docker image
+        run: |
+          set -e
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          VERSION="${{ steps.extract-version.outputs.version }}"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+
+          # Clean build artifacts and prepare image environment
+          docker exec "$CONTAINER_ID" bash -c "
+            set -e
+            rm -rf /home/grc-iit/chronolog-build
+            echo 'export PATH=${{ env.RELEASE_INSTALL }}/chronolog/bin:\$PATH' >> /home/grc-iit/.bashrc
+            echo 'export LD_LIBRARY_PATH=${{ env.RELEASE_INSTALL }}/chronolog/lib:\$LD_LIBRARY_PATH' >> /home/grc-iit/.bashrc
+          "
+
+          # Commit the running container as the release image
+          docker commit \
+            --change 'ENV PATH=${{ env.RELEASE_INSTALL }}/chronolog/bin:$PATH' \
+            --change 'ENV LD_LIBRARY_PATH=${{ env.RELEASE_INSTALL }}/chronolog/lib' \
+            --change 'ENV CHRONOLOG_HOME=${{ env.RELEASE_INSTALL }}/chronolog' \
+            --change 'LABEL org.opencontainers.image.title=ChronoLog' \
+            --change "LABEL org.opencontainers.image.version=${VERSION}" \
+            --change 'LABEL org.opencontainers.image.source=https://github.com/grc-iit/ChronoLog' \
+            --change 'USER grc-iit' \
+            --change 'WORKDIR ${{ env.RELEASE_INSTALL }}/chronolog' \
+            "$CONTAINER_ID" "ghcr.io/${OWNER}/chronolog:v${VERSION}"
+
+          docker tag "ghcr.io/${OWNER}/chronolog:v${VERSION}" \
+                     "ghcr.io/${OWNER}/chronolog:latest"
+
+          echo "Release image committed: ghcr.io/${OWNER}/chronolog:v${VERSION}"
+
+      - name: Push release Docker image
+        run: |
+          set -e
+          VERSION="${{ steps.extract-version.outputs.version }}"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          docker push "ghcr.io/${OWNER}/chronolog:v${VERSION}"
+          docker push "ghcr.io/${OWNER}/chronolog:latest"
+          echo "Release images pushed to GHCR"
+
       - name: Build Debug package
         run: |
           set -e
@@ -253,24 +305,13 @@ jobs:
             ls \"\${BUILD_DIR}/\"chronolog-*-linux-*-debug.tar.gz
           "
 
-      - name: Copy tarballs out of container
+      - name: Copy Debug tarball out of container
         run: |
           set -e
           CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
-          mkdir -p /tmp/chronolog-artifacts
-
-          # Locate the tarballs by glob (CPack uses CHRONOLOG_PACKAGE_VERSION from
-          # CMakeLists.txt, which may differ from the git tag suffix)
-          RELEASE_TAR=$(docker exec "$CONTAINER_ID" bash -c \
-            "ls \$HOME/chronolog-build/Release/chronolog-*-linux-x86_64.tar.gz 2>/dev/null | head -1")
           DEBUG_TAR=$(docker exec "$CONTAINER_ID" bash -c \
             "ls \$HOME/chronolog-build/Debug/chronolog-*-linux-x86_64-debug.tar.gz 2>/dev/null | head -1")
-
-          echo "Release tarball: ${RELEASE_TAR}"
-          echo "Debug tarball:   ${DEBUG_TAR}"
-
-          docker exec "$CONTAINER_ID" bash -c "cat '${RELEASE_TAR}'" \
-            > /tmp/chronolog-artifacts/$(basename "${RELEASE_TAR}")
+          echo "Debug tarball: ${DEBUG_TAR}"
           docker exec "$CONTAINER_ID" bash -c "cat '${DEBUG_TAR}'" \
             > /tmp/chronolog-artifacts/$(basename "${DEBUG_TAR}")
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for CI and release processes, with a focus on improving Docker image naming consistency, simplifying image tagging logic, and adding automated publishing of a developer image on pushes to the `develop` branch. The changes also enhance artifact handling and permissions in the release workflow.

**Docker image naming and tagging improvements:**

- Standardized Docker image naming to use the lowercased repository owner (`github.repository_owner`) instead of the full repository name, ensuring more predictable and consistent image names and tags across all workflow steps. This affects both CI and release workflows. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL60-R52) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL170-R159) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL184-R173) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL511-R499) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL524-R512) [[6]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L54-R57)

**CI workflow enhancements:**

- Removed unnecessary path filters and environment variables from the CI workflow to streamline execution and reduce maintenance overhead. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL8-L16) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL46-L51)
- Added a new `publish-dev-image` job that automatically builds and pushes a developer/debug Docker image (`chronolog-dev:develop`) to GHCR on every push to the `develop` branch. This job includes steps for reconcretizing the Spack environment, building and installing the Debug target, preparing the image, and cleaning up resources.

**Release workflow enhancements:**

- Updated permissions to allow package publishing (`packages: write`) and improved artifact handling by separately copying release and debug tarballs out of the build container. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L123-R123) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R218-R269) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L256-L273)
- Added explicit steps to commit and push release Docker images (`chronolog:v<version>` and `chronolog:latest`) to GHCR, ensuring that images are properly labeled and tagged with version information.

These changes make the CI/CD pipeline more robust, maintainable, and better aligned with best practices for Docker image management and artifact publishing.