### PR TITLE
Add official source tarball to release artifacts

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -234,6 +234,30 @@ jobs:
           docker exec "$CONTAINER_ID" bash -c "cat '${RELEASE_TAR}'" \
             > /tmp/chronolog-artifacts/$(basename "${RELEASE_TAR}")
 
+      - name: Create Source tarball
+        run: |
+          set -e
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          docker exec "$CONTAINER_ID" bash -c "
+            set -e
+            source /home/grc-iit/spack/share/spack/setup-env.sh
+            spack env activate -p .
+            BUILD_DIR=\"\$HOME/chronolog-build/Release\"
+            cmake --build \"\${BUILD_DIR}\" --target package_source
+            echo 'Source tarball created:'
+            ls \"\${BUILD_DIR}/\"chronolog-*-source.tar.gz
+          "
+
+      - name: Copy Source tarball out of container
+        run: |
+          set -e
+          CONTAINER_ID="${{ steps.create-container.outputs.container-id }}"
+          SOURCE_TAR=$(docker exec "$CONTAINER_ID" bash -c \
+            "ls \$HOME/chronolog-build/Release/chronolog-*-source.tar.gz 2>/dev/null | head -1")
+          echo "Source tarball: ${SOURCE_TAR}"
+          docker exec "$CONTAINER_ID" bash -c "cat '${SOURCE_TAR}'" \
+            > /tmp/chronolog-artifacts/$(basename "${SOURCE_TAR}")
+
       - name: Commit release Docker image
         run: |
           set -e
@@ -287,7 +311,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: chronolog-${{ steps.extract-version.outputs.version }}-release-tarball
-          path: /tmp/chronolog-artifacts/*.tar.gz
+          path: /tmp/chronolog-artifacts/chronolog-*-linux-*.tar.gz
+          retention-days: 7
+
+      - name: Upload Source tarball as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chronolog-${{ steps.extract-version.outputs.version }}-source-tarball
+          path: /tmp/chronolog-artifacts/chronolog-*-source.tar.gz
           retention-days: 7
 
   publish-docker-debug-image:
@@ -465,6 +496,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: chronolog-${{ needs.publish-docker-release-image.outputs.version }}-release-tarball
+          path: /tmp/chronolog-artifacts
+
+      - name: Download Source tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: chronolog-${{ needs.publish-docker-release-image.outputs.version }}-source-tarball
           path: /tmp/chronolog-artifacts
 
       - name: Download Debug tarball

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,3 +387,8 @@ add_custom_target(package_release
     COMMENT "Creating ${_pkg_release}.tar.gz"
     VERBATIM
 )
+
+# Source tarball is built via the CPack-provided `package_source` target
+# (auto-generated when CPACK_SOURCE_GENERATOR is set in cmake/CPackConfig.cmake).
+# Output: chronolog-<version>-source.tar.gz
+# Usage: cmake --build . --target package_source

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -73,18 +73,89 @@ if(DPKG_FOUND)
     message(STATUS "CPack: dpkg-deb found — DEB generator enabled")
 endif()
 
+# --- Source package ----------------------------------------------------------
+# Produce a curated source tarball via `cpack --config CPackSourceConfig.cmake`
+# (wrapped by the `package_source` custom target defined in CMakeLists.txt).
+# Excludes build artifacts, node_modules, caches, and local tooling directories
+# so users get a clean, versioned source package.
+set(CPACK_SOURCE_GENERATOR "TGZ")
+set(CPACK_SOURCE_PACKAGE_FILE_NAME
+    "${CPACK_PACKAGE_NAME}-${CHRONOLOG_PACKAGE_VERSION}-source")
+
 # --- Source ignore patterns --------------------------------------------------
+# Patterns are POSIX regexes matched against absolute paths. Keep these in sync
+# with .gitignore where it makes sense — .gitignore covers developer workflow,
+# this list protects the release tarball from build/cache bloat.
 set(CPACK_SOURCE_IGNORE_FILES
+    # VCS / CI metadata
     "/[.]git/"
     "/[.]github/"
-    "/build/"
-    "/chronolog-build/"
     "[.]gitignore$"
     "[.]gitmodules$"
-    "[.]clang-format$"
+    "[.]gitattributes$"
+    "[.]travis[.]yml$"
+    # Editor / AI-agent tooling
+    "/[.]idea/"
+    "/[.]vscode/"
+    "/[.]cursor/"
+    "/[.]claude/"
+    "/[.]aider[^/]*"
+    "/[.]windsurf/"
+    "/[.]codeium/"
+    "/[.]copilot/"
+    "/[.]continue/"
+    "/[.]mcp/"
+    "/[.]agent[s]?/"
+    "/[.]local/"
+    "/[.]localdev/"
+    # Build / CMake artifacts
+    "/build/"
+    "/chronolog-build/"
+    "/cmake-build-[^/]+/"
     "CMakeCache[.]txt$"
     "CMakeFiles/"
     "_CPack_Packages/"
+    "[.]spack-env/"
+    "spack[.]lock$"
+    "compile_commands[.]json$"
+    # Node / website build outputs
+    "/node_modules/"
+    "/[.]docusaurus/"
+    "docs-website/build/"
+    "website/dist/"
+    "/[.]next/"
+    "/[.]nuxt/"
+    "/[.]turbo/"
+    "/[.]parcel-cache/"
+    "[.]tsbuildinfo$"
+    "[.]eslintcache$"
+    # Python / test caches
+    "__pycache__/"
+    "/[.]pytest_cache/"
+    "/[.]mypy_cache/"
+    "/[.]ruff_cache/"
+    "/[.]cache/"
+    "[.]py[cod]$"
+    "/venv/"
+    "/[.]venv/"
+    # Coverage
+    "[.]gcno$"
+    "[.]gcda$"
+    "[.]gcov$"
+    "lcov[.]info$"
+    "/coverage/"
+    "/htmlcov/"
+    # OS / editor noise
+    "[.]DS_Store$"
+    "Thumbs[.]db$"
+    "[.]swp$"
+    "[.]swo$"
+    "~$"
+    # Backup / patch files
+    "[.]bak$"
+    "[.]orig$"
+    "[.]rej$"
+    "[.]log$"
 )
 
 # --- RPM-specific settings ---------------------------------------------------


### PR DESCRIPTION
Releases currently ship the binary and debug tarballs plus whatever GitHub auto-generates from the tag. This adds a third asset: an officially curated CPack source tarball (`chronolog-<version>-source.tar.gz`) that excludes build artifacts, `node_modules`, CMake/Spack caches, and local tooling directories, so users downloading the source get a clean, versioned package rather than a snapshot of whatever happened to be in the tree.

Validated on a throwaway test tag (`v2.5.0-test565`): the resulting tarball was 20 MB with 810 entries and no hits for any of the excluded patterns. Closes #565.