### PR TITLE
Standardize dockerfiles with versions, users and paths

### DIFF
--- a/.github/docker/dockerfile
+++ b/.github/docker/dockerfile
@@ -43,39 +43,33 @@ RUN id $UID && userdel $(id -un $UID) || : \
  && echo "$USERNAME ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME \
  && passwd -d $USERNAME
 
-# Setup user's home directory and bashrc (matching local.dockerfile)
-RUN mkdir -p /home/$USERNAME \
- && chown -R $USERNAME:$USERNAME /home/$USERNAME
-
-# Switch to user to install Spack in their home directory (matching local.dockerfile)
+# Switch to user to install Spack in their home directory
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
-# Clone Spack to user's home directory (matching local.dockerfile)
+# Clone Spack to user's home directory
 RUN git clone --branch v0.21.2 https://github.com/spack/spack.git ~/spack
 
 # Setup Spack in PATH (using user's home directory)
 ENV SPACK_ROOT=/home/$USERNAME/spack
 ENV PATH=$SPACK_ROOT/bin:$PATH
 
-# Source Spack in user's bashrc (matching local.dockerfile)
+# Source Spack in user's bashrc
 RUN printf '%s\n' \
     'source ~/spack/share/spack/setup-env.sh' \
     'export USER=grc-iit' \
     >> ~/.bashrc
 
-# Switch back to root for system-wide Spack access (for CI workflow)
+# Source Spack in system bashrc so root can also use it (needed for CI chown steps)
 USER root
-
-# Source Spack in system bashrc for root access
 RUN echo "source /home/$USERNAME/spack/share/spack/setup-env.sh" >> /etc/bash.bashrc
 
-# Create chronolog-repo directory (matching local.dockerfile)
+# Create chronolog-repo directory with correct ownership
 RUN mkdir -p /home/$USERNAME/chronolog-repo \
  && chown -R $USERNAME:$USERNAME /home/$USERNAME/chronolog-repo
 
-# Set working directory to user's home (matching local.dockerfile)
-# The workflow will mount code to /home/$USERNAME/chronolog-repo and use -w to set working directory
+# Return to grc-iit user; CI workflows override with --user root when needed
+USER $USERNAME
 WORKDIR /home/$USERNAME
 
 # Welcome message

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -115,7 +115,7 @@ jobs:
           echo "Pushing base image: ${{ steps.set-base-image-name.outputs.full-name }}"
           docker push "${{ steps.set-base-image-name.outputs.full-name }}"
 
-  publish-docker-image:
+  publish-docker-release-image:
     runs-on: ubuntu-24.04
     needs: base-image
     permissions:
