### PR TITLE
Fix Debug build break in client_clientid_roundtrip test

### DIFF
--- a/tests/integration/client/client_clientid_roundtrip_test.cpp
+++ b/tests/integration/client/client_clientid_roundtrip_test.cpp
@@ -139,8 +139,8 @@ int main(int argc, char** argv)
     for(auto const& ev: events)
     {
         assert(ev.client_id() == writer_id && "Event::client_id() must equal the writer's packed ClientId");
-        assert(ev.sequence().clientId == writer_id &&
-               "EventSequence::clientId must equal the writer's packed ClientId");
+        assert(std::get<1>(ev.sequence()) == writer_id &&
+               "EventSequence ClientId slot must equal the writer's packed ClientId");
     }
 
     client.DestroyStory(chronicle, story);


### PR DESCRIPTION
## Summary

The Publish Dev Image workflow has been failing on `develop` since #670 with:

```
client_clientid_roundtrip_test.cpp:142:30: error: 'chronolog::EventSequence'
{aka 'class std::tuple<long unsigned int, long unsigned int, unsigned int>'}
has no member named 'clientId'
```

`EventSequence` is a `std::tuple` (see `client/cpp/include/chronolog_types.h:25`), so `.clientId` was never valid. The expression sits inside `assert(...)`, so in Release builds glibc's `assert` macro expands to `((void)0)` and the expression is never compiled — that's why Local/Distributed Pipeline (Release) stayed green while Publish Dev Image (Debug) fails.

Fix: read the ClientId slot via `std::get<1>(ev.sequence())`.

## Test plan

- [ ] Publish Dev Image workflow goes green on this PR
- [ ] Local Pipeline / Distributed Pipeline remain green

Closes #674