### PR TITLE
CI: pin spack target to x86_64 for stable base image cache

### DIFF
--- a/.github/workflows/integration-pipeline.yml
+++ b/.github/workflows/integration-pipeline.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -135,15 +135,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -447,7 +447,7 @@ jobs:
           docker cp "$CONTAINER_ID:/home/grc-iit/chronolog-install" ./chronolog-install
 
       - name: Upload chronolog-install artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chronolog-install-${{ github.head_ref || github.ref_name }}
           path: ./chronolog-install
@@ -477,15 +477,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,3 +11,11 @@ spack:
   - py-pybind11@2.11.1
   - googletest@1.12.1  cxxstd=17
   view: true
+  packages:
+    all:
+      # Pin to generic x86_64 so package hashes are consistent across all
+      # GitHub Actions runners regardless of their CPU microarchitecture
+      # (zen2, zen3, cascadelake, etc.). Without this, spack targets the
+      # runner's exact microarch and the base image packages are unusable
+      # on any runner with a different microarch, triggering a full rebuild.
+      target: [x86_64]


### PR DESCRIPTION
Spack currently concretizes against the exact CPU microarchitecture of whichever GitHub Actions runner builds the base image, so paths like `linux-ubuntu24.04-icelake/...` get baked into every installed package. When a later job runs on a runner with a different microarch, the Spack hashes no longer match and the entire dependency tree is reinstalled from source during the build step — adding 15+ minutes before ChronoLog even starts compiling.

Pinning `packages.all.target` to `x86_64` in `spack.yaml` keeps the hashes stable across runner generations so the cached base image stays usable.

This change was originally part of PR #562 and is being split out into its own PR for independent review.

Closes #601