@@ -290,7 +290,7 @@ jobs:
           path: /tmp/chronolog-artifacts/*.tar.gz
           retention-days: 7
 
-  publish-debug-image:
+  publish-docker-debug-image:
     runs-on: ubuntu-24.04
     needs: base-image
     permissions:
@@ -421,7 +421,7 @@ jobs:
             --change 'ENV PATH=${{ env.DEBUG_INSTALL }}/chronolog/bin:$PATH' \
             --change 'ENV LD_LIBRARY_PATH=${{ env.DEBUG_INSTALL }}/chronolog/lib' \
             --change 'ENV CHRONOLOG_HOME=${{ env.DEBUG_INSTALL }}/chronolog' \
-            --change 'LABEL org.opencontainers.image.title=ChronoLog Debug' \
+            --change 'LABEL org.opencontainers.image.title="ChronoLog Debug"' \
             --change "LABEL org.opencontainers.image.version=${VERSION}" \
             --change 'LABEL org.opencontainers.image.source=https://github.com/grc-iit/ChronoLog' \
             --change 'USER grc-iit' \
@@ -455,7 +455,7 @@ jobs:
 
   publish-release:
     runs-on: ubuntu-24.04
-    needs: [publish-docker-image, publish-debug-image]
+    needs: [publish-docker-release-image, publish-docker-debug-image]
     permissions:
       contents: write
     timeout-minutes: 30
@@ -464,20 +464,20 @@ jobs:
       - name: Download Release tarball
         uses: actions/download-artifact@v4
         with:
-          name: chronolog-${{ needs.publish-docker-image.outputs.version }}-release-tarball
+          name: chronolog-${{ needs.publish-docker-release-image.outputs.version }}-release-tarball
           path: /tmp/chronolog-artifacts
 
       - name: Download Debug tarball
         uses: actions/download-artifact@v4
         with:
-          name: chronolog-${{ needs.publish-debug-image.outputs.version }}-debug-tarball
+          name: chronolog-${{ needs.publish-docker-debug-image.outputs.version }}-debug-tarball
           path: /tmp/chronolog-artifacts
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
-          name: ChronoLog ${{ needs.publish-docker-image.outputs.version }}
+          name: ChronoLog ${{ needs.publish-docker-release-image.outputs.version }}
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,8 +13,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  RELEASE_INSTALL: /home/grc-iit/chronolog-release-install
-  DEBUG_INSTALL: /home/grc-iit/chronolog-debug-install
+  RELEASE_INSTALL: /home/grc-iit/chronolog-install
+  DEBUG_INSTALL: /home/grc-iit/chronolog-install
 
 jobs:
   base-image:
@@ -165,10 +165,10 @@ jobs:
           set -e
           BASE_IMAGE="${{ needs.base-image.outputs.image-name }}"
           CONTAINER_ID=$(docker create --user root --init \
-            -v "${{ github.workspace }}:/home/grc-iit/chronolog-repo" \
-            -w /home/grc-iit/chronolog-repo \
+            -v "${{ github.workspace }}:/tmp/chronolog-src" \
+            -w /tmp/chronolog-src \
             "$BASE_IMAGE" \
-            bash -c "chown -R grc-iit:grc-iit /home/grc-iit/chronolog-repo && tail -f /dev/null")
+            bash -c "chown -R grc-iit:grc-iit /tmp/chronolog-src && tail -f /dev/null")
           echo "container-id=${CONTAINER_ID}" >> $GITHUB_OUTPUT
           docker start "$CONTAINER_ID"
 
@@ -245,6 +245,7 @@ jobs:
           docker exec "$CONTAINER_ID" bash -c "
             set -e
             rm -rf /home/grc-iit/chronolog-build
+            chown -R grc-iit:grc-iit '${{ env.RELEASE_INSTALL }}'
             echo 'export PATH=${{ env.RELEASE_INSTALL }}/chronolog/bin:\$PATH' >> /home/grc-iit/.bashrc
             echo 'export LD_LIBRARY_PATH=${{ env.RELEASE_INSTALL }}/chronolog/lib:\$LD_LIBRARY_PATH' >> /home/grc-iit/.bashrc
           "
@@ -289,13 +290,15 @@ jobs:
           path: /tmp/chronolog-artifacts/*.tar.gz
           retention-days: 7
 
-  publish-release:
+  publish-debug-image:
     runs-on: ubuntu-24.04
-    needs: publish-docker-image
+    needs: base-image
     permissions:
-      contents: write
-      packages: read
+      contents: read
+      packages: write
     timeout-minutes: 120
+    outputs:
+      version: ${{ steps.extract-version.outputs.version }}
 
     steps:
       - name: Checkout code
@@ -304,6 +307,14 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           fetch-depth: 0
 
+      - name: Extract version from tag
+        id: extract-version
+        run: |
+          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Building debug packages for version: ${VERSION}"
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -311,20 +322,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull release Docker image
+      - name: Pull base Docker image
         run: |
-          docker pull "${{ needs.publish-docker-image.outputs.image-name }}"
+          docker pull "${{ needs.base-image.outputs.image-name }}"
 
-      - name: Create and start container from release image
+      - name: Create and start container
         id: create-container
         run: |
           set -e
-          RELEASE_IMAGE="${{ needs.publish-docker-image.outputs.image-name }}"
+          BASE_IMAGE="${{ needs.base-image.outputs.image-name }}"
           CONTAINER_ID=$(docker create --user root --init \
-            -v "${{ github.workspace }}:/home/grc-iit/chronolog-repo" \
-            -w /home/grc-iit/chronolog-repo \
-            "$RELEASE_IMAGE" \
-            bash -c "chown -R grc-iit:grc-iit /home/grc-iit/chronolog-repo && tail -f /dev/null")
+            -v "${{ github.workspace }}:/tmp/chronolog-src" \
+            -w /tmp/chronolog-src \
+            "$BASE_IMAGE" \
+            bash -c "chown -R grc-iit:grc-iit /tmp/chronolog-src && tail -f /dev/null")
           echo "container-id=${CONTAINER_ID}" >> $GITHUB_OUTPUT
           docker start "$CONTAINER_ID"
 
@@ -390,6 +401,44 @@ jobs:
           docker exec "$CONTAINER_ID" bash -c "cat '${DEBUG_TAR}'" \
             > /tmp/chronolog-artifacts/$(basename "${DEBUG_TAR}")
 
+      - name: Commit debug Docker image
+        run: |
+          set -e
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          VERSION="${{ steps.extract-version.outputs.version }}"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+
+          docker exec "$CONTAINER_ID" bash -c "
+            set -e
+            rm -rf /home/grc-iit/chronolog-build
+            chown -R grc-iit:grc-iit '${{ env.DEBUG_INSTALL }}'
+            echo 'export PATH=${{ env.DEBUG_INSTALL }}/chronolog/bin:\$PATH' >> /home/grc-iit/.bashrc
+            echo 'export LD_LIBRARY_PATH=${{ env.DEBUG_INSTALL }}/chronolog/lib:\$LD_LIBRARY_PATH' >> /home/grc-iit/.bashrc
+          "
+
+          docker stop "$CONTAINER_ID"
+          docker commit \
+            --change 'ENV PATH=${{ env.DEBUG_INSTALL }}/chronolog/bin:$PATH' \
+            --change 'ENV LD_LIBRARY_PATH=${{ env.DEBUG_INSTALL }}/chronolog/lib' \
+            --change 'ENV CHRONOLOG_HOME=${{ env.DEBUG_INSTALL }}/chronolog' \
+            --change 'LABEL org.opencontainers.image.title=ChronoLog Debug' \
+            --change "LABEL org.opencontainers.image.version=${VERSION}" \
+            --change 'LABEL org.opencontainers.image.source=https://github.com/grc-iit/ChronoLog' \
+            --change 'USER grc-iit' \
+            --change 'WORKDIR ${{ env.DEBUG_INSTALL }}/chronolog' \
+            "$CONTAINER_ID" "ghcr.io/${OWNER}/chronolog-debug:v${VERSION}"
+
+          docker tag "ghcr.io/${OWNER}/chronolog-debug:v${VERSION}" \
+                     "ghcr.io/${OWNER}/chronolog-debug:latest"
+
+      - name: Push debug Docker image
+        run: |
+          set -e
+          VERSION="${{ steps.extract-version.outputs.version }}"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          docker push "ghcr.io/${OWNER}/chronolog-debug:v${VERSION}"
+          docker push "ghcr.io/${OWNER}/chronolog-debug:latest"
+
       - name: Stop and remove container
         if: always()
         run: |
@@ -397,10 +446,31 @@ jobs:
           docker stop "$CONTAINER_ID" || true
           docker rm "$CONTAINER_ID" || true
 
+      - name: Upload Debug tarball as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chronolog-${{ steps.extract-version.outputs.version }}-debug-tarball
+          path: /tmp/chronolog-artifacts/*.tar.gz
+          retention-days: 7
+
+  publish-release:
+    runs-on: ubuntu-24.04
+    needs: [publish-docker-image, publish-debug-image]
+    permissions:
+      contents: write
+    timeout-minutes: 30
+
+    steps:
       - name: Download Release tarball
         uses: actions/download-artifact@v4
         with:
           name: chronolog-${{ needs.publish-docker-image.outputs.version }}-release-tarball
+          path: /tmp/chronolog-artifacts
+
+      - name: Download Debug tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: chronolog-${{ needs.publish-debug-image.outputs.version }}-debug-tarball
           path: /tmp/chronolog-artifacts
 
       - name: Publish GitHub Release

--- a/.github/workflows/publish-dev-image.yml
+++ b/.github/workflows/publish-dev-image.yml
@@ -145,10 +145,10 @@ jobs:
           set -e
           BASE_IMAGE="${{ needs.chronolog-base.outputs.image-name }}"
           CONTAINER_ID=$(docker create --user root --init \
-            -v "${{ github.workspace }}:/home/grc-iit/chronolog-repo" \
-            -w /home/grc-iit/chronolog-repo \
+            -v "${{ github.workspace }}:/tmp/chronolog-src" \
+            -w /tmp/chronolog-src \
             "$BASE_IMAGE" \
-            bash -c "chown -R grc-iit:grc-iit /home/grc-iit/chronolog-repo && tail -f /dev/null")
+            bash -c "chown -R grc-iit:grc-iit /tmp/chronolog-src && tail -f /dev/null")
           echo "container-id=${CONTAINER_ID}" >> $GITHUB_OUTPUT
           docker start "$CONTAINER_ID"
 
@@ -195,14 +195,15 @@ jobs:
           CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
           docker exec "$CONTAINER_ID" bash -c "
             set -e
-            # Copy source into container (bind-mount content does not survive docker commit)
-            cp -a /home/grc-iit/chronolog-repo /home/grc-iit/chronolog-src
-            # Remove build artifacts to reduce image size
+            # Copy source into container at chronolog-repo (bind-mount does not survive docker commit)
+            cp -a /tmp/chronolog-src /home/grc-iit/chronolog-repo
+            # Fix ownership of install tree (built as root; grc-iit needs write access for monitor/output dirs)
+            chown -R grc-iit:grc-iit /home/grc-iit/chronolog-install
+            # Remove CMake build artifacts to reduce image size
             rm -rf /home/grc-iit/chronolog-build
             # Add runtime environment to bashrc
             echo 'export PATH=/home/grc-iit/chronolog-install/chronolog/bin:\$PATH' >> /home/grc-iit/.bashrc
             echo 'export LD_LIBRARY_PATH=/home/grc-iit/chronolog-install/chronolog/lib:\$LD_LIBRARY_PATH' >> /home/grc-iit/.bashrc
-            echo 'cd /home/grc-iit/chronolog-src' >> /home/grc-iit/.bashrc
           "
 
       - name: Commit and push dev image
@@ -221,7 +222,7 @@ jobs:
             --change "LABEL org.opencontainers.image.revision=${{ github.sha }}" \
             --change 'LABEL org.opencontainers.image.source=https://github.com/grc-iit/ChronoLog' \
             --change 'USER grc-iit' \
-            --change 'WORKDIR /home/grc-iit/chronolog-src' \
+            --change 'WORKDIR /home/grc-iit' \
             "$CONTAINER_ID" "ghcr.io/${OWNER}/chronolog-dev:develop"
 
           docker push "ghcr.io/${OWNER}/chronolog-dev:develop"

--- a/.github/workflows/publish-dev-image.yml
+++ b/.github/workflows/publish-dev-image.yml
@@ -196,7 +196,8 @@ jobs:
           docker exec "$CONTAINER_ID" bash -c "
             set -e
             # Copy source into container at chronolog-repo (bind-mount does not survive docker commit)
-            cp -a /tmp/chronolog-src /home/grc-iit/chronolog-repo
+            mkdir -p /home/grc-iit/chronolog-repo
+            cp -a /tmp/chronolog-src/. /home/grc-iit/chronolog-repo/
             # Fix ownership of install tree (built as root; grc-iit needs write access for monitor/output dirs)
             chown -R grc-iit:grc-iit /home/grc-iit/chronolog-install
             # Remove CMake build artifacts to reduce image size

--- a/CI/docker/chronolog-ssh.dockerfile
+++ b/CI/docker/chronolog-ssh.dockerfile
@@ -1,15 +1,8 @@
-FROM scslab/chronolog:0.1
+FROM ghcr.io/grc-iit/chronolog:latest
 ENV DEBIAN_FRONTEND="noninteractive"
 
-RUN apt-get install -y openssh-server sudo
-
-RUN passwd -d root
-
-RUN mkdir /var/run/sshd
-RUN sed -i'' -e's/^#PermitRootLogin prohibit-password$/PermitRootLogin yes/' /etc/ssh/sshd_config \
-        && sed -i'' -e's/^#PasswordAuthentication yes$/PasswordAuthentication yes/' /etc/ssh/sshd_config \
-        && sed -i'' -e's/^#PermitEmptyPasswords no$/PermitEmptyPasswords yes/' /etc/ssh/sshd_config \
-        && sed -i'' -e's/^UsePAM yes/UsePAM no/' /etc/ssh/sshd_config
+# SSH server and configuration are already set up in the base image.
+# Just expose port 22 and start sshd as grc-iit (via sudo).
 
 EXPOSE 22
 CMD ["/usr/bin/sudo", "/usr/sbin/sshd", "-D"]

--- a/CI/docker/chronolog.dockerfile
+++ b/CI/docker/chronolog.dockerfile
@@ -1,33 +1,71 @@
-# Use scs-lab/base:1.0 as base image
-FROM spack/ubuntu-jammy:latest as coeus-builder
-ENV DOCKER_TAG=0.2
+FROM ubuntu:24.04
 
-# What we want to install and how we want to install it
-# is specified in a manifest file (spack.yaml)
-RUN mkdir /opt/spack-environment \
-&&  (echo "spack:" \
-&&   echo "  specs:" \
-&&   echo "  - cmake@3.25.1" \
-&&   echo "  - mpich@4.0.2~fortran +verbs +argobots ^libfabric@1.16.1 fabrics=mlx,rxd,rxm,shm,sockets,tcp,udp,verbs" \
-&&   echo "  - mochi-thallium@0.10.1 ^libfabric@1.16.1 fabrics=mlx,rxd,rxm,shm,sockets,tcp,udp,verbs" \
-&&   echo "  - mochi-margo@0.13 ^libfabric@1.16.1 fabrics=mlx,rxd,rxm,shm,sockets,tcp,udp,verbs" \
-&&   echo "  - mercury@2.2.0~boostsys ^libfabric@1.16.1 fabrics=mlx,rxd,rxm,shm,sockets,tcp,udp,verbs" \
-&&   echo "  - boost@1.80.0" \
-&&   echo "  concretizer:" \
-&&   echo "    unify: true" \
-&&   echo "  config:" \
-&&   echo "    install_tree: /opt/software" \
-&&   echo "  view: /opt/view") > /opt/spack-environment/spack.yaml
+SHELL ["/bin/bash", "-c"]
 
-# Install the software, remove unnecessary deps
-RUN cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y
+ARG USERNAME=grc-iit
+ARG UID=1001
 
-FROM ubuntu:22.04
-ENV DEBIAN_FRONTEND="noninteractive"
+# Set noninteractive frontend
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NOWARNINGS=yes
+ENV TZ=America/Chicago
 
-RUN apt-get update -y && apt-get upgrade -y
-RUN apt-get install -y pkg-config cmake build-essential environment-modules gfortran git python3 gdb
+# Install system dependencies
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    gcc g++ automake cmake libtool pkgconf \
+    libjson-c-dev libboost-dev libcereal-dev \
+    git vim fuse sudo curl wget \
+    libfuse-dev libssl-dev \
+    python3 python3-dev python3-pip \
+    bzip2 xz-utils jq net-tools lsof htop pssh procps bind9-dnsutils chrpath \
+    build-essential unzip tar autoconf
 
-COPY --from=coeus-builder /opt/spack-environment /opt/spack-environment
-COPY --from=coeus-builder /opt/software /opt/software
-COPY --from=coeus-builder /opt/view /usr
+# Install SSH server and client with configuration
+RUN apt-get -y install --no-install-recommends \
+    openssh-server openssh-client \
+  && printf '%s\n' \
+    'PermitRootLogin yes' \
+    'PasswordAuthentication yes' \
+    'PermitEmptyPasswords yes' \
+    'UsePAM no' \
+    > /etc/ssh/sshd_config.d/auth.conf \
+  && printf '%s\n' \
+    'Host *' \
+    '    StrictHostKeyChecking no' \
+    > /etc/ssh/ssh_config.d/ignore-host-key.conf \
+  && pip3 install --break-system-packages pssh
+
+# Create grc-iit user
+RUN id $UID && userdel $(id -un $UID) || : \
+ && useradd -m -u $UID -s /bin/bash $USERNAME \
+ && mkdir -p /etc/sudoers.d \
+ && echo "$USERNAME ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME \
+ && passwd -d $USERNAME
+
+# Switch to user to install Spack in their home directory
+USER $USERNAME
+WORKDIR /home/$USERNAME
+
+# Get ChronoLog
+RUN git clone https://github.com/grc-iit/ChronoLog.git chronolog-repo \
+ && cd chronolog-repo \
+ && git switch develop \
+ && git pull
+
+# Install Spack and build/install ChronoLog
+RUN git clone --branch v0.21.2 https://github.com/spack/spack.git ~/spack \
+ && export SPACK_ROOT=$(pwd)/spack \
+ && source spack/share/spack/setup-env.sh \
+ && cd chronolog-repo \
+ && ./tools/deploy/ChronoLog/local_single_user_deploy.sh -b \
+ && ./tools/deploy/ChronoLog/local_single_user_deploy.sh -i
+
+# Source Spack and set USER on each shell
+RUN printf '%s\n' \
+    'source ~/spack/share/spack/setup-env.sh' \
+    'export USER=grc-iit' \
+    >> ~/.bashrc
+
+# Welcome message
+CMD ["/bin/bash", "-c", "echo $'+-----------------------------------------------------------------------------------------+\n| ..######..##.....##.########...#######..##....##..#######..##........#######...######.. |\n| .##....##.##.....##.##.....##.##.....##.###...##.##.....##.##.......##.....##.##....##. |\n| .##.......##.....##.##.....##.##.....##.####..##.##.....##.##.......##.....##.##....... |\n| .##.......#########.########..##.....##.##.##.##.##.....##.##.......##.....##.##...#### |\n| .##.......##.....##.##...##...##.....##.##..####.##.....##.##.......##.....##.##....##. |\n| .##....##.##.....##.##....##..##.....##.##...###.##.....##.##.......##.....##.##....##. |\n| ..######..##.....##.##.....##..#######..##....##..#######..########..#######...######.. |\n+-----------------------------------------------------------------------------------------+\n|                                Welcome to ChronoLog                                     |\n|                                                                                         |\n| ChronoLog is a cutting-edge, distributed, and tiered shared log storage ecosystem       |\n| that leverages physical time to ensure total log ordering and elastic scaling           |\n| through intelligent auto-tiering. Designed as a robust foundation for innovation,       |\n| ChronoLog supports advanced plugins including a SQL-like query engine, a streaming      |\n| processor, a log-based key-value store, and a log-based TensorFlow module.              |\n|                                                                                         |\n| Version:                                                                                |\n|   This Docker image provides a lightweight ChronoLog instance for local deployment.     |\n|   It simplifies installation and understanding of the system. For advanced              |\n|   deployment options, including production-ready configurations, please visit:          |\n|                                                                                         |\n| Useful Links:                                                                           |\n|   • Website:    https://www.chronolog.dev                                               |\n|   • Repository: https://github.com/grc-iit/ChronoLog                                    |\n|   • Wiki:       https://github.com/grc-iit/ChronoLog/wiki                               |\n|                                                                                         |\n| Thank you for choosing ChronoLog. Enjoy your session!                                   |\n+-----------------------------------------------------------------------------------------+' && exec bash"]

--- a/CI/docker/distributed.docker-compose.yaml
+++ b/CI/docker/distributed.docker-compose.yaml
@@ -1,5 +1,5 @@
 x-common: &x-common
-  image: gnosisrc/chronolog:latest
+  image: ghcr.io/grc-iit/chronolog:latest
   init: true
   networks:
     - chronolog_net

--- a/CI/docker/local.dockerfile
+++ b/CI/docker/local.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 SHELL ["/bin/bash", "-c"]
 
@@ -20,7 +20,8 @@ RUN apt-get update \
     git vim fuse sudo curl wget \
     libfuse-dev libssl-dev \
     python3 python3-dev python3-pip \
-    bzip2 xz-utils jq net-tools lsof htop pssh procps bind9-dnsutils chrpath
+    bzip2 xz-utils jq net-tools lsof htop pssh procps bind9-dnsutils chrpath \
+    build-essential unzip tar autoconf
 
 RUN apt-get -y install --no-install-recommends \
     openssh-server openssh-client \
@@ -34,7 +35,7 @@ RUN apt-get -y install --no-install-recommends \
     'Host *' \
     '    StrictHostKeyChecking no' \
     > /etc/ssh/ssh_config.d/ignore-host-key.conf \
-  && pip3 install pssh
+  && pip3 install --break-system-packages pssh
 
 RUN id $UID && userdel $(id -un $UID) || : \
  && useradd -m -u $UID -s /bin/bash $USERNAME \


### PR DESCRIPTION
ChronoLog has several Docker images for different purposes (development, local use, CI/CD, distributed testing). They have grown out of sync. The user needs all images to consistently use the grc-iit user (UID 1001) with /home/grc-iit/ as the root working folder, no permission issues, and these specific paths:
     - Repo: /home/grc-iit/chronolog-repo
     - Build: /home/grc-iit/chronolog-build
     - Install: /home/grc-iit/chronolog-install
     - Spack: /home/grc-iit/spack