### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_MACOSX_RPATH)
     set(CMAKE_MACOSX_RPATH 0)
 endif()
 
-project(ChronoLog VERSION 2.8.0 LANGUAGES CXX C)
+project(ChronoLog VERSION 3.0.0 LANGUAGES CXX C)
 
 #------------------------------------------------------------------------------
 # Version information


### PR DESCRIPTION
Bumps `project(ChronoLog VERSION ...)` in the root CMakeLists.txt from 2.8.0 to 3.0.0 ahead of the v3.0.0 release.